### PR TITLE
fixed node value summation in GalerkinEval()

### DIFF
--- a/src/tribol/integ/FE.cpp
+++ b/src/tribol/integ/FE.cpp
@@ -68,7 +68,7 @@ void GalerkinEval( const real* const RESTRICT x,
             EvalBasis( x, pX, pY, pZ, numNodes, nd, phi );
             for (int i=0; i<galerkinDim; ++i)
             {
-               galerkinVal[i] += nodeVals[i] * phi;
+               galerkinVal[i] += nodeVals[i+nd*galerkinDim] * phi;
             } 
          }
          break;


### PR DESCRIPTION
Sums up the correct node values with the basis function value.