### PR TITLE
Check to make sure DOFs exist on rank

### DIFF
--- a/src/tribol/interface/mfem_tribol.cpp
+++ b/src/tribol/interface/mfem_tribol.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId )
    // creates a block Jacobian on the parent mesh/parent-linked boundary submesh
    // based on the element Jacobians stored in the coupling scheme's method data
    return coupling_scheme->getMfemJacobianData()->GetMfemBlockJacobian(
-      *coupling_scheme->getMethodData()
+      coupling_scheme->getMethodData()
    );
 }
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -203,9 +203,12 @@ void ParentField::UpdateField(ParentRedecompTransfer& parent_redecomp_xfer)
 std::vector<const real*> ParentField::GetRedecompFieldPtrs() const
 {
   auto data_ptrs = std::vector<const real*>(3, nullptr);
-  for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
+  if (GetRedecompGridFn().FESpace()->GetNDofs() > 0)
   {
-    data_ptrs[i] = &GetRedecompGridFn()(GetRedecompGridFn().FESpace()->DofToVDof(0, i));
+    for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
+    {
+      data_ptrs[i] = &GetRedecompGridFn()(GetRedecompGridFn().FESpace()->DofToVDof(0, i));
+    }
   }
   return data_ptrs;
 }
@@ -213,9 +216,12 @@ std::vector<const real*> ParentField::GetRedecompFieldPtrs() const
 std::vector<real*> ParentField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
 {
   auto data_ptrs = std::vector<real*>(3, nullptr);
-  for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
+  if (redecomp_gridfn.FESpace()->GetNDofs() > 0)
   {
-    data_ptrs[i] = &redecomp_gridfn(redecomp_gridfn.FESpace()->DofToVDof(0, i));
+    for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
+    {
+      data_ptrs[i] = &redecomp_gridfn(redecomp_gridfn.FESpace()->DofToVDof(0, i));
+    }
   }
   return data_ptrs;
 }

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -275,9 +275,12 @@ void PressureField::UpdateField(SubmeshRedecompTransfer& submesh_redecomp_xfer)
 std::vector<const real*> PressureField::GetRedecompFieldPtrs() const
 {
   auto data_ptrs = std::vector<const real*>(3, nullptr);
-  for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
+  if (GetRedecompGridFn().FESpace()->GetNDofs() > 0)
   {
-    data_ptrs[i] = &GetRedecompGridFn()(GetRedecompGridFn().FESpace()->DofToVDof(0, i));
+    for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
+    {
+      data_ptrs[i] = &GetRedecompGridFn()(GetRedecompGridFn().FESpace()->DofToVDof(0, i));
+    }
   }
   return data_ptrs;
 }
@@ -285,9 +288,12 @@ std::vector<const real*> PressureField::GetRedecompFieldPtrs() const
 std::vector<real*> PressureField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
 {
   auto data_ptrs = std::vector<real*>(3, nullptr);
-  for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
+  if (redecomp_gridfn.FESpace()->GetNDofs() > 0)
   {
-    data_ptrs[i] = &redecomp_gridfn(redecomp_gridfn.FESpace()->DofToVDof(0, i));
+    for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
+    {
+      data_ptrs[i] = &redecomp_gridfn(redecomp_gridfn.FESpace()->DofToVDof(0, i));
+    }
   }
   return data_ptrs;
 }

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -708,6 +708,8 @@ std::unique_ptr<mfem::BlockOperator> MfemJacobianData::GetMfemBlockJacobian(
   // (0,1) and (1,0) are symmetric (for now using SINGLE_MORTAR with approximate tangent)
   const auto& elem_map_1 = parent_data_.GetElemMap1();
   const auto& elem_map_2 = parent_data_.GetElemMap2();
+  // empty data structures are needed even when no meshes are on rank since TransferToParallelSparse() needs to be
+  // called on all ranks (even those without data)
   auto mortar_elems = axom::Array<integer>(0, 0);
   auto nonmortar_elems = axom::Array<integer>(0, 0);
   auto lm_elems = axom::Array<integer>(0, 0);

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -1378,7 +1378,7 @@ public:
    * @return std::unique_ptr<mfem::BlockOperator> 
    */
   std::unique_ptr<mfem::BlockOperator> GetMfemBlockJacobian(
-    const MethodData& method_data
+    const MethodData* method_data
   ) const;
 
 private:


### PR DESCRIPTION
Add a check in the Tribol MFEM interface to only try to get pointers to DOFs when the redecomp grid function has DOFs.