### PR TITLE
Limit use of Axom CMake targets

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -10,7 +10,7 @@ set( contact_examples
      )
 
 
-set(example_depends axom tribol axom::cli11 axom::fmt)
+set(example_depends tribol)
 blt_list_append(TO example_depends ELEMENTS cuda IF ENABLE_CUDA )
 
 foreach( example ${contact_examples} )
@@ -80,7 +80,7 @@ if ( BUILD_REDECOMP )
         NAME       ${example_name}_ex
         SOURCES    ${example}
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON axom mfem mpi redecomp tribol
+        DEPENDS_ON tribol
         )
 
     if (ENABLE_CUDA)
@@ -107,7 +107,7 @@ if ( BUILD_REDECOMP )
         NAME       ${example_name}_ex
         SOURCES    ${example}
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON axom mfem mpi redecomp tribol
+        DEPENDS_ON tribol
         )
 
     if (ENABLE_CUDA)

--- a/src/examples/examples_common.hpp
+++ b/src/examples/examples_common.hpp
@@ -8,7 +8,6 @@
 
 // axom includes
 #include "axom/core.hpp"
-#include "axom/mint.hpp"
 #include "axom/primal.hpp"
 #include "axom/slic.hpp"
 #include "axom/CLI11.hpp"
@@ -25,7 +24,6 @@
 #include <iostream>
 
 // namespace aliases
-namespace mint      = axom::mint;
 namespace primal    = axom::primal;
 namespace slic      = axom::slic;
 namespace utilities = axom::utilities;

--- a/src/redecomp/CMakeLists.txt
+++ b/src/redecomp/CMakeLists.txt
@@ -43,7 +43,7 @@ set( redecomp_sources
      )
 
 ## setup the dependency list for redecomp
-set(redecomp_depends axom mfem)
+set(redecomp_depends axom::primal mfem)
 blt_list_append(TO redecomp_depends ELEMENTS mpi IF TRIBOL_USE_MPI )
 
 ## create the library

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ set( tribol_tests
      tribol_twb_integ.cpp
      )
 
-set(test_depends axom mfem tribol gtest)
+set(test_depends tribol gtest)
 blt_list_append(TO test_depends ELEMENTS cuda IF ENABLE_CUDA )
 
 foreach( test ${tribol_tests} )
@@ -70,7 +70,7 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
       redecomp_rectmatrix.cpp
       )
 
-  set(redecomp_test_depends axom mfem redecomp tribol gtest)
+  set(redecomp_test_depends tribol gtest)
   blt_list_append(TO redecomp_test_depends ELEMENTS cuda IF ENABLE_CUDA )
 
   foreach( test ${redecomp_tests} )
@@ -108,7 +108,7 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
       tribol_mfem_mortar_lm.cpp
       )
 
-  set(combined_test_depends axom mfem redecomp tribol gtest)
+  set(combined_test_depends tribol gtest)
   blt_list_append(TO combined_test_depends ELEMENTS cuda IF ENABLE_CUDA )
 
   foreach( test ${combined_tests} )

--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -101,7 +101,7 @@ if (ENABLE_FORTRAN)
 endif()
 
 ## setup the dependency list for tribol
-set(tribol_depends axom mfem)
+set(tribol_depends axom::slic mfem)
 blt_list_append(TO tribol_depends ELEMENTS mpi IF TRIBOL_USE_MPI )
 blt_list_append(TO tribol_depends ELEMENTS redecomp IF BUILD_REDECOMP )
 blt_list_append(TO tribol_depends ELEMENTS cuda IF ENABLE_CUDA )
@@ -117,6 +117,9 @@ blt_add_library(
     DEPENDS_ON ${tribol_depends}
     FOLDER tribol
     )
+
+# Don't propagate internal dependencies
+target_link_libraries(tribol PRIVATE axom::quest)
 
 target_include_directories(tribol PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>

--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -101,7 +101,7 @@ if (ENABLE_FORTRAN)
 endif()
 
 ## setup the dependency list for tribol
-set(tribol_depends axom::slic mfem)
+set(tribol_depends axom::primal axom::slic mfem)
 blt_list_append(TO tribol_depends ELEMENTS mpi IF TRIBOL_USE_MPI )
 blt_list_append(TO tribol_depends ELEMENTS redecomp IF BUILD_REDECOMP )
 blt_list_append(TO tribol_depends ELEMENTS cuda IF ENABLE_CUDA )


### PR DESCRIPTION
This limits which Axom CMake targets are propagated to downstream users. This should only make `axom::primal` and below required to be propagated, while `axom::quest` is only used internally.

~~I also did a very quick pass-through to quiet all compiler warnings. I won't be offended if you don't like how I fixed them.~~