### PR TITLE
Make LOR grid function a pointer

### DIFF
--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -18,27 +18,25 @@ SubmeshLORTransfer::SubmeshLORTransfer(
   mfem::ParMesh& lor_mesh
 )
 : lor_gridfn_ { CreateLORGridFunction(
-    lor_mesh,
+    lor_mesh, 
     std::make_unique<mfem::H1_FECollection>(1, lor_mesh.SpaceDimension()),
     submesh_fes.GetVDim()
   ) },
-  lor_xfer_ { submesh_fes, *lor_gridfn_.ParFESpace() }
-{
-  SLIC_WARNING_ROOT("LOR support is experimental at this time.");
-}
+  lor_xfer_ { submesh_fes, *lor_gridfn_->ParFESpace() }
+{}
 
 void SubmeshLORTransfer::TransferToLORGridFn(
   const mfem::ParGridFunction& submesh_src
 )
 {
-  SubmeshToLOR(submesh_src, lor_gridfn_);
+  SubmeshToLOR(submesh_src, *lor_gridfn_);
 }
 
 void SubmeshLORTransfer::TransferFromLORGridFn(
   mfem::ParGridFunction& submesh_dst
 ) const
 {
-  lor_xfer_.ForwardOperator().MultTranspose(lor_gridfn_, submesh_dst);
+  lor_xfer_.ForwardOperator().MultTranspose(*lor_gridfn_, submesh_dst);
 }
 
 void SubmeshLORTransfer::SubmeshToLOR(
@@ -49,21 +47,21 @@ void SubmeshLORTransfer::SubmeshToLOR(
   lor_xfer_.ForwardOperator().Mult(submesh_src, lor_dst);
 }
 
-mfem::ParGridFunction SubmeshLORTransfer::CreateLORGridFunction(
+std::unique_ptr<mfem::ParGridFunction> SubmeshLORTransfer::CreateLORGridFunction(
   mfem::ParMesh& lor_mesh,
   std::unique_ptr<mfem::FiniteElementCollection> lor_fec,
   integer vdim
 )
 {
-  mfem::ParGridFunction lor_gridfn {
+  auto lor_gridfn = std::make_unique<mfem::ParGridFunction>( 
     new mfem::ParFiniteElementSpace(
       &lor_mesh,
       lor_fec.get(),
       vdim,
       mfem::Ordering::byNODES
     )
-  };
-  lor_gridfn.MakeOwner(lor_fec.release());
+  );
+  lor_gridfn->MakeOwner(lor_fec.release());
   return lor_gridfn;
 }
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -18,7 +18,7 @@ SubmeshLORTransfer::SubmeshLORTransfer(
   mfem::ParMesh& lor_mesh
 )
 : lor_gridfn_ { CreateLORGridFunction(
-    lor_mesh, 
+    lor_mesh,
     std::make_unique<mfem::H1_FECollection>(1, lor_mesh.SpaceDimension()),
     submesh_fes.GetVDim()
   ) },

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -98,14 +98,14 @@ public:
    * 
    * @return mfem::ParGridFunction& 
    */
-  mfem::ParGridFunction& GetLORGridFn() { return lor_gridfn_; }
+  mfem::ParGridFunction& GetLORGridFn() { return *lor_gridfn_; }
 
   /**
    * @brief Access the local low-order grid function on the LOR mesh
    * 
    * @return const mfem::ParGridFunction& 
    */
-  const mfem::ParGridFunction& GetLORGridFn() const { return lor_gridfn_; }
+  const mfem::ParGridFunction& GetLORGridFn() const { return *lor_gridfn_; }
 
 private:
   /**
@@ -116,7 +116,7 @@ private:
   * @param vdim Vector dimension of the grid function
   * @return mfem::ParGridFunction on lor_mesh, with lor_fec and vdim specified
   */
-  static mfem::ParGridFunction CreateLORGridFunction(
+  static std::unique_ptr<mfem::ParGridFunction> CreateLORGridFunction(
     mfem::ParMesh& lor_mesh,
     std::unique_ptr<mfem::FiniteElementCollection> lor_fec,
     integer vdim
@@ -125,7 +125,7 @@ private:
   /**
    * @brief Local low-order grid function on the LOR mesh 
    */
-  mfem::ParGridFunction lor_gridfn_;
+  std::unique_ptr<mfem::ParGridFunction> lor_gridfn_;
 
   /**
    * @brief Low-order refined <-> higher-order coarse transfer object


### PR DESCRIPTION
Make LOR grid function a pointer to prevent a potential copy which invalidates the grid function.