### PR TITLE
Make forces/gaps dual

### DIFF
--- a/src/examples/mfem_mortar_lm_patch.cpp
+++ b/src/examples/mfem_mortar_lm_patch.cpp
@@ -377,8 +377,8 @@ int main( int argc, char** argv )
   mfem::Vector g;
   tribol::getMfemGap(coupling_scheme_id, g);
 
-  // Apply a restriction operator on the submesh: maps dofs stored in g to tdofs
-  // stored in G for parallel solution of the linear system.
+  // Apply a transpose prolongation operator on the submesh: maps dofs stored in g to tdofs stored in G for parallel
+  // solution of the linear system.
   //
   // NOTE: gap is a dual field so we apply the transpose prolongation operator
   {

--- a/src/examples/mfem_mortar_lm_patch.cpp
+++ b/src/examples/mfem_mortar_lm_patch.cpp
@@ -380,18 +380,15 @@ int main( int argc, char** argv )
   // Apply a restriction operator on the submesh: maps dofs stored in g to tdofs
   // stored in G for parallel solution of the linear system.
   //
-  // NOTE: gap is a dual field, but we still apply R here because tribol stores
-  // this like a ParGridFunction: shared DOFs have the same (summed) value on
-  // all ranks
+  // NOTE: gap is a dual field so we apply the transpose prolongation operator
   {
     auto& G = B_blk.GetBlock(1);
-    auto& R_submesh = *tribol::getMfemPressure(coupling_scheme_id)
-      .ParFESpace()->GetRestrictionMatrix();
-    R_submesh.Mult(g, G);
+    auto& P_submesh = *tribol::getMfemPressure(coupling_scheme_id)
+      .ParFESpace()->GetProlongationMatrix();
+    P_submesh.MultTranspose(g, G);
   }
 
-  // Create a single HypreParMatrix from blocks (useful for different
-  // solvers/preconditioners). This process requires two steps: (1) store
+  // Create a single HypreParMatrix from blocks. This process requires two steps: (1) store
   // pointer to the BlockOperator HypreParMatrixs in a 2D array and (2) call
   // mfem::HypreParMatrixFromBlocks() to create the merged, single
   // HypreParMatrix (without blocks).

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -296,7 +296,8 @@ void RedecompMesh::BuildRedecomp()
   }
 
   // Finalize mesh topology
-  FinalizeTopology(false);
+  auto generate_boundary = false;
+  FinalizeTopology(generate_boundary);
 
   // Fill r2p_elem_offsets_ with element rank offsets
   // r2p = redecomp to parent

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -296,7 +296,7 @@ void RedecompMesh::BuildRedecomp()
   }
 
   // Finalize mesh topology
-  FinalizeTopology();
+  FinalizeTopology(false);
 
   // Fill r2p_elem_offsets_ with element rank offsets
   // r2p = redecomp to parent

--- a/src/tests/tribol_mfem_common_plane.cpp
+++ b/src/tests/tribol_mfem_common_plane.cpp
@@ -241,15 +241,17 @@ protected:
   }
 };
 
-TEST_P(MfemCommonPlaneTest, mass_matrix_transfer)
+TEST_P(MfemCommonPlaneTest, common_plane)
 {
-  EXPECT_LT(std::abs(max_disp_ - 0.013637427890739103), 1.0e-8);
+  EXPECT_LT(std::abs(max_disp_ - 0.013637427890739103), 1.5e-6);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
 INSTANTIATE_TEST_SUITE_P(tribol, MfemCommonPlaneTest, testing::Values(std::make_pair(1, tribol::KINEMATIC_CONSTANT),
-                                                                      std::make_pair(1, tribol::KINEMATIC_ELEMENT)));
+                                                                      std::make_pair(1, tribol::KINEMATIC_ELEMENT),
+                                                                      std::make_pair(2, tribol::KINEMATIC_CONSTANT),
+                                                                      std::make_pair(2, tribol::KINEMATIC_ELEMENT)));
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/tests/tribol_mfem_mortar_lm.cpp
+++ b/src/tests/tribol_mfem_mortar_lm.cpp
@@ -191,7 +191,7 @@ protected:
     mfem::ParGridFunction g;
     tribol::getMfemGap(0, g);
 
-  // restriction operator on submesh: maps dofs stored in g to tdofs stored in G
+  // prolongation transpose operator on submesh: maps dofs stored in g to tdofs stored in G
     {
       auto& G = B_blk.GetBlock(1);
       auto& P_submesh = *tribol::getMfemPressure(0).ParFESpace()->GetProlongationMatrix();

--- a/src/tests/tribol_mfem_mortar_lm.cpp
+++ b/src/tests/tribol_mfem_mortar_lm.cpp
@@ -194,8 +194,8 @@ protected:
   // restriction operator on submesh: maps dofs stored in g to tdofs stored in G
     {
       auto& G = B_blk.GetBlock(1);
-      auto& R_submesh = *tribol::getMfemPressure(0).ParFESpace()->GetRestrictionOperator();
-      R_submesh.Mult(g, G);
+      auto& P_submesh = *tribol::getMfemPressure(0).ParFESpace()->GetProlongationMatrix();
+      P_submesh.MultTranspose(g, G);
     }
 
     // solve for X_blk

--- a/src/tribol/interface/mfem_tribol.cpp
+++ b/src/tribol/interface/mfem_tribol.cpp
@@ -40,9 +40,9 @@ void registerMfemCouplingScheme( integer cs_id,
    );
    // register empty meshes so the coupling scheme is valid
    registerMesh(
-      mesh_id_1, 0, 0, nullptr, mfem_data->GetElemType(), nullptr, nullptr);
+      mesh_id_1, 0, 0, nullptr, 1, nullptr, nullptr);
    registerMesh(
-      mesh_id_2, 0, 0, nullptr, mfem_data->GetElemType(), nullptr, nullptr);
+      mesh_id_2, 0, 0, nullptr, 1, nullptr, nullptr);
    registerCouplingScheme(
       cs_id,
       mesh_id_1,

--- a/src/tribol/interface/mfem_tribol.hpp
+++ b/src/tribol/interface/mfem_tribol.hpp
@@ -237,7 +237,8 @@ std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId );
 /**
  * @brief Returns gap vector to a given mfem::Vector
  *
- * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+ * @note This is stored as an MFEM dual vector, meaning the shared DOFs expect to be summed over all ranks to obtain
+ * their value.
  *
  * @pre Coupling scheme cs_id must be registered using registerMfemCouplingScheme()
  * @pre Redecomp mesh must be created and up to date by calling updateMfemParallelDecomposition()

--- a/src/tribol/interface/mfem_tribol.hpp
+++ b/src/tribol/interface/mfem_tribol.hpp
@@ -203,15 +203,14 @@ void registerMfemVelocity( integer cs_id, const mfem::ParGridFunction& v );
 /**
  * @brief Returns the response (RHS) vector to a given mfem::Vector
  *
- * @pre Coupling scheme cs_id must be registered using
- * registerMfemCouplingScheme()
- * @pre Redecomp mesh must be created and up to date by calling
- * updateMfemParallelDecomposition()
+ * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+ *
+ * @pre Coupling scheme cs_id must be registered using registerMfemCouplingScheme()
+ * @pre Redecomp mesh must be created and up to date by calling updateMfemParallelDecomposition()
  * @pre Tribol data must be up to date for current geometry by calling update()
  *
  * @param [in] cs_id The ID of the coupling scheme with the MFEM mesh
- * @param [out] r mfem::Vector of the response (RHS) vector (properly sized,
- * pre-allocated, and initialized)
+ * @param [out] r mfem::Vector of the response (RHS) vector (properly sized, pre-allocated, and initialized)
  */
 void getMfemResponse( integer cs_id, mfem::Vector& r );
 
@@ -238,16 +237,14 @@ std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId );
 /**
  * @brief Returns gap vector to a given mfem::Vector
  *
- * @pre Coupling scheme cs_id must be registered using
- * registerMfemCouplingScheme()
- * @pre Redecomp mesh must be created and up to date by calling
- * updateMfemParallelDecomposition()
- * @pre Response vector must be up to date for current geometry by calling
- * update()
+ * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+ *
+ * @pre Coupling scheme cs_id must be registered using registerMfemCouplingScheme()
+ * @pre Redecomp mesh must be created and up to date by calling updateMfemParallelDecomposition()
+ * @pre Response vector must be up to date for current geometry by calling update()
  *
  * @param [in] cs_id Coupling scheme id with a registered MFEM mesh
- * @param [out] g Nodal gap values (values do not have to be pre-allocated) on
- * the parent-linked boundary submesh
+ * @param [out] g Nodal gap values (values do not have to be pre-allocated) on the parent-linked boundary submesh
  */
 void getMfemGap( integer cs_id, mfem::Vector& g );
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -127,9 +127,13 @@ void SubmeshRedecompTransfer::RedecompToSubmesh(
   // transfer data from redecomp mesh
   mfem::ParGridFunction dst_gridfn(dst_fespace_ptr, *dst_ptr);
   redecomp_xfer_.TransferToParallel(redecomp_src, dst_gridfn);
-  // using redecomp, shared dof values are set equal (i.e. a ParGridFunction), but we want the sum of shared dof
-  // values to equal the actual dof value when transferring dual fields (i.e. force and gap) back to the parallel mesh
+
+  // using redecomp, shared dof values are set equal (i.e. a ParGridFunction), but we want the sum of shared dof values
+  // to equal the actual dof value when transferring dual fields (i.e. force and gap) back to the parallel mesh
   // following MFEMs convention.  set non-owned DOF values to zero.
+  
+  // P_I is the row index vector on the MFEM prolongation matrix. If there are no column entries for the row, then the
+  // DOF is owned by another rank.
   auto P_I = dst_fespace_ptr->Dof_TrueDof_Matrix()->GetDiagMemoryI();
   HYPRE_Int tdof_ct {0};
   for (int i{0}; i < dst_fespace_ptr->GetVSize(); ++i)

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -703,7 +703,7 @@ public:
    */
   integer GetMesh1NE() const
   { 
-    return GetUpdateData().conn_1_.size() / num_verts_per_elem_;
+    return GetUpdateData().conn_1_.size() / update_data_->num_verts_per_elem_;
   }
 
   /**
@@ -713,7 +713,7 @@ public:
    */
   integer GetMesh2NE() const
   {
-    return GetUpdateData().conn_2_.size() / num_verts_per_elem_;
+    return GetUpdateData().conn_2_.size() / update_data_->num_verts_per_elem_;
   }
 
   /**
@@ -748,7 +748,7 @@ public:
    *
    * @return integer 
    */
-  integer GetElemType() const { return elem_type_; }
+  integer GetElemType() const { return update_data_->elem_type_; }
 
   /**
    * @brief Get pointers to component arrays of the coordinates on the
@@ -1163,7 +1163,6 @@ private:
      * the first Tribol registered mesh
      * @param attributes_2 Set of boundary attributes identifying elements in
      * the second Tribol registered mesh
-     * @param num_verts_per_elem Number of vertices on each element
      */
     UpdateData(
       mfem::ParSubMesh& submesh,
@@ -1172,8 +1171,7 @@ private:
       mfem::ParGridFunction& submesh_gridfn,
       SubmeshLORTransfer* submesh_lor_xfer,
       const std::set<integer>& attributes_1,
-      const std::set<integer>& attributes_2,
-      integer num_verts_per_elem
+      const std::set<integer>& attributes_2
     );
 
     /**
@@ -1210,6 +1208,16 @@ private:
      */
     std::vector<integer> elem_map_2_;
 
+    /**
+    * @brief Type of elements on the contact meshes
+    */
+    InterfaceElementType elem_type_;
+
+    /**
+    * @brief Number of vertices on each element in the contact meshes
+    */
+    integer num_verts_per_elem_;
+
   private:
     /**
      * @brief Builds connectivity arrays and redecomp mesh to Tribol registered
@@ -1219,13 +1227,13 @@ private:
      * registered mesh
      * @param attributes_2 Set of boundary attributes for the second Tribol
      * registered mesh
-     * @param num_verts_per_elem Number of vertices on each element
      */
     void UpdateConnectivity(
       const std::set<integer>& attributes_1,
-      const std::set<integer>& attributes_2,
-      integer num_verts_per_elem
+      const std::set<integer>& attributes_2
     );
+
+    void SetElementData();
   };
   
   /**
@@ -1256,18 +1264,6 @@ private:
     const mfem::ParMesh& parent_mesh,
     const std::set<integer>& attributes_1,
     const std::set<integer>& attributes_2
-  );
-
-  /**
-   * @brief Create a grid function on the given parent-linked boundary submesh
-   *
-   * @param submesh Parent-linked boundary submesh
-   * @param parent_fes Finite element space on the parent mesh
-   * @return mfem::ParGridFunction 
-   */
-  static mfem::ParGridFunction CreateSubmeshGridFn(
-    mfem::ParSubMesh& submesh,
-    mfem::ParFiniteElementSpace& parent_fes
   );
 
   /**
@@ -1326,16 +1322,6 @@ private:
    * used; nullptr otherwise
    */
   std::unique_ptr<SubmeshLORTransfer> submesh_lor_xfer_;
-
-  /**
-   * @brief Type of elements on the contact meshes
-   */
-  InterfaceElementType elem_type_;
-
-  /**
-   * @brief Number of vertices on each element in the contact meshes
-   */
-  integer num_verts_per_elem_;
 
   /**
    * @brief Contains velocity grid function and transfer operators if set;

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -703,7 +703,7 @@ public:
    */
   integer GetMesh1NE() const
   { 
-    return GetUpdateData().conn_1_.size() / update_data_->num_verts_per_elem_;
+    return GetUpdateData().conn_1_.size() / GetUpdateData().num_verts_per_elem_;
   }
 
   /**
@@ -713,7 +713,7 @@ public:
    */
   integer GetMesh2NE() const
   {
-    return GetUpdateData().conn_2_.size() / update_data_->num_verts_per_elem_;
+    return GetUpdateData().conn_2_.size() / GetUpdateData().num_verts_per_elem_;
   }
 
   /**
@@ -748,7 +748,7 @@ public:
    *
    * @return integer 
    */
-  integer GetElemType() const { return update_data_->elem_type_; }
+  InterfaceElementType GetElemType() const { return GetUpdateData().elem_type_; }
 
   /**
    * @brief Get pointers to component arrays of the coordinates on the
@@ -789,7 +789,8 @@ public:
   /**
    * @brief Get the nodal response vector on the parent mesh
    *
-   * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+   * @note This is stored as an MFEM dual vector, meaning the shared DOFs are expected to be summed over all ranks to
+   * obtain their value.
    *
    * @param [out] r Pre-allocated, initialized mfem::Vector to which response vector is added
    */
@@ -1553,7 +1554,8 @@ public:
   /**
    * @brief Get the gap vector on the parent-linked boundary submesh
    *
-   * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+   * @note This is stored as an MFEM dual vector, meaning the shared DOFs are expected to be summed over all ranks to
+   * obtain their value.
    *
    * @param [out] g Un-initialized mfem::Vector holding the nodal gap values
    */

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -66,9 +66,9 @@ public:
   void TransferToLORGridFn(const mfem::ParGridFunction& submesh_src);
 
   /**
-   * @brief Transfers data to a higher-order grid function on a parent-linked boundary submesh
+   * @brief Transfers data to a higher-order vector on a parent-linked boundary submesh
    *
-   * Data must be stored in the low-order grid function on the LOR mesh accessed using GetLORGridFn().
+   * Data must be stored in the low-order vector on the LOR mesh accessed using GetLORVector().
    *
    * @param submesh_dst Destination higher-order vector on the parent-linked boundary submesh
    */
@@ -101,16 +101,16 @@ public:
   const mfem::ParGridFunction& GetLORGridFn() const { return *lor_gridfn_; }
 
   /**
-   * @brief Access the local low-order grid function on the LOR mesh
+   * @brief Access the local low-order vector on the LOR mesh
    * 
-   * @return mfem::ParGridFunction& 
+   * @return mfem::Vector& 
    */
   mfem::Vector& GetLORVector() { return *lor_gridfn_; }
 
   /**
-   * @brief Access the local low-order grid function on the LOR mesh
+   * @brief Access the local low-order vector on the LOR mesh
    * 
-   * @return const mfem::ParGridFunction& 
+   * @return const mfem::Vector& 
    */
   const mfem::Vector& GetLORVector() const { return *lor_gridfn_; }
 
@@ -189,7 +189,7 @@ public:
    * @brief Transfer grid function on redecomp mesh to vector on parent-linked boundary submesh
    *
    * @note The redecomp_src GridFunction is expected to have values at shared DOFs equal.  The submesh_dst will need
-   * parallel summation for shared DOF values to be equal.  This arrangement of DOF values is in line with dual fields
+   * parallel summation for shared DOF values to be equal.  This arrangement of DOF values is in line with dual vectors
    * in MFEM.
    *
    * @param redecomp_src Grid function on redecomp mesh
@@ -305,16 +305,16 @@ public:
   ) const;
   
   /**
-   * @brief Transfer grid function on redecomp mesh to grid function on parent
-   * mesh
+   * @brief Transfer grid function on redecomp mesh to vector on parent mesh
+   *
+   * @note The redecomp_src GridFunction is expected to have values at shared DOFs equal.  The parallel_dst will need
+   * parallel summation for shared DOF values to be equal.  This arrangement of DOF values is in line with dual vectors
+   * in MFEM.
    *
    * @param [in] redecomp_src Grid function on RedecompMesh
-   * @param [out] parent_dst Zero-valued grid function on parent mesh
+   * @param [out] parent_dst Zero-valued vector on parent mesh
    */
-  void RedecompToParent(
-    const mfem::GridFunction& redecomp_src, 
-    mfem::ParGridFunction& parent_dst
-  ) const;
+  void RedecompToParent(const mfem::GridFunction& redecomp_src, mfem::Vector& parent_dst) const;
 
   /**
    * @brief Get the parent-linked boundary submesh finite element space
@@ -789,8 +789,9 @@ public:
   /**
    * @brief Get the nodal response vector on the parent mesh
    *
-   * @param [out] r Pre-allocated, initialized mfem::Vector to which response
-   * vector is added
+   * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
+   *
+   * @param [out] r Pre-allocated, initialized mfem::Vector to which response vector is added
    */
   void GetParentResponse(mfem::Vector& r) const;
 
@@ -1562,6 +1563,8 @@ public:
 
   /**
    * @brief Get the gap vector on the parent-linked boundary submesh
+   *
+   * @note This is stored as a dual vector, meaning the shared DOFs must be summed over all ranks to obtain their value.
    *
    * @param [out] g Un-initialized mfem::Vector holding the nodal gap values
    */

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -63,23 +63,16 @@ public:
    * @param submesh_src Source higher-order grid function on the parent-linked
    * boundary submesh
    */
-  void TransferToLORGridFn(
-    const mfem::ParGridFunction& submesh_src
-  );
+  void TransferToLORGridFn(const mfem::ParGridFunction& submesh_src);
 
   /**
-   * @brief Transfers data to a higher-order grid function on a parent-linked
-   * boundary submesh
+   * @brief Transfers data to a higher-order grid function on a parent-linked boundary submesh
    *
-   * Data must be stored in the low-order grid function on the LOR mesh accessed
-   * using GetLORGridFn().
+   * Data must be stored in the low-order grid function on the LOR mesh accessed using GetLORGridFn().
    *
-   * @param submesh_dst Destination higher-order grid function on the
-   * parent-linked boundary submesh
+   * @param submesh_dst Destination higher-order vector on the parent-linked boundary submesh
    */
-  void TransferFromLORGridFn(
-    mfem::ParGridFunction& submesh_dst
-  ) const;
+  void TransferFromLORVector(mfem::Vector& submesh_dst) const;
 
   /**
    * @brief Transfer grid function on parent-linked boundary submesh to grid
@@ -103,9 +96,23 @@ public:
   /**
    * @brief Access the local low-order grid function on the LOR mesh
    * 
-   * @return const mfem::ParGridFunction& 
+   * @return mfem::ParGridFunction& 
    */
   const mfem::ParGridFunction& GetLORGridFn() const { return *lor_gridfn_; }
+
+  /**
+   * @brief Access the local low-order grid function on the LOR mesh
+   * 
+   * @return mfem::ParGridFunction& 
+   */
+  mfem::Vector& GetLORVector() { return *lor_gridfn_; }
+
+  /**
+   * @brief Access the local low-order grid function on the LOR mesh
+   * 
+   * @return const mfem::ParGridFunction& 
+   */
+  const mfem::Vector& GetLORVector() const { return *lor_gridfn_; }
 
 private:
   /**
@@ -179,16 +186,18 @@ public:
   ) const;
 
   /**
-   * @brief Transfer grid function on redecomp mesh to grid function on
-   * parent-linked boundary submesh
+   * @brief Transfer grid function on redecomp mesh to vector on parent-linked boundary submesh
+   *
+   * @note The redecomp_src GridFunction is expected to have values at shared DOFs equal.  The submesh_dst will need
+   * parallel summation for shared DOF values to be equal.  This arrangement of DOF values is in line with dual fields
+   * in MFEM.
    *
    * @param redecomp_src Grid function on redecomp mesh
-   * @param submesh_dst Zero-valued grid function on parent-linked boundary
-   * submesh
+   * @param submesh_dst Zero-valued vector on parent-linked boundary submesh
    */
   void RedecompToSubmesh(
     const mfem::GridFunction& redecomp_src,
-    mfem::ParGridFunction& submesh_dst
+    mfem::Vector& submesh_dst
   ) const;
 
   /**

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -1233,6 +1233,9 @@ private:
       const std::set<integer>& attributes_2
     );
 
+    /**
+     * @brief Sets the number of vertices per element and the element type for the redecomp mesh
+     */
     void SetElementData();
   };
   

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -2080,15 +2080,14 @@ void ExplicitMechanics::Mult(
    elasticity.Mult(u, f_int);
    f.Add(-1.0, f_int);
 
+   f.Add(1.0, f_ext);
+
    // sum forces over ranks
    auto& fespace = *elasticity.ParFESpace();
    const Operator& P = *fespace.GetProlongationMatrix();
    mfem::Vector f_true {fespace.GetTrueVSize()};
    P.MultTranspose(f, f_true);
    P.Mult(f_true, f);
-
-   // external force already summed over ranks
-   f.Add(1.0, f_ext);
 
    for (int i {0}; i < inv_lumped_mass.Size(); ++i)
    {


### PR DESCRIPTION
This PR changes the behavior of the force and gap fields returned in the MFEM interface to be dual vectors.  In other words, the shared DOFs across processors will need to be summed in parallel to obtain the value at the DOF.

This behavior is required to use the LOR transfer operator and is standard in MFEM.

Note this is a breaking change.

Further, there are a few small fixes in the MFEM interface and redecomp and an LOR test for the common plane method.