### PR TITLE
Add Ubuntu 22.04 LTS spack config

### DIFF
--- a/cmake/TribolConfig.cmake
+++ b/cmake/TribolConfig.cmake
@@ -16,10 +16,6 @@ message(STATUS "Configuring Tribol version ${TRIBOL_VERSION_FULL}")
 convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} TRIBOL_REPO_DIR)
 convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   TRIBOL_BIN_DIR)
 
-# Generate and install config header
-tribol_configure_file(${PROJECT_SOURCE_DIR}/src/tribol/config.hpp.in
-                      ${PROJECT_BINARY_DIR}/include/tribol/config.hpp)
-
 install(FILES ${PROJECT_BINARY_DIR}/include/tribol/config.hpp DESTINATION include/tribol)
 
 # Set up some paths, preserve existing cache values (if present)

--- a/cmake/TribolConfig.cmake
+++ b/cmake/TribolConfig.cmake
@@ -13,9 +13,6 @@ message(STATUS "Configuring Tribol version ${TRIBOL_VERSION_FULL}")
 #------------------------------------------------------------------------------
 # General Build Info
 #------------------------------------------------------------------------------
-convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} TRIBOL_REPO_DIR)
-convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   TRIBOL_BIN_DIR)
-
 install(FILES ${PROJECT_BINARY_DIR}/include/tribol/config.hpp DESTINATION include/tribol)
 
 # Set up some paths, preserve existing cache values (if present)

--- a/scripts/spack/configs/linux_ubuntu_22/compilers.yaml
+++ b/scripts/spack/configs/linux_ubuntu_22/compilers.yaml
@@ -1,0 +1,16 @@
+compilers:
+- compiler:
+    spec: gcc@11.4.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: 
+      cflags: -pthread
+      cxxflags: -pthread
+    operating_system: ubuntu22.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/scripts/spack/configs/linux_ubuntu_22/packages.yaml
+++ b/scripts/spack/configs/linux_ubuntu_22/packages.yaml
@@ -1,0 +1,125 @@
+packages:
+  all:
+    target: [ivybridge]
+    compiler: [gcc]
+    providers:
+      mpi: [mpich]
+      blas: [openblas]
+      lapack: [openblas]
+      gl: [opengl]
+      glu: [openglu]
+
+  # Lock down which MPI we are using
+  mpi:
+    buildable: false
+  mpich:
+    externals:
+    - spec: mpich@4.0%gcc
+      prefix: /usr
+
+  # System level packages to not build
+  cuda:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+  opengl:
+    buildable: false
+    externals:
+    - spec: opengl@1.7.0
+      prefix: /usr
+  openglu:
+    buildable: false
+    externals:
+    - spec: openglu@1.3.1
+      prefix: /usr
+  bzip2:
+    buildable: false
+    externals:
+    - spec: bzip2@1.0.8
+      prefix: /
+  gettext:
+    buildable: false
+    externals:
+    - spec: gettext@0.19.8.1
+      prefix: /usr
+  perl:
+    buildable: false
+    externals:
+    - spec: perl@5.30.0
+      prefix: /usr
+  tar:
+    buildable: false
+    externals:
+    - spec: tar@1.30
+      prefix: /
+  libx11:
+    buildable: false
+    externals:
+    - spec: libx11@6.3.0
+      prefix: /usr
+  autoconf:
+    buildable: false
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@1.1.1
+      prefix: /usr/lib/x86_64-linux-gnu/
+  openblas:
+    buildable: false
+    externals:
+    - spec: openblas@0.3.8
+      prefix: /usr/lib/x86_64-linux-gnu/
+  pkg-config:
+    buildable: false
+    externals:
+    - spec: pkg-config@0.29.2
+      prefix: /usr
+  unzip:
+    buildable: false
+    externals:
+    - spec: unzip@6.0
+      prefix: /usr
+  zlib:
+    buildable: false
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
+  m4:
+    buildable: false
+    externals:
+    - spec: m4@1.4.16
+      prefix: /usr
+
+  # Lock in versions of Devtools
+  cmake:
+    buildable: false
+    externals:
+    - spec: cmake@3.20.4
+      prefix: /usr
+  doxygen:
+    version: [1.8.17]
+    buildable: false
+    externals:
+    - spec: doxygen@1.8.17
+      prefix: /usr
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm@10.0.0+clang
+      prefix: /usr
+  python:
+    version: [3.8.5]
+    buildable: false
+    externals:
+    - spec: python@3.8.5
+      prefix: /usr
+  py-sphinx:
+    version: [3.2.1]
+    buildable: false
+    externals:
+    - spec: py-sphinx@3.2.1
+      prefix: /usr

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,5 +43,8 @@ if ( TRIBOL_ENABLE_EXAMPLES )
 endif()
 
 # Generate and install config header
+convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} TRIBOL_REPO_DIR)
+convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   TRIBOL_BIN_DIR)
+
 tribol_configure_file(${PROJECT_SOURCE_DIR}/src/tribol/config.hpp.in
                       ${PROJECT_BINARY_DIR}/include/tribol/config.hpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,3 +41,7 @@ endif()
 if ( TRIBOL_ENABLE_EXAMPLES )
   add_subdirectory(examples)
 endif()
+
+# Generate and install config header
+tribol_configure_file(${PROJECT_SOURCE_DIR}/src/tribol/config.hpp.in
+                      ${PROJECT_BINARY_DIR}/include/tribol/config.hpp)


### PR DESCRIPTION
This PR adds a spack config for Ubuntu 22.04 LTS and moves the config header to the src directory.