### PR TITLE
Modifies constant penalty calculation to provide equivalence with element-wise calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Tribol: Contact Interface Physics Library
 
 High fidelity simulations modeling complex interactions of moving bodies require specialized contact algorithms to
-enforce constraints between surfaces that come into contact in order to prevent penetration and to compute the
-associated contact response forces. Tribol aims to provide a unified interface for various contact algorithms,
-specifically, contact detection and enforcement, and serve as a common infrastructure enabling the research and
-development of advanced contact algorithms.
-
+enforce zero-interpenetration constraints between surfaces. Tribol provides a unified interface for various 
+contact algorithms, including contact search, detection and enforcement, thereby enabling the research and development 
+of advanced contact algorithms.
 
 ## Quick Start Guide
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added coupling scheme tests with null pointer registration.
 - Multi-rank contact API using MFEM data structures.
 - New API calls for MFEM data structures (see `interface/mfem_tribol.hpp`).
+- Updated the penalty stiffness calculation using the `KINEMATIC_CONSTANT` option
+  to follow the `springs-in-serial` stiffness model used for `KINEMATIC_ELEMENT`.
 
 ### Changed
 - Return negative timestep vote for non-null meshes with null velocity pointers.

--- a/src/examples/mfem_common_plane.cpp
+++ b/src/examples/mfem_common_plane.cpp
@@ -91,7 +91,7 @@ int main( int argc, char** argv )
   double mu = 100000.0;
   // kinematic penalty parameter (only for constant penalty)
   // the kinematic constant penalty is chosen here to match the kinematic element penalty
-  double p_kine = (lambda + 2.0 / 3.0 * mu) * std::pow(2.0, ref_levels - 1);
+  double p_kine = (lambda + 2.0 / 3.0 * mu) / (1.0 / std::pow(2.0, ref_levels));
 
   // parse command line options
   axom::CLI::App app { "mfem_common_plane" };

--- a/src/tests/tribol_common_plane_gap_rate.cpp
+++ b/src/tests/tribol_common_plane_gap_rate.cpp
@@ -622,7 +622,8 @@ TEST_F( CommonPlaneTest, percent_rate_penetration )
    // check the gaps, pressures, and force sense
    //real gap = z_min2 - z_max1;
    real rate_gap = velZ2 - velZ1;
-   real pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
+   real stiffness = tribol::ComputePenaltyStiffnessPerArea( penalty, penalty );
+   real pressure = (rate_gap < 0.) ? stiffness * rate_gap : 0.;
    compareGaps( couplingScheme, rate_gap, 1.E-8, "rate_penetration" );
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
    checkForceSense( couplingScheme ); // note: the kinematic and rate contributions are not separated

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -434,7 +434,7 @@ TEST_F( CommonPlaneTest, constant_penalty_check )
 
    // check the pressures
    real gap = z_min2 - z_max1;
-   real pressure = parameters.const_penalty * gap;
+   real pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
    checkPressures( couplingScheme, pressure, 1.E-8 );
    checkForceSense( couplingScheme );
 
@@ -594,12 +594,23 @@ TEST_F( CommonPlaneTest, tied_contact_check )
 
    // check the pressures
    real gap = z_min2 - z_max1;
-   real pressure = parameters.const_penalty * gap;
+   real pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
    checkPressures( couplingScheme, pressure, 1.E-8 );
    checkForceSense( couplingScheme, true );
 
    tribol::finalize();
 }
+
+//TEST_F( CommonPlaneTest, penalty_equivalence )
+//{
+//   auto bulk_mod1 = 1.0;
+//   auto bulk_mod2 = 1.0;
+//   auto t1 = 1.0;
+//   auto t2 = 1.0;
+//   auto const_pen1 = 1.0;
+//   auto const_pen2 = 1.0;
+//   auto tiny_length = 1.e-12;
+//}
 
 int main(int argc, char* argv[])
 {

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -601,17 +601,6 @@ TEST_F( CommonPlaneTest, tied_contact_check )
    tribol::finalize();
 }
 
-//TEST_F( CommonPlaneTest, penalty_equivalence )
-//{
-//   auto bulk_mod1 = 1.0;
-//   auto bulk_mod2 = 1.0;
-//   auto t1 = 1.0;
-//   auto t2 = 1.0;
-//   auto const_pen1 = 1.0;
-//   auto const_pen2 = 1.0;
-//   auto tiny_length = 1.e-12;
-//}
-
 int main(int argc, char* argv[])
 {
   int result = 0;

--- a/src/tests/tribol_mfem_common_plane.cpp
+++ b/src/tests/tribol_mfem_common_plane.cpp
@@ -60,8 +60,9 @@ protected:
     double lambda = 100000.0;
     // lame parameter (shear modulus)
     double mu = 100000.0;
-    // kinematic penalty
-    double p_kine = (lambda + 2.0 / 3.0 * mu) * std::pow(2.0, ref_levels - 1);
+    // kinematic constant penalty stiffness equivalent to the element-wise calculation, 
+    // which is bulk-modulus over element thickness.
+    double p_kine = (lambda + 2.0 / 3.0 * mu) / (1.0 / std::pow(2.0, ref_levels));
 
     // fixed options
     // location of mesh file. TRIBOL_REPO_DIR is defined in tribol/config.hpp

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -450,10 +450,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
 
    } // end loop over interface pairs
   
-   if (neg_thickness)
-   {
-      SLIC_DEBUG("ApplyNormal<COMMON_PLANE, PENALTY>: negative element thicknesses encountered.");
-   }
+   SLIC_DEBUG_IF(neg_thickness, "ApplyNormal<COMMON_PLANE, PENALTY>: negative element thicknesses encountered.");
 
    return err;
 

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -241,9 +241,10 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       {
          case KINEMATIC_CONSTANT: 
          {
-            // Average each mesh's penalty stiffness premultiplied by each mesh's penalty scale
+            // pre-multiply each spring stiffness by each mesh's penalty scale
             auto stiffness1 = pen_scale1 * mesh1.m_elemData.m_penalty_stiffness;
             auto stiffness2 = pen_scale2 * mesh2.m_elemData.m_penalty_stiffness;
+            // compute the equivalent contact penalty spring stiffness per area
             penalty_stiff_per_area  = ComputePenaltyStiffnessPerArea( stiffness1, stiffness2 );
             break;
          }

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -22,31 +22,25 @@
 namespace tribol
 {
 
-real ComputePenaltyStiffnessPerArea( const real K1,
-                                     const real t1,
-                                     const real K2,
-                                     const real t2,
-                                     const real tiny_length )
+real ComputePenaltyStiffnessPerArea( const real K1_over_t1,
+                                     const real K2_over_t2 )
 {
    // compute face-pair specific penalty stiffness per unit area.
    // Note: This assumes that each face has a spring stiffness 
    // equal to that side's material Bulk modulus, K, over the 
    // thickness of the volume element to which that face belongs, 
-   // times the overlap area. That is, K1/t1 * A and K2/t2 * A. We 
+   // times the overlap area. That is, K1_over_t1 * A and K2_over_t2 * A. We 
    // then assume the two springs are in series and compute an 
    // equivalent spring stiffness as, 
-   // k_eq = A*(K1/t1)*(K2/t2) / ((K1/t1)+(K2/t2). Note, the host 
-   // code registers each face's (K/t) as a penalty scale.
+   // k_eq = A*(K1_over_t1)*(K2_over_t2) / ((K1_over_t1)+(K2_over_t2). 
+   // Note, the host code registers each face's (K/t) as a penalty scale.
    //
    // UNITS: we multiply k_eq above by the overlap area A, to get a 
    // stiffness per unit area. This will make the force calculations 
    // commensurate with the previous calculations using only the 
    // constant registered penalty scale.
 
-   // add tiny length to thickness to avoid division by zero.
-   double t_1 = t1 + tiny_length;
-   double t_2 = t2 + tiny_length;
-   return K1/t_1 * K2/t_2 / (K1/t_1 + K2/t_2);
+   return K1_over_t1 * K2_over_t2 / (K1_over_t1 + K2_over_t2);
 
 } // end ComputePenaltyStiffnessPerArea
 
@@ -248,21 +242,22 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
          case KINEMATIC_CONSTANT: 
          {
             // Average each mesh's penalty stiffness premultiplied by each mesh's penalty scale
-            penalty_stiff_per_area  = 0.5 * 
-                                      ( pen_scale1 * mesh1.m_elemData.m_penalty_stiffness +
-                                        pen_scale2 * mesh2.m_elemData.m_penalty_stiffness );
+            auto stiffness1 = pen_scale1 * mesh1.m_elemData.m_penalty_stiffness;
+            auto stiffness2 = pen_scale2 * mesh2.m_elemData.m_penalty_stiffness;
+            penalty_stiff_per_area  = ComputePenaltyStiffnessPerArea( stiffness1, stiffness2 );
             break;
          }
          case KINEMATIC_ELEMENT:
          {
-            // multiply the material modulus (i.e. material stiffness) by each mesh's penalty scale
-            penalty_stiff_per_area = ComputePenaltyStiffnessPerArea( 
-                                        pen_scale1 * mesh1.m_elemData.m_mat_mod[ index1 ],
-                                        mesh1.m_elemData.m_thickness[ index1 ],
-                                        pen_scale2 * mesh2.m_elemData.m_mat_mod[ index2 ],
-                                        mesh2.m_elemData.m_thickness[ index2 ],
-                                        pen_enfrc_options.tiny_length
-                                                                   );
+            // add tiny_length to element thickness to avoid division by zero
+            auto t1 = mesh1.m_elemData.m_thickness[ index1 ] + pen_enfrc_options.tiny_length;
+            auto t2 = mesh2.m_elemData.m_thickness[ index2 ] + pen_enfrc_options.tiny_length;
+            // compute each element spring stiffness. Pre-multiply the material modulus 
+            // (i.e. material stiffness) by each mesh's penalty scale
+            auto stiffness1 = pen_scale1 * mesh1.m_elemData.m_mat_mod[ index1 ] / t1;
+            auto stiffness2 = pen_scale2 * mesh2.m_elemData.m_mat_mod[ index2 ] / t2;
+            // compute the equivalent contact penalty spring stiffness per area
+            penalty_stiff_per_area = ComputePenaltyStiffnessPerArea( stiffness1, stiffness2 );
             break;
          }
          default:

--- a/src/tribol/physics/CommonPlane.hpp
+++ b/src/tribol/physics/CommonPlane.hpp
@@ -15,10 +15,8 @@ namespace tribol
  *
  * \brief computes penalty stiffness for Common Plane + Penalty 
  *
- * \param [in] K1 Bulk modulus for face 1
- * \param [in] t1 element thickness for face 1
- * \param [in] K2 Bulk modulus for face 2 
- * \param [in] t2 element thickness for face 2
+ * \param [in] K1/t1 contact spring stiffness for face 1 (bulk_modulus/element_thickness for face 1)
+ * \param [in] K2/t2 contact spring stiffness for face 2 (bulk_modulus/element_thickness for face 2)
  *
  * \return face-pair based, element-wise penalty stiffness per area 
  *         
@@ -26,11 +24,8 @@ namespace tribol
  * \pre Bulk modulus and element thickness arrays are registered by host code 
  *
  */
-real ComputePenaltyStiffnessPerArea( const real K1,
-                                     const real t1,
-                                     const real K2,
-                                     const real t2,
-                                     const real tiny_length );
+real ComputePenaltyStiffnessPerArea( const real K1_over_t1,
+                                     const real K2_over_t2 );
 
 /*!
  *


### PR DESCRIPTION
- The constant penalty calculation was not commensurate with the 'model' used in the element-wise penalty calculation
- This PR modifies the constant penalty calculation to follow the spring-in-series model used in the element-wise calculation.
- This allows a user or developer to compare behavior when using the two penalty types under the condition that each mesh's penalty stiffness is equivalent across penalty types. (E.g. bulk_mod/t = 1, constant_penalty = 1).