### PR TITLE
Modified logging level enum to be a class for clarity.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,8 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
   interface.
 - Logging refactor using SLIC macros. Lots of warnings were demoted to DEBUG level.
 - Changed various computational geometry routines to return a FaceGeomError enum error handling
+- Changed LoggingLevel enum to be an enum class for clarity, and to avoid MACRO conflicts
+  with host codes.
   
 ### Fixed
 - Allow null velocity and response pointers for various use cases

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -33,7 +33,7 @@ constexpr integer ANY_MESH = -1;
 /*!
  * \brief Enumerates the logging level options
  */
-enum LoggingLevel
+enum class LoggingLevel
 {
    UNDEFINED, ///! Undefined 
    DEBUG,     ///! Debug and higher

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -33,14 +33,14 @@ constexpr integer ANY_MESH = -1;
 /*!
  * \brief Enumerates the logging level options
  */
-enum class LoggingLevel
+enum LoggingLevel
 {
-   UNDEFINED, ///! Undefined 
-   DEBUG,     ///! Debug and higher
-   INFO,      ///! Info and higher
-   WARNING,   ///! Warning and higher
-   ERROR,     ///! Errors only
-   NUM_LOGGING_LEVELS = ERROR
+   TRIBOL_UNDEFINED, ///! Undefined 
+   TRIBOL_DEBUG,     ///! Debug and higher
+   TRIBOL_INFO,      ///! Info and higher
+   TRIBOL_WARNING,   ///! Warning and higher
+   TRIBOL_ERROR,     ///! Errors only
+   NUM_LOGGING_LEVELS = TRIBOL_ERROR
 };
 
 /*!

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -334,11 +334,12 @@ void setLoggingLevel( int csId, LoggingLevel log_level )
                  "invalid CouplingScheme id.");
    CouplingScheme* couplingScheme  = csManager.getCoupling( csId );
 
-   if ( !in_range(log_level, NUM_LOGGING_LEVELS) )
+   if ( !in_range(static_cast<int>(log_level), 
+                  static_cast<int>(tribol::LoggingLevel::NUM_LOGGING_LEVELS)) )
    {
       SLIC_INFO_ROOT("tribol::setLoggingLevel(): Logging level not an option; " << 
                      "using 'warning' level.");
-      couplingScheme->setLoggingLevel( tribol::WARNING );
+      couplingScheme->setLoggingLevel( tribol::LoggingLevel::WARNING );
    }
    else
    {

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -335,11 +335,11 @@ void setLoggingLevel( int csId, LoggingLevel log_level )
    CouplingScheme* couplingScheme  = csManager.getCoupling( csId );
 
    if ( !in_range(static_cast<int>(log_level), 
-                  static_cast<int>(tribol::LoggingLevel::NUM_LOGGING_LEVELS)) )
+                  static_cast<int>(tribol::NUM_LOGGING_LEVELS)) )
    {
       SLIC_INFO_ROOT("tribol::setLoggingLevel(): Logging level not an option; " << 
                      "using 'warning' level.");
-      couplingScheme->setLoggingLevel( tribol::LoggingLevel::WARNING );
+      couplingScheme->setLoggingLevel( tribol::TRIBOL_WARNING );
    }
    else
    {

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -355,7 +355,7 @@ CouplingScheme::CouplingScheme( integer couplingSchemeId,
   m_couplingSchemeInfo.cs_case_info        = NO_CASE_INFO;
   m_couplingSchemeInfo.cs_enforcement_info = NO_ENFORCEMENT_INFO;
 
-  m_loggingLevel = LoggingLevel::UNDEFINED;
+  m_loggingLevel = TRIBOL_UNDEFINED;
 
   // STEP 0: create contact-pairs object associated with this coupling scheme
   m_interfacePairs = new InterfacePairs( );
@@ -1006,26 +1006,26 @@ bool CouplingScheme::init()
 void CouplingScheme::setSlicLoggingLevel()
 {
    // set slic logging level for coupling schemes that have API modified logging levels
-   if (this->m_loggingLevel != LoggingLevel::UNDEFINED)
+   if (this->m_loggingLevel != TRIBOL_UNDEFINED)
    {
       switch (this->m_loggingLevel)
       {
-         case LoggingLevel::DEBUG:
+         case TRIBOL_DEBUG:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Debug );
             break;
          } 
-         case LoggingLevel::INFO:
+         case TRIBOL_INFO:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Info );
             break;
          } 
-         case LoggingLevel::WARNING:
+         case TRIBOL_WARNING:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Warning );
             break;
          } 
-         case LoggingLevel::ERROR:
+         case TRIBOL_ERROR:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Error );
             break;

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -355,7 +355,7 @@ CouplingScheme::CouplingScheme( integer couplingSchemeId,
   m_couplingSchemeInfo.cs_case_info        = NO_CASE_INFO;
   m_couplingSchemeInfo.cs_enforcement_info = NO_ENFORCEMENT_INFO;
 
-  m_loggingLevel = UNDEFINED;
+  m_loggingLevel = LoggingLevel::UNDEFINED;
 
   // STEP 0: create contact-pairs object associated with this coupling scheme
   m_interfacePairs = new InterfacePairs( );
@@ -1006,26 +1006,26 @@ bool CouplingScheme::init()
 void CouplingScheme::setSlicLoggingLevel()
 {
    // set slic logging level for coupling schemes that have API modified logging levels
-   if (this->m_loggingLevel != UNDEFINED)
+   if (this->m_loggingLevel != LoggingLevel::UNDEFINED)
    {
       switch (this->m_loggingLevel)
       {
-         case DEBUG:
+         case LoggingLevel::DEBUG:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Debug );
             break;
          } 
-         case INFO:
+         case LoggingLevel::INFO:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Info );
             break;
          } 
-         case WARNING:
+         case LoggingLevel::WARNING:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Warning );
             break;
          } 
-         case ERROR:
+         case LoggingLevel::ERROR:
          {
             axom::slic::setLoggingMsgLevel( axom::slic::message::Error );
             break;

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -399,7 +399,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
         IndexType node0 = nodalConnectivity1[ index1*numNodesPerFace + a ];
         IndexType node1 = nodalConnectivity2[ index2*numNodesPerFace + a ];
 
-        if (logLevel == LoggingLevel::DEBUG)
+        if (logLevel == TRIBOL_DEBUG)
         {
            phi_sum_1 += phi1[a];
            phi_sum_2 += phi2[a];
@@ -413,7 +413,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
         const real nodal_force_y2 = force_y * phi2[a];
         const real nodal_force_z2 = force_z * phi2[a];
 
-        if (logLevel == LoggingLevel::DEBUG)
+        if (logLevel == TRIBOL_DEBUG)
         {
            dbg_sum_force1 += magnitude( nodal_force_x1, 
                                         nodal_force_y1, 

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -399,7 +399,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
         IndexType node0 = nodalConnectivity1[ index1*numNodesPerFace + a ];
         IndexType node1 = nodalConnectivity2[ index2*numNodesPerFace + a ];
 
-        if (logLevel == DEBUG)
+        if (logLevel == LoggingLevel::DEBUG)
         {
            phi_sum_1 += phi1[a];
            phi_sum_2 += phi2[a];
@@ -413,7 +413,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
         const real nodal_force_y2 = force_y * phi2[a];
         const real nodal_force_z2 = force_z * phi2[a];
 
-        if (logLevel == DEBUG)
+        if (logLevel == LoggingLevel::DEBUG)
         {
            dbg_sum_force1 += magnitude( nodal_force_x1, 
                                         nodal_force_y1, 

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -1174,7 +1174,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
                            enforcement,
                            BINNING_GRID );
 
-   setLoggingLevel(csIndex, WARNING);
+   setLoggingLevel(csIndex, LoggingLevel::WARNING);
 
    if (method == COMMON_PLANE && enforcement == PENALTY)
    {

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -1174,7 +1174,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
                            enforcement,
                            BINNING_GRID );
 
-   setLoggingLevel(csIndex, LoggingLevel::WARNING);
+   setLoggingLevel(csIndex, TRIBOL_WARNING);
 
    if (method == COMMON_PLANE && enforcement == PENALTY)
    {


### PR DESCRIPTION
- Changing LoggingLevel enum to be a class
- Fix MACRO incompatibility with host-codes
- Adds clarity when using the logging enum