### PR TITLE
Guard install

### DIFF
--- a/cmake/SetupThirdParty.cmake
+++ b/cmake/SetupThirdParty.cmake
@@ -63,10 +63,16 @@ if (TARGET mfem)
     # Note - white238: I can't seem to get this to pass install testing due to mfem being included
     # in multiple export sets
     message(STATUS "MFEM support is ON, using existing mfem target")
+
     # Add it to this export set but don't prefix it with tribol::
-    install(TARGETS              mfem
-            EXPORT               tribol-targets
-            DESTINATION          lib)
+    # NOTE: imported targets cannot be part of an export set
+    get_target_property(_is_imported mfem IMPORTED)
+    if(NOT "${_is_imported}")
+        install(TARGETS              mfem
+                EXPORT               tribol-targets
+                DESTINATION          lib)
+    endif()
+
     set(MFEM_FOUND TRUE CACHE BOOL "" FORCE)
 elseif (DEFINED MFEM_DIR)
   message(STATUS "Setting up external MFEM TPL...")


### PR DESCRIPTION
In older (?) configurations, `mfem` is not namespaced from Axom (I think but its the only place i can think of it coming from).

This will guard the install from erroring out.