### PR TITLE
Further Handle Zero-Element Nullptrs

### DIFF
--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -685,6 +685,15 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
    EXPECT_EQ(tribol::update(1, 1., dt), 0);
    EXPECT_EQ(cs_null->getNumActivePairs(), 0);
 
+   // check InterfacePairs data
+   bool isNullPtr {false};
+   if (cs_null->getInterfacePairs() == nullptr)
+   {
+      isNullPtr = true;
+   }
+   EXPECT_EQ( isNullPtr, false );
+   EXPECT_EQ( cs_null->getInterfacePairs()->getNumPairs(), 0 );
+
    tribol::finalize();
 }
 
@@ -1073,6 +1082,15 @@ TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
 
    EXPECT_EQ( isInit, true );
    EXPECT_EQ( scheme->nullMeshes(), true );
+
+   // check the InterfacePairs member class on the coupling scheme
+   bool isNullPtr {false};
+   if (scheme->getInterfacePairs() == nullptr)
+   {
+      isNullPtr = true;
+   }
+   EXPECT_EQ( isNullPtr, false );
+   EXPECT_EQ( scheme->getInterfacePairs()->getNumPairs(), 0 );
 
    tribol::finalize();
 }

--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -675,7 +675,11 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
  
    // check that the number of active pairs is zero from initialization and not 
    // carried over from previous coupling scheme registration with non-null meshes
-   EXPECT_EQ(cs_null->getNumActivePairs(), 0);
+   EXPECT_EQ( cs_null->getNumActivePairs(), 0 );
+
+   // call cs_null->init() to make sure the nullMeshes boolean is correctly set
+   cs_null->init();
+   EXPECT_EQ( cs_null->nullMeshes(), true );
 
    // call update() to make sure there is a no-op for this coupling scheme
    EXPECT_EQ(tribol::update(1, 1., dt), 0);
@@ -1067,7 +1071,8 @@ TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
    tribol::CouplingScheme* scheme  = csManager.getCoupling(0);
    bool isInit = scheme->init();
 
-   EXPECT_EQ( isInit, false );
+   EXPECT_EQ( isInit, true );
+   EXPECT_EQ( scheme->nullMeshes(), true );
 
    tribol::finalize();
 }

--- a/src/tribol/geom/ContactPlaneManager.cpp
+++ b/src/tribol/geom/ContactPlaneManager.cpp
@@ -585,7 +585,7 @@ void ContactPlaneManager::addContactPlane( const ContactPlane2D& cp )
 }
 
 //------------------------------------------------------------------------------
-void ContactPlaneManager::deleteCPManager()
+void ContactPlaneManager::clearCPManager()
 {
 
    // delete allocated storage

--- a/src/tribol/geom/ContactPlaneManager.hpp
+++ b/src/tribol/geom/ContactPlaneManager.hpp
@@ -109,7 +109,7 @@ public:
   * \brief Destructor
   *
   */
-  ~ContactPlaneManager() { if( m_numContactPlanes > 0 ) deleteCPManager(); } ;
+  ~ContactPlaneManager() { if( m_numContactPlanes > 0 ) clearCPManager(); } ;
 
   /*!
   * \brief Returns a reference to the ContactPlaneManager instance.
@@ -234,10 +234,12 @@ public:
                                real * coords );
 
   /*!
-  * \brief Delete contact plane manager 
+  * \brief clear contact plane manager 
+  *
+  * \note this clears data and deallocates/nullptr for allocatable arrays
   *
   */
-  void deleteCPManager();
+  void clearCPManager();
 
 private:
   /*!

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -896,7 +896,7 @@ int CouplingScheme::apply( integer cycle, real t, real &dt )
   cpMgr.setSpaceDim( params.dimension );
 
   // loop over number of interface pairs
-  IndexType numPairs = (m_interfacePairs == nullptr) ? 0 : m_interfacePairs->getNumPairs();
+  IndexType numPairs = m_interfacePairs->getNumPairs();
 
   SLIC_DEBUG("Coupling scheme " << m_id << " has " << numPairs << " pairs.");
 

--- a/src/tribol/mesh/CouplingScheme.hpp
+++ b/src/tribol/mesh/CouplingScheme.hpp
@@ -239,6 +239,13 @@ public:
   bool nullMeshes() { return m_nullMeshes; }
 
   /*!
+   * \brief Returns true if one or both meshes are zero-element, null meshes 
+   *
+   * \return true if one or both null meshes in coupling scheme
+   */
+  bool nullMeshes() const { return m_nullMeshes; }
+
+  /*!
    * \brief Returns true if a valid mode is specified, otherwise false
    *
    * \return true indicating if the mode is valid;
@@ -529,6 +536,7 @@ private:
   integer m_meshId2; ///< Integer id for mesh 2
 
   bool m_nullMeshes {false}; ///< True if one or both meshes are zero-element (null) meshes
+  bool m_isValid {true}; ///< False if the coupling scheme is not valid per call to init()
 
   integer m_numTotalNodes; ///< Total number of nodes in the coupling scheme
 

--- a/src/tribol/mesh/MeshData.hpp
+++ b/src/tribol/mesh/MeshData.hpp
@@ -162,6 +162,12 @@ public:
 public:
 
   /*!
+   * \brief Checks for valid Lagrange multiplier enforcement data
+   *
+   */
+   int checkLagrangeMultiplierData();
+
+  /*!
    * \brief Checks for valid penalty enforcement data 
    *
    * \param [in] p_enfrc_options penalty enforcement options guiding check

--- a/src/tribol/physics/AlignedMortar.cpp
+++ b/src/tribol/physics/AlignedMortar.cpp
@@ -167,7 +167,7 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
 void ComputeAlignedMortarGaps( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
+   IndexType const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
@@ -281,7 +281,7 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
 {
 
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
+   IndexType const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -160,7 +160,7 @@ template< >
 int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -160,7 +160,7 @@ template< >
 int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
+   IndexType const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -180,7 +180,7 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
 void ComputeSingleMortarGaps( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
+   IndexType const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
@@ -317,7 +317,7 @@ template< >
 int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = (pairs == nullptr) ? 0 :pairs->getNumPairs();
+   IndexType const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -180,7 +180,7 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
 void ComputeSingleMortarGaps( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexType const numPairs = (pairs == nullptr) ? 0 : pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
@@ -210,6 +210,7 @@ void ComputeSingleMortarGaps( CouplingScheme const * cs )
    IndexType const * nonmortarConn = nonmortarMesh.m_connectivity;
 
    // compute nodal normals (do this outside the element loop)
+   // Note, this is guarded against zero element meshes
    nonmortarMesh.computeNodalNormals( dim );
 
    // declare local variables to hold face nodal coordinates
@@ -316,7 +317,7 @@ template< >
 int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexType const numPairs = (pairs == nullptr) ? 0 :pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
@@ -356,33 +357,37 @@ int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs
    real nonmortarX_bar[ dim * numNodesPerFace ];
    real* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
 
-   ////////////////////////////////
-   //                            //
-   // compute single mortar gaps //
-   //                            //
-   ////////////////////////////////
+   ///////////////////////////////////////////////////////
+   //                                                   //
+   //            compute single mortar gaps             //
+   //                                                   //
+   // Note, this routine is guarded against null meshes //
+   ///////////////////////////////////////////////////////
    ComputeSingleMortarGaps( cs );
 
    int numTotalNodes = cs->getNumTotalNodes();
    int numRows = dim * numTotalNodes + numTotalNodes;
    const EnforcementOptions& enforcement_options = const_cast<EnforcementOptions&>(cs->getEnforcementOptions());
    const LagrangeMultiplierImplicitOptions& lm_options  = enforcement_options.lm_implicit_options;
-   if ( lm_options.sparse_mode == SparseMode::MFEM_ELEMENT_DENSE )
+   if (!cs->nullMeshes())
    {
-      static_cast<MortarData*>( cs->getMethodData() )->reserveBlockJ( 
-         {BlockSpace::MORTAR, BlockSpace::NONMORTAR, BlockSpace::LAGRANGE_MULTIPLIER},
-         numPairs
-      );
-   }
-   else if ( lm_options.sparse_mode == SparseMode::MFEM_INDEX_SET || 
-             lm_options.sparse_mode == SparseMode::MFEM_LINKED_LIST )
-   {
-      static_cast<MortarData*>( cs->getMethodData() )->allocateMfemSparseMatrix( numRows );
-   }
-   else
-   {
-      SLIC_WARNING("Unsupported Jacobian storage method.");
-      return 1;
+      if ( lm_options.sparse_mode == SparseMode::MFEM_ELEMENT_DENSE )
+      {
+         static_cast<MortarData*>( cs->getMethodData() )->reserveBlockJ( 
+            {BlockSpace::MORTAR, BlockSpace::NONMORTAR, BlockSpace::LAGRANGE_MULTIPLIER},
+            numPairs
+         );
+      }
+      else if ( lm_options.sparse_mode == SparseMode::MFEM_INDEX_SET || 
+                lm_options.sparse_mode == SparseMode::MFEM_LINKED_LIST )
+      {
+         static_cast<MortarData*>( cs->getMethodData() )->allocateMfemSparseMatrix( numRows );
+      }
+      else
+      {
+         SLIC_WARNING("Unsupported Jacobian storage method.");
+         return 1;
+      }
    }
 
    ////////////////////////////////////////////////////////////////

--- a/src/tribol/utils/ContactPlaneOutput.cpp
+++ b/src/tribol/utils/ContactPlaneOutput.cpp
@@ -7,6 +7,8 @@
 #include "tribol/common/Parameters.hpp"
 #include "tribol/geom/ContactPlaneManager.hpp"
 #include "tribol/mesh/MeshManager.hpp"
+#include "tribol/mesh/CouplingSchemeManager.hpp"
+#include "tribol/mesh/CouplingScheme.hpp"
 #include "tribol/utils/ContactPlaneOutput.hpp"
 
 // AXOM includes
@@ -60,6 +62,8 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
    MeshManager & meshManager = MeshManager::getInstance();
    MeshData& mesh1 = meshManager.GetMeshInstance(meshId1);
    MeshData& mesh2 = meshManager.GetMeshInstance(meshId2);
+   CouplingSchemeManager& csManager = CouplingSchemeManager::getInstance();
+   CouplingScheme* couplingScheme  = csManager.getCoupling(csId);
 
    int nranks = 1;
    int rank = -1;
@@ -74,6 +78,7 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
    // Write contact faces and/or overlaps //
    //                                     //
    /////////////////////////////////////////
+   if (!couplingScheme->nullMeshes())
    {
       int cpSize = cpMgr.size();
       bool overlaps { false };
@@ -356,13 +361,14 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
 
       } // end if-overlaps
 
-   } // end write faces and/or overlaps
+   } // end write faces and/or overlaps for non-null meshes
 
    //////////////////////////////////////////////////////////////
    //                                                          //
    // Write registered contact meshes for this coupling scheme //
    //                                                          //
    //////////////////////////////////////////////////////////////
+   if (!couplingScheme->nullMeshes())
    {
       switch( v_type ) {
         case VIS_MESH :
@@ -489,7 +495,7 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
 
 
       mesh.close();
-   } // end write mesh
+   } // end write mesh for non-null meshes
 
    return;
 


### PR DESCRIPTION
- more comprehensively handle nullptrs associated with zero-element on rank meshes.
- Make it so even zero-element ranks call all of the main Tribol functions down to the physics Apply routines.