### PR TITLE
Fix normal calc for small elements

### DIFF
--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -92,9 +92,16 @@ protected:
          for (int i=0; i<m_lengthNodalData; ++i)
          {
             m_connectivity[i] = i;
-            m_x[i] = 0.;
-            m_y[i] = 0.;
          }
+         // unit square
+         m_x[0] = 0.;
+         m_y[0] = 0.;
+         m_x[1] = 1.;
+         m_y[1] = 0.;
+         m_x[2] = 1.;
+         m_y[2] = 1.;
+         m_x[3] = 0.;
+         m_y[3] = 1.;
 
          if (set_response)
          {
@@ -141,10 +148,32 @@ protected:
          for (int i=0; i<m_lengthNodalData; ++i)
          {
             m_connectivity[i] = i;
-            m_x[i] = 0.;
-            m_y[i] = 0.;
-            m_z[i] = 0.;
          }
+         // unit cube
+         m_x[0] = 0.;
+         m_y[0] = 0.;
+         m_z[0] = 0.;
+         m_x[1] = 1.;
+         m_y[1] = 0.;
+         m_z[1] = 0.;
+         m_x[2] = 1.;
+         m_y[2] = 1.;
+         m_z[2] = 0.;
+         m_x[3] = 0.;
+         m_y[3] = 1.;
+         m_z[3] = 0.;
+         m_x[4] = 0.;
+         m_y[4] = 0.;
+         m_z[4] = 1.;
+         m_x[5] = 1.;
+         m_y[5] = 0.;
+         m_z[5] = 1.;
+         m_x[6] = 1.;
+         m_y[6] = 1.;
+         m_z[6] = 1.;
+         m_x[7] = 0.;
+         m_y[7] = 1.;
+         m_z[7] = 1.;
 
          if (set_response)
          {

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -413,7 +413,7 @@ void MeshData::computeFaceData( int const dim )
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
         } else {
-           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {e} < {e}", mag, nrmlMagTol));
+           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {:e} < {:e}", mag, nrmlMagTol));
         }
         m_nX[i] *= invMag;
         m_nY[i] *= invMag;
@@ -514,7 +514,7 @@ void MeshData::computeFaceData( int const dim )
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
         } else {
-           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {e} < {e}", mag, nrmlMagTol));
+           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {:e} < {:e}", mag, nrmlMagTol));
         }
 
         // normalize the average normal

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -352,8 +352,9 @@ void MeshData::deallocateArrays()
 }
 
 //------------------------------------------------------------------------------
-void MeshData::computeFaceData( int const dim )
+bool MeshData::computeFaceData( int const dim )
 {
+  bool faceDataOk = true;
   real fac = 1.0 / m_numNodesPerCell;
   constexpr real nrmlMagTol = 1.0e-15;
 
@@ -415,7 +416,7 @@ void MeshData::computeFaceData( int const dim )
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
         } else {
-           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {:e} < {:e}", mag, nrmlMagTol));
+           faceDataOk = false;
         }
         m_nX[i] *= invMag;
         m_nY[i] *= invMag;
@@ -516,7 +517,7 @@ void MeshData::computeFaceData( int const dim )
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
         } else {
-           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {:e} < {:e}", mag, nrmlMagTol));
+           faceDataOk = false;
         }
 
         // normalize the average normal
@@ -528,7 +529,10 @@ void MeshData::computeFaceData( int const dim )
 
   } // end cell loop
 
-  return; 
+  SLIC_WARNING_IF(!faceDataOk, 
+      axom::fmt::format("There are faces with a normal magnitude less than tolerance ({:e}).", nrmlMagTol));
+
+  return faceDataOk; 
 
 } // end MeshData::computeFaceData()
 

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -352,12 +352,8 @@ void MeshData::deallocateArrays()
 //------------------------------------------------------------------------------
 void MeshData::computeFaceData( int const dim )
 {
-  int nodeId;
-  int nextNodeId;
-  int nodeIndex;
   real fac = 1.0 / m_numNodesPerCell;
-  real mag, invMag;
-  real nrmlMagTol = 1.E-6;
+  constexpr real nrmlMagTol = 1.0e-15;
 
   // loop over all cells in the mesh
   for (int i=0; i<m_numCells; ++i) {
@@ -368,8 +364,8 @@ void MeshData::computeFaceData( int const dim )
 
      // loop over the nodes per cell
      for (int j=0; j<m_numNodesPerCell; ++j) {
-        nodeIndex = m_numNodesPerCell * i + j;
-        nodeId = m_connectivity[ nodeIndex ];
+        auto nodeIndex = m_numNodesPerCell * i + j;
+        auto nodeId = m_connectivity[ nodeIndex ];
         // always compute the x and y components for 2D and 3D
         m_cX[i] += m_positionX[ nodeId ];
         m_cY[i] += m_positionY[ nodeId ];
@@ -380,8 +376,8 @@ void MeshData::computeFaceData( int const dim )
 
      if (dim == 3) {
         for (int j=0; j<m_numNodesPerCell; ++j) {
-           nodeIndex = m_numNodesPerCell * i + j;
-           nodeId = m_connectivity[ nodeIndex ];
+           auto nodeIndex = m_numNodesPerCell * i + j;
+           auto nodeId = m_connectivity[ nodeIndex ];
            m_cZ[i] += m_positionZ[ nodeId ];
         } // end loop over nodes
         m_cZ[i] = fac * m_cZ[i];
@@ -397,9 +393,9 @@ void MeshData::computeFaceData( int const dim )
         // counter-clockwise ordering of the quad4 area element
         // to which the 1D line segment belongs. This is to properly 
         // orient the normal outward
-        nodeIndex = m_numNodesPerCell * i;
-        nodeId = m_connectivity[ nodeIndex ];
-        nextNodeId = m_connectivity[ nodeIndex+1 ];
+        auto nodeIndex = m_numNodesPerCell * i;
+        auto nodeId = m_connectivity[ nodeIndex ];
+        auto nextNodeId = m_connectivity[ nodeIndex+1 ];
         real lambdaX = m_positionX[ nextNodeId ] - m_positionX[ nodeId ];
         real lambdaY = m_positionY[ nextNodeId ] - m_positionY[ nodeId ];
    
@@ -412,9 +408,12 @@ void MeshData::computeFaceData( int const dim )
         m_area[i] = magnitude( lambdaX, lambdaY );
 
         // normalize normal vector
-        mag = magnitude( m_nX[i], m_nY[i] );
+        auto mag = magnitude( m_nX[i], m_nY[i] );
+        auto invMag = nrmlMagTol;
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
+        } else {
+           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {e} < {e}", mag, nrmlMagTol));
         }
         m_nX[i] *= invMag;
         m_nY[i] *= invMag;
@@ -445,9 +444,9 @@ void MeshData::computeFaceData( int const dim )
         // loop over m_numNodesPerCell-1 cell edges and compute pallet normal
         for (int j=0; j<(m_numNodesPerCell-1); ++j) 
         {
-           nodeIndex = m_numNodesPerCell * i + j;
-           nodeId = m_connectivity[ nodeIndex ];
-           nextNodeId = m_connectivity[ nodeIndex + 1 ];
+           auto nodeIndex = m_numNodesPerCell * i + j;
+           auto nodeId = m_connectivity[ nodeIndex ];
+           auto nextNodeId = m_connectivity[ nodeIndex + 1 ];
            // first triangle edge vector between the face's two 
            // edge nodes
            vX1 = m_positionX[ nextNodeId ] - m_positionX[ nodeId ];
@@ -479,9 +478,9 @@ void MeshData::computeFaceData( int const dim )
         }
 
         // compute the pallet normal contribution for the last pallet
-        nodeIndex = m_numNodesPerCell * i;
-        nodeId = m_connectivity[ nodeIndex ];
-        nextNodeId = m_connectivity[ nodeIndex + m_numNodesPerCell - 1 ];
+        auto nodeIndex = m_numNodesPerCell * i;
+        auto nodeId = m_connectivity[ nodeIndex ];
+        auto nextNodeId = m_connectivity[ nodeIndex + m_numNodesPerCell - 1 ];
         vX1 = m_positionX[ nodeId ] - m_positionX[ nextNodeId ];
         vY1 = m_positionY[ nodeId ] - m_positionY[ nextNodeId ];
         vZ1 = m_positionZ[ nodeId ] - m_positionZ[ nextNodeId ];
@@ -510,9 +509,12 @@ void MeshData::computeFaceData( int const dim )
         m_nZ[i] = fac * m_nZ[i];
 
         // compute the magnitude of the average pallet normal
-        mag = magnitude(m_nX[i], m_nY[i], m_nZ[i] );
+        auto mag = magnitude(m_nX[i], m_nY[i], m_nZ[i] );
+        auto invMag = nrmlMagTol;
         if (mag >= nrmlMagTol) {
            invMag = 1.0 / mag;
+        } else {
+           SLIC_ERROR(axom::fmt::format("Magnitude of the normal is less than tolerance: {e} < {e}", mag, nrmlMagTol));
         }
 
         // normalize the average normal

--- a/src/tribol/mesh/MeshData.hpp
+++ b/src/tribol/mesh/MeshData.hpp
@@ -182,10 +182,11 @@ public:
    * \brief Computes the face normals and centroids for all faces in the mesh.
    *
    * \param [in] dim Dimension of the problem 
+   * \return true if face calculations do not encounter errors or warnings
    * 
    * This routine accounts for warped faces by computing an average normal.
    */
-  void computeFaceData( int const dim );
+  bool computeFaceData( int const dim );
   
   /*!
    * \brief Computes average nodal normals for use with mortar methods


### PR DESCRIPTION
This PR makes the normal computation work for small elements by reducing the size of the allowed magnitude of the normal to around machine precision.  If the magnitude of the normal is smaller than this (including zero or negative), the routine will now produce a warning and return false.

Additionally, the scope of some variables has been reduced and they are now initialized upon creation.