### PR TITLE
Mesh Data Calcs After Valid Mesh/Scheme Checks

### DIFF
--- a/src/tests/tribol_mortar_gap.cpp
+++ b/src/tests/tribol_mortar_gap.cpp
@@ -163,8 +163,9 @@ public:
          }
       }
 
+      int dim = 3;
       tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
-      tribol::initialize( 3, problem_comm );
+      tribol::initialize( dim, problem_comm );
 
       const int mortarMeshId = 0;
       const int nonmortarMeshId = 1;
@@ -177,6 +178,14 @@ public:
                             this->numNodesPerFace,
                             conn2, cellType,
                             x2, y2, z2 );
+
+      // get instance of meshes to compute face data required for other calculations
+      tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
+      tribol::MeshData& mortarMesh = meshManager.GetMeshInstance( mortarMeshId );
+      tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarMeshId );
+
+      mortarMesh.computeFaceData(dim);
+      nonmortarMesh.computeFaceData(dim);
 
       real* gaps;
       int size = 2*this->numNodesPerFace;
@@ -210,10 +219,6 @@ public:
          SLIC_ERROR("Unsupported contact method");
          break;
       }
-
-      // get instance of mesh in order to compute nodal gaps
-      tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
-      tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarMeshId );
 
       nonmortarMesh.computeNodalNormals( this->dim );
 

--- a/src/tests/tribol_nodal_nrmls.cpp
+++ b/src/tests/tribol_nodal_nrmls.cpp
@@ -52,6 +52,9 @@ public:
       tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
       tribol::MeshData& mesh = meshManager.GetMeshInstance( meshId );
 
+      // compute the face data for this mesh
+      mesh.computeFaceData( dim );
+
       mesh.computeNodalNormals( dim );
 
       return;

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -375,6 +375,7 @@ void registerMesh( integer meshId,
    // since Tribol supports null meshes. This is not uncommon in parallel 
    // contact simulations
    mesh.m_meshId = meshId;
+   mesh.m_dim = dim;
    mesh.m_positionX = x;
    mesh.m_positionY = y;
    mesh.m_positionZ = z;
@@ -420,9 +421,6 @@ void registerMesh( integer meshId,
    {
       mesh.sortSurfaceNodeIds();
    }
-
-   mesh.m_dim = dim;
-   mesh.deallocateArrays();
 
    if (mesh.m_numCells > 0)
    {

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -422,6 +422,24 @@ void registerMesh( integer meshId,
    }
 
    mesh.m_dim = dim;
+   mesh.deallocateArrays();
+
+   if (mesh.m_numCells > 0)
+   {
+      mesh.allocateArrays(dim);
+      initRealArray( mesh.m_nX,   mesh.m_numCells, 0. );
+      initRealArray( mesh.m_nY,   mesh.m_numCells, 0. );
+      initRealArray( mesh.m_cX,   mesh.m_numCells, 0. );
+      initRealArray( mesh.m_cY,   mesh.m_numCells, 0. );
+      initRealArray( mesh.m_area, mesh.m_numCells, 0. );
+   }
+
+   if (mesh.m_dim == 3 && mesh.m_numCells > 0)
+   {
+      initRealArray( mesh.m_nZ, mesh.m_numCells, 0. );
+      initRealArray( mesh.m_cZ, mesh.m_numCells, 0. );
+   }
+
 
 } // end of registerMesh()
 

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -421,25 +421,7 @@ void registerMesh( integer meshId,
       mesh.sortSurfaceNodeIds();
    }
 
-   // allocate outward unit face normal arrays and centroid arrays and cell area array
    mesh.m_dim = dim;
-   mesh.deallocateArrays();
-
-   if (mesh.m_numCells > 0)
-   {
-      mesh.allocateArrays(dim);
-      initRealArray( mesh.m_nX,   mesh.m_numCells, 0. );
-      initRealArray( mesh.m_nY,   mesh.m_numCells, 0. );
-      initRealArray( mesh.m_cX,   mesh.m_numCells, 0. );
-      initRealArray( mesh.m_cY,   mesh.m_numCells, 0. );
-      initRealArray( mesh.m_area, mesh.m_numCells, 0. );
-   }
-
-   if (dim == 3 && mesh.m_numCells > 0)
-   {
-      initRealArray( mesh.m_nZ, mesh.m_numCells, 0. );
-      initRealArray( mesh.m_cZ, mesh.m_numCells, 0. );
-   }
 
 } // end of registerMesh()
 

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -441,9 +441,6 @@ void registerMesh( integer meshId,
       initRealArray( mesh.m_cZ, mesh.m_numCells, 0. );
    }
 
-   // compute the face data
-   mesh.computeFaceData( dim );
-
 } // end of registerMesh()
 
 //------------------------------------------------------------------------------

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1001,6 +1001,17 @@ bool CouplingScheme::init()
       // set individual coupling scheme logging level
       this->setSlicLoggingLevel();
       this->allocateMethodData();
+
+      // compute the face data
+      MeshManager & meshManager = MeshManager::getInstance(); 
+      MeshData & mesh1 = meshManager.GetMeshInstance( this->m_meshId1 );
+      mesh1.computeFaceData( mesh1.m_dim );
+      if (this->m_meshId2 != this->m_meshId1)
+      {
+         MeshData & mesh2 = meshManager.GetMeshInstance( this->m_meshId2 );
+         mesh2.computeFaceData( mesh2.m_dim );
+      }
+
       return true;
    }
    else

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -354,24 +354,6 @@ void MeshData::deallocateArrays()
 //------------------------------------------------------------------------------
 void MeshData::computeFaceData( int const dim )
 {
-   this->deallocateArrays();
-
-   if (this->m_numCells > 0)
-   {
-      this->allocateArrays(dim);
-      initRealArray( this->m_nX,   this->m_numCells, 0. );
-      initRealArray( this->m_nY,   this->m_numCells, 0. );
-      initRealArray( this->m_cX,   this->m_numCells, 0. );
-      initRealArray( this->m_cY,   this->m_numCells, 0. );
-      initRealArray( this->m_area, this->m_numCells, 0. );
-   }
-
-   if (this->m_dim == 3 && this->m_numCells > 0)
-   {
-      initRealArray( this->m_nZ, this->m_numCells, 0. );
-      initRealArray( this->m_cZ, this->m_numCells, 0. );
-   }
-
   int nodeId;
   int nextNodeId;
   int nodeIndex;

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -354,6 +354,24 @@ void MeshData::deallocateArrays()
 //------------------------------------------------------------------------------
 void MeshData::computeFaceData( int const dim )
 {
+   this->deallocateArrays();
+
+   if (this->m_numCells > 0)
+   {
+      this->allocateArrays(dim);
+      initRealArray( this->m_nX,   this->m_numCells, 0. );
+      initRealArray( this->m_nY,   this->m_numCells, 0. );
+      initRealArray( this->m_cX,   this->m_numCells, 0. );
+      initRealArray( this->m_cY,   this->m_numCells, 0. );
+      initRealArray( this->m_area, this->m_numCells, 0. );
+   }
+
+   if (this->m_dim == 3 && this->m_numCells > 0)
+   {
+      initRealArray( this->m_nZ, this->m_numCells, 0. );
+      initRealArray( this->m_cZ, this->m_numCells, 0. );
+   }
+
   int nodeId;
   int nextNodeId;
   int nodeIndex;

--- a/src/tribol/mesh/MeshManager.hpp
+++ b/src/tribol/mesh/MeshManager.hpp
@@ -101,7 +101,6 @@ public:
 private:
   std::unordered_map< integer, MeshData > m_meshInstances; ///< Unordered map of mesh instances
 
-
 };
 }
 #endif /* SRC_MESH_MESHMANAGER_HPP_ */


### PR DESCRIPTION
- This moves the computeFaceData() into the couplingScheme::init() calculation. 
- This fixes possible bug for host-codes that only call registerMesh() once, which is where the face data was being computed
- This now allocates and computes mesh face data each time tribol::update() is called, which is appropriate, and only does so for valid meshes/schemes, which is also appropriate.
- Tests that just checked mesh data now have to explicitly call mesh.computeFaceData(), as opposed to simply calling tribol::registerMesh().