### PR TITLE
Modify API to more clearly support setting of auto contact scale

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,8 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
   loop; don't error out in the presence of a bad dt vote, but issue debug print.
 - Updated logging of face geometry issues to `SLIC_INFO()` and don't error out in presence of
   geometry issue.
+- Changed `setContactPenFrac()` to `setAutoContactPenScale()`, which better describes when and
+  how this scale factor is used.
   
 ### Fixed
 - Allow null velocity and response pointers for various use cases

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -504,7 +504,6 @@ TEST_F( CommonPlaneTest, element_penalty_check )
 
    // call tribol setup and update
    tribol::TestControlParameters parameters; 
-   parameters.contact_pen_frac = 0.29;
    parameters.penalty_ratio = true;
    parameters.const_penalty = 0.75;
    parameters.dt = dt;

--- a/src/tests/tribol_comp_geom.cpp
+++ b/src/tests/tribol_comp_geom.cpp
@@ -425,7 +425,6 @@ TEST_F( CompGeomTest, 2d_projections_1 )
                                    tribol::BINNING_GRID );
 
    tribol::setPenaltyOptions( 0, tribol::KINEMATIC, tribol::KINEMATIC_CONSTANT );
-   tribol::setContactPenFrac(0.5);
    tribol::setContactAreaFrac(1.e-4);
 
    // TODO check penetration and overlap tolerance with what is being used in host-code
@@ -677,7 +676,7 @@ TEST_F( CompGeomTest, auto_contact_lt_max_interpen )
 
    // amount of interpenetration in the z-direction
    real max_interpen_frac = 1.0;
-   tribol::setContactPenFrac( max_interpen_frac );
+   tribol::setAutoContactPenScale( max_interpen_frac );
    real test_ratio = 0.90; // fraction of max interpen frac used for this test
    z[4] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[5] = -test_ratio * max_interpen_frac * element_thickness[1]; 
@@ -807,7 +806,7 @@ TEST_F( CompGeomTest, auto_contact_gt_max_interpen )
 
    // amount of interpenetration in the z-direction
    real max_interpen_frac = 1.0;
-   tribol::setContactPenFrac( max_interpen_frac );
+   tribol::setAutoContactPenScale( max_interpen_frac );
    real test_ratio = 1.01; // fraction of max interpen frac used for this test
    z[4] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[5] = -test_ratio * max_interpen_frac * element_thickness[1]; 

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -496,7 +496,9 @@ struct parameters_t
   VisType vis_type;              ///! Type of interface physics visualization output
   std::string output_directory;  ///! Output directory for visualization dumps
   bool enable_timestep_vote;     ///! True if host-code desires the timestep vote to be calculated and returned
-  bool auto_interpen_check;      ///! True if the auto-contact interpenetration check is used for full-overlap pairs
+
+  double auto_contact_len_scale_factor; ///! Sacle factor applied to element thickness for auto contact length scale
+  bool auto_interpen_check;             ///! True if the auto-contact interpenetration check is used for full-overlap pairs
 
 private:
 

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -489,7 +489,7 @@ struct parameters_t
   double gap_tied_tol;           ///! Ratio for determining max separation tied contact can support
   double len_collapse_ratio;     ///! Ratio of face length providing topology collapse length tolerance
   double projection_ratio;       ///! Ratio for defining nonzero projections
-  double contact_pen_frac;       ///! Max allowable interpenetration as percent of element thickness for contact candidacy
+  double auto_contact_pen_frac;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
   double timestep_pen_frac;      ///! Max allowable interpenetration as percent of element thickness prior to triggering timestep vote
 
   int vis_cycle_incr;            ///! Frequency for visualizations dumps

--- a/src/tribol/geom/ContactPlane.cpp
+++ b/src/tribol/geom/ContactPlane.cpp
@@ -310,7 +310,7 @@ bool ExceedsMaxAutoInterpen( const MeshData& meshDat1, const MeshData& meshDat2,
    parameters_t& params = parameters_t::getInstance();
    if (params.auto_interpen_check)
    {
-      real max_interpen = -1. * params.contact_pen_frac * 
+      real max_interpen = -1. * params.auto_contact_pen_frac * 
                           axom::utilities::min( meshDat1.m_elemData.m_thickness[ faceId1 ],
                                                 meshDat2.m_elemData.m_thickness[ faceId2 ] );
 
@@ -542,9 +542,7 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    // CHECK #5: check if the nodes of face2 interpenetrate the 
    // plane defined by face1 AND vice-versa. For proximate faces 
    // that pass check #3 this check may easily indicate that the faces 
-   // do in fact intersect. Note, the separation tolerance is 1/2 the longest 
-   // dimension of the face element. A larger tolerance allowing for separation 
-   // is per testing of the mortar method.
+   // do in fact intersect. 
    real separationTol = params.gap_separation_ratio * 
                         axom::utilities::max( mesh1.m_faceRadius[ faceId1 ], 
                                               mesh2.m_faceRadius[ faceId2 ] );
@@ -806,9 +804,9 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
       axom::utilities::max( mesh1.m_faceRadius[ faceId1 ], 
                             mesh2.m_faceRadius[ faceId2 ] ));
 
-   // The gap tolerance allows separation up to 50% the largest face-radius.
-   // This is conservative and allows for possible over-inclusion. This is done 
-   // for the mortar method per testing.
+   // The gap tolerance allows separation up to the separation ratio of the 
+   // largest face-radius. This is conservative and allows for possible 
+   // over-inclusion. This is done for the mortar method per testing.
    cp.m_gapTol = params.gap_separation_ratio * 
                  axom::utilities::max( mesh1.m_faceRadius[ faceId1 ], 
                                        mesh2.m_faceRadius[ faceId2 ] );
@@ -1999,7 +1997,7 @@ FaceGeomError CheckEdgePair( InterfacePair& pair,
    // a fullOverlap computation, but we don't know if there is a positive 
    // length of overlap and will have to construct the contact plane 
    // (contact segment) and perform this check. Note, this tolerance is 
-   // inclusive up to a separation of the edge-radius.
+   // inclusive up to a separation of a fraction of the edge-radius.
    // This is done for the mortar method per 3D testing.
    real separationTol = params.gap_separation_ratio * 
                         axom::utilities::max( mesh1.m_faceRadius[ edgeId1 ], 

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -67,7 +67,7 @@ void set_defaults()
    parameters.gap_tied_tol                 = 0.1;    // tolerance for how much separation can occur before opposing faces are let go
    parameters.len_collapse_ratio           = 1.E-8;
    parameters.projection_ratio             = 1.E-10;
-   parameters.contact_pen_frac             = 1.0;    // max allowable interpenetration as percent of element thickness for contact candidacy 
+   parameters.auto_contact_pen_frac        = 0.95;   // max allowable interpenetration as percent of element thickness for contact candidacy 
    parameters.timestep_pen_frac            = 3.e-1;  // max allowable interpenetration as percent of element thickness prior to triggering timestep vote (not exposed to API) 
    parameters.enable_timestep_vote         = false;  // true if host-code wants to receive tribol timestep vote
    
@@ -78,7 +78,6 @@ void set_defaults()
    // constituent face elements, then we don't consider the face-pair a contact candidate.
    // Note, auto-contact will require registration of element thicknesses.
    parameters.auto_interpen_check           = false; // true if the auto-contact interpenetration check is used for interpenetrating face-pairs.
-   parameters.auto_contact_len_scale_factor = 1.0;   // sacle factor applied to element thickness for auto contact length scale
 
 }
 
@@ -188,18 +187,18 @@ void setRatePercentPenalty( int meshId, double r_p )
 } // end setRatePercentPenalty()
 
 //------------------------------------------------------------------------------
-void setContactPenFrac( double frac )
+void setAutoContactPenScale( double scale )
 {
    parameters_t & parameters = parameters_t::getInstance();
-   if (frac <= 0.)
+   if (scale <= .95)
    {
-      // Don't set the contact_pen_frac. This will use default
+      parameters.auto_contact_pen_frac = 0.95;
       return;
    }
 
-   parameters.contact_pen_frac = frac;
+   parameters.auto_contact_pen_frac = scale;
 
-} // end setContactPenFrac()
+} // end setAutoContactPenScale()
 
 //------------------------------------------------------------------------------
 void setTimestepPenFrac( double frac )

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -190,11 +190,10 @@ void setRatePercentPenalty( int meshId, double r_p )
 void setAutoContactPenScale( double scale )
 {
    parameters_t & parameters = parameters_t::getInstance();
-   if (scale <= .95)
-   {
-      parameters.auto_contact_pen_frac = 0.95;
-      return;
-   }
+
+   // check for strict positivity of the input parameter
+   SLIC_WARNING_ROOT_IF(scale<0., "tribol::setAutoContactPenScale(): " << 
+                        "input for the auto-contact length scale factor must be positive.");
 
    parameters.auto_contact_pen_frac = scale;
 

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -77,7 +77,8 @@ void set_defaults()
    // interpenetration kinematic gap is more than the smallest thickness of the 
    // constituent face elements, then we don't consider the face-pair a contact candidate.
    // Note, auto-contact will require registration of element thicknesses.
-   parameters.auto_interpen_check          = false; // true if the auto-contact interpenetration check is used for interpenetrating face-pairs.
+   parameters.auto_interpen_check           = false; // true if the auto-contact interpenetration check is used for interpenetrating face-pairs.
+   parameters.auto_contact_len_scale_factor = 1.0;   // sacle factor applied to element thickness for auto contact length scale
 
 }
 

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -87,14 +87,16 @@ void setRatePercentPenalty( int meshId, double r_p );
 
 /*!
  *
- * \brief sets the contact interpen fraction on the parameters struct
+ * \brief sets the auto-contact interpen fraction on the parameters struct
  *
- * \param [in] frac the maximum allowable interpenetration factor
+ * \param [in] scale the scale applied to the element thickness to determine the auto-contact length scale 
  *
  * \note this is only used for common-plane with penalty enforcement
  *
+ * \pre scale < 0.95 will be reset to use the default of scale = 0.95
+ *
  */
-void setContactPenFrac( double frac );
+void setAutoContactPenScale( double scale );
 
 /*!
  *

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -91,9 +91,9 @@ void setRatePercentPenalty( int meshId, double r_p );
  *
  * \param [in] scale the scale applied to the element thickness to determine the auto-contact length scale 
  *
- * \note this is only used for common-plane with penalty enforcement
- *
- * \pre scale < 0.95 will be reset to use the default of scale = 0.95
+ * \note this is only used for common-plane with penalty enforcement. A sacle < 1.0 may 
+ * result in missed contact face-pairs in softer contact responses
+ *     
  *
  */
 void setAutoContactPenScale( double scale );

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -1155,7 +1155,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
       }
 
       // set the penetration fraction for timestep votes computed with penalty enforcements
-      setContactPenFrac( params.contact_pen_frac );
+      setAutoContactPenScale( params.auto_contact_pen_frac );
 
    } // end if-penalty
 

--- a/src/tribol/utils/TestUtils.hpp
+++ b/src/tribol/utils/TestUtils.hpp
@@ -61,7 +61,7 @@ struct TestControlParameters
    }
 
    real dt {0.};
-   real contact_pen_frac {1.0};
+   real auto_contact_pen_frac {0.95};
 
    // penalty control parameters
    bool penalty_ratio;


### PR DESCRIPTION
- Changed setContactPenFrac(), which was not being used correctly, to setAutoContactPenScale(), which more clearly indicates using a scale factor to scale the element thickness to be used as an auto-contact length scale.
- The auto contact length scale precludes contact on opposite faces of thin plates.