### PR TITLE
Add const support for `BlockOperator::GetBlock()`

### DIFF
--- a/src/examples/mfem_mortar_lm_patch.cpp
+++ b/src/examples/mfem_mortar_lm_patch.cpp
@@ -397,7 +397,8 @@ int main( int argc, char** argv )
     {
       if (A_blk->GetBlock(i, j).Height() != 0 && A_blk->GetBlock(i, j).Width() != 0)
       {
-        hypre_blocks(i, j) = dynamic_cast<mfem::HypreParMatrix*>(&A_blk->GetBlock(i, j));
+        hypre_blocks(i, j) = const_cast<mfem::HypreParMatrix*>(
+          dynamic_cast<const mfem::HypreParMatrix*>(&A_blk->GetBlock(i, j)));
       }
       else
       {


### PR DESCRIPTION
Improves MFEM compatibility due to recent changes in `BlockOperator::GetBlock()`.

This change maximizes compatibility with previous and future versions of MFEM, but eventually, `hypre_blocks` should be changed to `mfem::Array2D<const mfem::HypreParMatrix*>` pending [MFEM #4135](https://github.com/mfem/mfem/pull/4135).