### PR TITLE
Update types in Tribol

### DIFF
--- a/src/examples/common_plane.cpp
+++ b/src/examples/common_plane.cpp
@@ -19,6 +19,11 @@
 #include "tribol/physics/CommonPlane.hpp"
 #include "tribol/geom/GeomUtilities.hpp"
 
+#ifdef TRIBOL_USE_UMPIRE
+// Umpire includes
+#include "umpire/ResourceManager.hpp"
+#endif
+
 #include "axom/slic.hpp"
 
 // C/C++ includes
@@ -57,8 +62,12 @@ int main( int argc, char** argv )
 #ifdef TRIBOL_USE_MPI
   MPI_Init( &argc, &argv );
 #endif
-  tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+  tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
   initialize_logger( problem_comm );
+
+#ifdef TRIBOL_USE_UMPIRE
+  umpire::ResourceManager::getInstance();  // initialize umpire's ResouceManager
+#endif
 
   // parse command line arguments
   Arguments args;

--- a/src/examples/examples_common.hpp
+++ b/src/examples/examples_common.hpp
@@ -30,7 +30,7 @@ namespace utilities = axom::utilities;
 namespace fmt       = axom::fmt;
 namespace CLI       = axom::CLI;
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 //------------------------------------------------------------------------------
 // COMMON DATA STRUCTURE DEFINITIONS
@@ -101,12 +101,12 @@ struct Arguments
   bool dump_vis{false};          // should the example dump visualization files?
 
   /// input arguments for examples that use the TestMesh class
-  std::vector<tribol::integer> block1_res{4, 4, 4};      // block1 -- number of elements in each direction
-  std::vector<tribol::real> block1_min {0., 0., 0.};     // block1 -- bounding box min
-  std::vector<tribol::real> block1_max {1., 1., 1.05};   // block1 -- bounding box max
-  std::vector<tribol::integer> block2_res{4, 4, 4};      // block2 -- number of elements in each direction
-  std::vector<tribol::real> block2_min {0., 0., 0.95};   // block2 -- bounding box min
-  std::vector<tribol::real> block2_max {1., 1., 2.};     // block2 -- bounding box max
+  std::vector<int> block1_res{4, 4, 4};      // block1 -- number of elements in each direction
+  std::vector<tribol::RealT> block1_min {0., 0., 0.};     // block1 -- bounding box min
+  std::vector<tribol::RealT> block1_max {1., 1., 1.05};   // block1 -- bounding box max
+  std::vector<int> block2_res{4, 4, 4};      // block2 -- number of elements in each direction
+  std::vector<tribol::RealT> block2_min {0., 0., 0.95};   // block2 -- bounding box min
+  std::vector<tribol::RealT> block2_max {1., 1., 2.};     // block2 -- bounding box max
 };
 
 //------------------------------------------------------------------------------
@@ -233,7 +233,7 @@ int tribol_register_and_update( tribol::TestMesh &mesh,
    // STEP 0: initialize tribol //
    //                           //
    ///////////////////////////////
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( mesh.dim, problem_comm );
 
    /////////////////////////////////////////////
@@ -504,7 +504,7 @@ int tribol_register_and_update( tribol::TestMesh &mesh,
  * \brief Initialize logger
  * \param [in] problem_comm MPI communicator
  */
-void initialize_logger( tribol::CommType problem_comm )
+void initialize_logger( tribol::CommT problem_comm )
 {
   slic::initialize();
   slic::setLoggingMsgLevel( slic::message::Debug );

--- a/src/examples/mortar_lm_patch_test.cpp
+++ b/src/examples/mortar_lm_patch_test.cpp
@@ -84,7 +84,7 @@ int main( int argc, char** argv )
 #ifdef TRIBOL_USE_MPI
   MPI_Init( &argc, &argv );
 #endif
-  tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+  tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
 
 #ifdef TRIBOL_USE_UMPIRE
   umpire::ResourceManager::getInstance();         // initialize umpire's ResouceManager
@@ -184,8 +184,8 @@ int main( int argc, char** argv )
      ////////////////////////////////////////////////////
 
      // setup material properties
-     double nu_val {0.33}; // Poisson's ratio
-     double youngs_val {3.E7}; // Young's modulus (approximate, mild steel (psi))
+     RealT nu_val {0.33}; // Poisson's ratio
+     RealT youngs_val {3.E7}; // Young's modulus (approximate, mild steel (psi))
 
      /////////////////////////////////////////////////////////////////////////
      // compute equilibrium contributions and sum into Tribol sparse matrix //
@@ -205,7 +205,7 @@ int main( int argc, char** argv )
      // instantiate mfem vector for RHS contributions
      int rhs_size = mesh.dim * mesh.numTotalNodes + // equilibrium equations
                     mesh.numNonmortarSurfaceNodes;      // gap equations
-     double b[ rhs_size ];
+     RealT b[ rhs_size ];
      tribol::initRealArray( &b[0], rhs_size, 0. );
      mfem::Vector rhs( &b[0], rhs_size );
      rhs = 0.; // initialize
@@ -263,11 +263,11 @@ int main( int argc, char** argv )
      mfem::DenseMatrixInverse invA( A );
      mfem::Vector sol;
      invA.Mult( rhs, sol ); // solve the system
-     real * sol_data = sol.GetData(); // get solution data
+     RealT * sol_data = sol.GetData(); // get solution data
 
      SLIC_INFO( "Solved global system of equations." );
 
-     real pressureSum = 0.;
+     RealT pressureSum = 0.;
      for (int i=0; i<mesh.numNonmortarSurfaceNodes; ++i)
      {
         int offset = mesh.dim * mesh.numTotalNodes;

--- a/src/tests/tribol_common_plane_gap_rate.cpp
+++ b/src/tests/tribol_common_plane_gap_rate.cpp
@@ -31,18 +31,18 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 void compareGaps( tribol::CouplingScheme const * cs, 
-                  real gap, const real tol,
+                  RealT gap, const RealT tol,
                   const char *gapType )
 {
    tribol::ContactPlaneManager& cpManager = tribol::ContactPlaneManager::getInstance();
    tribol::InterfacePairs const * const pairs = cs->getInterfacePairs();
-   tribol::IndexType const numPairs = pairs->getNumPairs();
+   tribol::IndexT const numPairs = pairs->getNumPairs();
 
    int cpID = 0;
-   for (tribol::IndexType kp = 0; kp < numPairs; ++kp)
+   for (tribol::IndexT kp = 0; kp < numPairs; ++kp)
    {
       tribol::InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -51,7 +51,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
          continue;
       }
 
-      real my_gap = 0.;
+      RealT my_gap = 0.;
       if ( std::strcmp( gapType, "kinematic_penetration" ) == 0 ||
            std::strcmp( gapType, "kinematic_separation"  ) == 0 )
       {
@@ -63,7 +63,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
       }
 
       // gap tolerance per common-plane based calculation (see CouplingScheme::getGapTol)
-      double gap_tol = cs->getGapTol( pair.pairIndex1, pair.pairIndex2 );
+      RealT gap_tol = cs->getGapTol( pair.pairIndex1, pair.pairIndex2 );
                       
       // check gap sense.
       if ( std::strcmp( gapType, "kinematic_penetration" ) == 0  || 
@@ -86,7 +86,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
       }
 
       // check diffs
-      real diff = std::abs( my_gap - gap );
+      RealT diff = std::abs( my_gap - gap );
       EXPECT_LE( diff, tol );
 
       ++cpID;
@@ -94,11 +94,11 @@ void compareGaps( tribol::CouplingScheme const * cs,
 } // end compareGaps()
 
 void checkMeshPenalties( tribol::CouplingScheme const * cs,
-                         const real penalty, const real tol, 
+                         const RealT penalty, const RealT tol, 
                          const char * penaltyType )
 {
-   tribol::IndexType const meshId1 = cs->getMeshId1();
-   tribol::IndexType const meshId2 = cs->getMeshId2();
+   tribol::IndexT const meshId1 = cs->getMeshId1();
+   tribol::IndexT const meshId2 = cs->getMeshId2();
 
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::MeshData& mesh1 = meshManager.GetMeshInstance( meshId1 );
@@ -106,8 +106,8 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
 
    if ( std::strcmp( penaltyType, "constant" ) == 0 )
    {
-      real penalty_diff_1 = std::abs( mesh1.m_elemData.m_penalty_stiffness - penalty );
-      real penalty_diff_2 = std::abs( mesh2.m_elemData.m_penalty_stiffness - penalty );
+      RealT penalty_diff_1 = std::abs( mesh1.m_elemData.m_penalty_stiffness - penalty );
+      RealT penalty_diff_2 = std::abs( mesh2.m_elemData.m_penalty_stiffness - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
@@ -117,17 +117,17 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
    }
    else if ( std::strcmp( penaltyType, "constant_rate" ) == 0 )
    {
-      real penalty_diff_1 = std::abs( mesh1.m_elemData.m_rate_penalty_stiffness - penalty );
-      real penalty_diff_2 = std::abs( mesh2.m_elemData.m_rate_penalty_stiffness - penalty );
+      RealT penalty_diff_1 = std::abs( mesh1.m_elemData.m_rate_penalty_stiffness - penalty );
+      RealT penalty_diff_2 = std::abs( mesh2.m_elemData.m_rate_penalty_stiffness - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
    else if ( std::strcmp( penaltyType, "percent_rate" ) == 0 )
    {
-      real penalty1 = mesh1.m_elemData.m_rate_percent_stiffness * mesh1.m_elemData.m_penalty_stiffness; 
-      real penalty2 = mesh2.m_elemData.m_rate_percent_stiffness * mesh2.m_elemData.m_penalty_stiffness; 
-      real penalty_diff_1 = std::abs( penalty1 - penalty );
-      real penalty_diff_2 = std::abs( penalty2 - penalty );
+      RealT penalty1 = mesh1.m_elemData.m_rate_percent_stiffness * mesh1.m_elemData.m_penalty_stiffness; 
+      RealT penalty2 = mesh2.m_elemData.m_rate_percent_stiffness * mesh2.m_elemData.m_penalty_stiffness; 
+      RealT penalty_diff_1 = std::abs( penalty1 - penalty );
+      RealT penalty_diff_2 = std::abs( penalty2 - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
@@ -140,14 +140,14 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
 } // end checkMeshPenalties()
 
 void checkPressures( tribol::CouplingScheme const * cs, 
-                     real pressure, const real tol, const char * pressureType = "kinematic"  )
+                     RealT pressure, const RealT tol, const char * pressureType = "kinematic"  )
 {
    tribol::ContactPlaneManager& cpManager = tribol::ContactPlaneManager::getInstance();
    tribol::InterfacePairs const * const pairs = cs->getInterfacePairs();
-   tribol::IndexType const numPairs = pairs->getNumPairs();
+   tribol::IndexT const numPairs = pairs->getNumPairs();
 
    int cpID = 0;
-   for (tribol::IndexType kp = 0; kp < numPairs; ++kp)
+   for (tribol::IndexT kp = 0; kp < numPairs; ++kp)
    {
       tribol::InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -156,7 +156,7 @@ void checkPressures( tribol::CouplingScheme const * cs,
          continue;
       }
 
-      real my_pressure = 0.;
+      RealT my_pressure = 0.;
       if ( std::strcmp( pressureType, "rate" ) == 0 )
       {
          my_pressure = cpManager.m_ratePressure[ cpID ];
@@ -172,7 +172,7 @@ void checkPressures( tribol::CouplingScheme const * cs,
       }
 
       // check diffs
-      real press_diff = std::abs( my_pressure - pressure );
+      RealT press_diff = std::abs( my_pressure - pressure );
       EXPECT_LE( press_diff, tol );
 
       ++cpID;
@@ -186,8 +186,8 @@ void checkPressures( tribol::CouplingScheme const * cs,
 // mesh configurations.
 void checkForceSense( tribol::CouplingScheme const * cs, bool isTied = false )
 {
-   tribol::IndexType const meshId1 = cs->getMeshId1();
-   tribol::IndexType const meshId2 = cs->getMeshId2();
+   tribol::IndexT const meshId1 = cs->getMeshId1();
+   tribol::IndexT const meshId2 = cs->getMeshId2();
 
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::MeshData& mesh1 = meshManager.GetMeshInstance( meshId1 );
@@ -198,13 +198,13 @@ void checkForceSense( tribol::CouplingScheme const * cs, bool isTied = false )
       tribol::MeshData & mesh = (i==0) ? mesh1 : mesh2;
   
       // loop over faces and nodes
-      for (tribol::IndexType kf = 0; kf < mesh.m_numCells; ++kf)
+      for (tribol::IndexT kf = 0; kf < mesh.m_numCells; ++kf)
       {
-         for (tribol::IndexType a = 0; a<mesh.m_numNodesPerCell; ++a)
+         for (tribol::IndexT a = 0; a<mesh.m_numNodesPerCell; ++a)
          {
             int idx = mesh.m_numNodesPerCell * kf + a;
             int node_id = mesh.m_connectivity[ idx ];
-            real force_mag = tribol::dotProd( mesh.m_forceX[ node_id ],
+            RealT force_mag = tribol::dotProd( mesh.m_forceX[ node_id ],
                                               mesh.m_forceY[ node_id ], 
                                               mesh.m_forceZ[ node_id ],
                                               mesh.m_nX[ kf ],
@@ -265,19 +265,19 @@ TEST_F( CommonPlaneTest, constant_rate_penetration )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -288,13 +288,13 @@ TEST_F( CommonPlaneTest, constant_rate_penetration )
                                      0., 0. );
 
    // set velocities
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = -1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = -1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -321,7 +321,7 @@ TEST_F( CommonPlaneTest, constant_rate_penetration )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -334,9 +334,9 @@ TEST_F( CommonPlaneTest, constant_rate_penetration )
    }
 
    // check the gaps, pressures, and force sense
-   //real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
+   //RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
    compareGaps( couplingScheme, rate_gap, 1.E-8, "rate_penetration" );
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
    checkForceSense( couplingScheme ); // note: the kinematic and rate contributions are not separated
@@ -361,19 +361,19 @@ TEST_F( CommonPlaneTest, constant_rate_separation )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration kinematic gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -385,13 +385,13 @@ TEST_F( CommonPlaneTest, constant_rate_separation )
 
    // set velocities such that the blocks have equal and opposite 'separation' velocities
    // Note: this should not trigger a gap-rate contribution.
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = -1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = 1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = -1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = 1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -418,7 +418,7 @@ TEST_F( CommonPlaneTest, constant_rate_separation )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -431,9 +431,9 @@ TEST_F( CommonPlaneTest, constant_rate_separation )
    }
 
    // check the gaps, pressures and force sense
-   //real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
+   //RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
    compareGaps( couplingScheme, rate_gap, 1.E-8, "rate_separation" );
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
    checkForceSense( couplingScheme ); // note: the kinematic and rate contributions aren't separated
@@ -458,19 +458,19 @@ TEST_F( CommonPlaneTest, no_gap_constant_rate_penetration )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with zero gap.
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 1.;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 1.;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -481,13 +481,13 @@ TEST_F( CommonPlaneTest, no_gap_constant_rate_penetration )
                                      0., 0. );
 
    // set velocities such that further interpenetration would occur
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = -1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = -1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -514,7 +514,7 @@ TEST_F( CommonPlaneTest, no_gap_constant_rate_penetration )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -527,9 +527,9 @@ TEST_F( CommonPlaneTest, no_gap_constant_rate_penetration )
    }
 
    // check to make sure zero rate pressure
-   real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real pressure = (gap < 0. && rate_gap < 0.) ? penalty * rate_gap : 0.;
+   RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT pressure = (gap < 0. && rate_gap < 0.) ? penalty * rate_gap : 0.;
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
 
    tribol::finalize();
@@ -551,19 +551,19 @@ TEST_F( CommonPlaneTest, percent_rate_penetration )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -574,13 +574,13 @@ TEST_F( CommonPlaneTest, percent_rate_penetration )
                                      0., 0. );
 
    // set velocities such that further penetration would occur
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = -1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = -1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -607,7 +607,7 @@ TEST_F( CommonPlaneTest, percent_rate_penetration )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -620,10 +620,10 @@ TEST_F( CommonPlaneTest, percent_rate_penetration )
    }
 
    // check the gaps, pressures, and force sense
-   //real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real stiffness = tribol::ComputePenaltyStiffnessPerArea( penalty, penalty );
-   real pressure = (rate_gap < 0.) ? stiffness * rate_gap : 0.;
+   //RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT stiffness = tribol::ComputePenaltyStiffnessPerArea( penalty, penalty );
+   RealT pressure = (rate_gap < 0.) ? stiffness * rate_gap : 0.;
    compareGaps( couplingScheme, rate_gap, 1.E-8, "rate_penetration" );
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
    checkForceSense( couplingScheme ); // note: the kinematic and rate contributions are not separated
@@ -648,19 +648,19 @@ TEST_F( CommonPlaneTest, percent_rate_separation )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -673,13 +673,13 @@ TEST_F( CommonPlaneTest, percent_rate_separation )
    // set velocities such that equal and opposite 'separation' velocities would 
    // lead to eventual separation of the blocks. This should not trigger a gap-rate
    // contribution.
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = -1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = 1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = -1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = 1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -706,7 +706,7 @@ TEST_F( CommonPlaneTest, percent_rate_separation )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -719,9 +719,9 @@ TEST_F( CommonPlaneTest, percent_rate_separation )
    }
 
    // check the gaps, pressures and force sense
-   //real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
+   //RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT pressure = (rate_gap < 0.) ? penalty * rate_gap : 0.;
    compareGaps( couplingScheme, rate_gap, 1.E-8, "rate_separation" );
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
    checkForceSense( couplingScheme ); // note: the kinematic and rate contributions aren't separated
@@ -746,19 +746,19 @@ TEST_F( CommonPlaneTest, no_gap_percent_rate_penetration )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 1.;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 1.;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -769,13 +769,13 @@ TEST_F( CommonPlaneTest, no_gap_percent_rate_penetration )
                                      0., 0. );
 
    // set velocities such that further interpenetration would occur
-   real dt = 1.e-3;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 1.;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = -1.;
+   RealT dt = 1.e-3;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 1.;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = -1.;
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 );
    
@@ -802,7 +802,7 @@ TEST_F( CommonPlaneTest, no_gap_percent_rate_penetration )
       couplingSchemeManager.getCoupling( 0 );
 
    // check mesh rate penalties
-   real penalty = 0.;
+   RealT penalty = 0.;
    if (parameters.constant_rate_penalty)
    {
       penalty = parameters.rate_penalty;
@@ -815,9 +815,9 @@ TEST_F( CommonPlaneTest, no_gap_percent_rate_penetration )
    }
 
    // check to make sure zero rate pressure
-   real gap = z_min2 - z_max1;
-   real rate_gap = velZ2 - velZ1;
-   real pressure = (gap < 0. && rate_gap < 0.) ? penalty * rate_gap : 0.;
+   RealT gap = z_min2 - z_max1;
+   RealT rate_gap = velZ2 - velZ1;
+   RealT pressure = (gap < 0. && rate_gap < 0.) ? penalty * rate_gap : 0.;
    checkPressures( couplingScheme, pressure, 1.E-8, "rate" );
 
    tribol::finalize();

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -31,18 +31,18 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 void compareGaps( tribol::CouplingScheme const * cs, 
-                  real gap, const real tol,
+                  RealT gap, const RealT tol,
                   const char *gapType )
 {
    tribol::ContactPlaneManager& cpManager = tribol::ContactPlaneManager::getInstance();
    tribol::InterfacePairs const * const pairs = cs->getInterfacePairs();
-   tribol::IndexType const numPairs = pairs->getNumPairs();
+   tribol::IndexT const numPairs = pairs->getNumPairs();
 
    int cpID = 0;
-   for (tribol::IndexType kp = 0; kp < numPairs; ++kp)
+   for (tribol::IndexT kp = 0; kp < numPairs; ++kp)
    {
       tribol::InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -51,7 +51,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
          continue;
       }
 
-      real my_gap = 0.;
+      RealT my_gap = 0.;
       if ( std::strcmp( gapType, "kinematic_penetration" ) == 0 ||
            std::strcmp( gapType, "kinematic_separation"  ) == 0 )
       {
@@ -62,7 +62,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
          my_gap = cpManager.m_velGap[ cpID ];
       }
 
-      double gap_tol = cs->getGapTol( pair.pairIndex1, pair.pairIndex2 );
+      RealT gap_tol = cs->getGapTol( pair.pairIndex1, pair.pairIndex2 );
 
       // check gap sense
       if ( std::strcmp( gapType, "kinematic_penetration" ) == 0  ||
@@ -85,7 +85,7 @@ void compareGaps( tribol::CouplingScheme const * cs,
       }
 
       // check diffs
-      real diff = std::abs( my_gap - gap );
+      RealT diff = std::abs( my_gap - gap );
       EXPECT_LE( diff, tol );
 
       ++cpID;
@@ -93,11 +93,11 @@ void compareGaps( tribol::CouplingScheme const * cs,
 } // end compareGaps()
 
 void checkMeshPenalties( tribol::CouplingScheme const * cs,
-                         const real penalty, const real tol, 
+                         const RealT penalty, const RealT tol, 
                          const char * penaltyType )
 {
-   tribol::IndexType const meshId1 = cs->getMeshId1();
-   tribol::IndexType const meshId2 = cs->getMeshId2();
+   tribol::IndexT const meshId1 = cs->getMeshId1();
+   tribol::IndexT const meshId2 = cs->getMeshId2();
 
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::MeshData& mesh1 = meshManager.GetMeshInstance( meshId1 );
@@ -105,8 +105,8 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
 
    if ( std::strcmp( penaltyType, "constant" ) == 0 )
    {
-      real penalty_diff_1 = std::abs( mesh1.m_elemData.m_penalty_stiffness - penalty );
-      real penalty_diff_2 = std::abs( mesh2.m_elemData.m_penalty_stiffness - penalty );
+      RealT penalty_diff_1 = std::abs( mesh1.m_elemData.m_penalty_stiffness - penalty );
+      RealT penalty_diff_2 = std::abs( mesh2.m_elemData.m_penalty_stiffness - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
@@ -116,17 +116,17 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
    }
    else if ( std::strcmp( penaltyType, "constant_rate" ) == 0 )
    {
-      real penalty_diff_1 = std::abs( mesh1.m_elemData.m_rate_penalty_stiffness - penalty );
-      real penalty_diff_2 = std::abs( mesh2.m_elemData.m_rate_penalty_stiffness - penalty );
+      RealT penalty_diff_1 = std::abs( mesh1.m_elemData.m_rate_penalty_stiffness - penalty );
+      RealT penalty_diff_2 = std::abs( mesh2.m_elemData.m_rate_penalty_stiffness - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
    else if ( std::strcmp( penaltyType, "percent_rate" ) == 0 )
    {
-      real penalty1 = mesh1.m_elemData.m_rate_percent_stiffness * mesh1.m_elemData.m_penalty_stiffness; 
-      real penalty2 = mesh2.m_elemData.m_rate_percent_stiffness * mesh2.m_elemData.m_penalty_stiffness; 
-      real penalty_diff_1 = std::abs( penalty1 - penalty );
-      real penalty_diff_2 = std::abs( penalty2 - penalty );
+      RealT penalty1 = mesh1.m_elemData.m_rate_percent_stiffness * mesh1.m_elemData.m_penalty_stiffness; 
+      RealT penalty2 = mesh2.m_elemData.m_rate_percent_stiffness * mesh2.m_elemData.m_penalty_stiffness; 
+      RealT penalty_diff_1 = std::abs( penalty1 - penalty );
+      RealT penalty_diff_2 = std::abs( penalty2 - penalty );
       EXPECT_LE( penalty_diff_1, tol );
       EXPECT_LE( penalty_diff_2, tol );
    }
@@ -139,14 +139,14 @@ void checkMeshPenalties( tribol::CouplingScheme const * cs,
 } // end checkMeshPenalties()
 
 void checkPressures( tribol::CouplingScheme const * cs, 
-                     real pressure, const real tol, const char * pressureType = "kinematic"  )
+                     RealT pressure, const RealT tol, const char * pressureType = "kinematic"  )
 {
    tribol::ContactPlaneManager& cpManager = tribol::ContactPlaneManager::getInstance();
    tribol::InterfacePairs const * const pairs = cs->getInterfacePairs();
-   tribol::IndexType const numPairs = pairs->getNumPairs();
+   tribol::IndexT const numPairs = pairs->getNumPairs();
 
    int cpID = 0;
-   for (tribol::IndexType kp = 0; kp < numPairs; ++kp)
+   for (tribol::IndexT kp = 0; kp < numPairs; ++kp)
    {
       tribol::InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -155,7 +155,7 @@ void checkPressures( tribol::CouplingScheme const * cs,
          continue;
       }
 
-      real my_pressure = 0.;
+      RealT my_pressure = 0.;
       if ( std::strcmp( pressureType, "rate" ) == 0 )
       {
          my_pressure = cpManager.m_ratePressure[ cpID ];
@@ -171,7 +171,7 @@ void checkPressures( tribol::CouplingScheme const * cs,
       }
 
       // check diffs
-      real press_diff = std::abs( my_pressure - pressure );
+      RealT press_diff = std::abs( my_pressure - pressure );
       EXPECT_LE( press_diff, tol );
 
       ++cpID;
@@ -185,8 +185,8 @@ void checkPressures( tribol::CouplingScheme const * cs,
 // mesh configurations.
 void checkForceSense( tribol::CouplingScheme const * cs, bool isTied = false )
 {
-   tribol::IndexType const meshId1 = cs->getMeshId1();
-   tribol::IndexType const meshId2 = cs->getMeshId2();
+   tribol::IndexT const meshId1 = cs->getMeshId1();
+   tribol::IndexT const meshId2 = cs->getMeshId2();
 
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::MeshData& mesh1 = meshManager.GetMeshInstance( meshId1 );
@@ -197,13 +197,13 @@ void checkForceSense( tribol::CouplingScheme const * cs, bool isTied = false )
       tribol::MeshData & mesh = (i==0) ? mesh1 : mesh2;
   
       // loop over faces and nodes
-      for (tribol::IndexType kf = 0; kf < mesh.m_numCells; ++kf)
+      for (tribol::IndexT kf = 0; kf < mesh.m_numCells; ++kf)
       {
-         for (tribol::IndexType a = 0; a<mesh.m_numNodesPerCell; ++a)
+         for (tribol::IndexT a = 0; a<mesh.m_numNodesPerCell; ++a)
          {
             int idx = mesh.m_numNodesPerCell * kf + a;
             int node_id = mesh.m_connectivity[ idx ];
-            real force_mag = tribol::dotProd( mesh.m_forceX[ node_id ],
+            RealT force_mag = tribol::dotProd( mesh.m_forceX[ node_id ],
                                               mesh.m_forceY[ node_id ], 
                                               mesh.m_forceZ[ node_id ],
                                               mesh.m_nX[ kf ],
@@ -264,19 +264,19 @@ TEST_F( CommonPlaneTest, penetration_gap_check )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -304,7 +304,7 @@ TEST_F( CommonPlaneTest, penetration_gap_check )
    tribol::CouplingScheme* couplingScheme = 
       couplingSchemeManager.getCoupling( 0 );
 
-   real gap = z_min2 - z_max1;
+   RealT gap = z_min2 - z_max1;
 
    compareGaps( couplingScheme, gap, 1.E-8, "kinematic_penetration" );
 
@@ -328,19 +328,19 @@ TEST_F( CommonPlaneTest, separation_gap_check )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 separation gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 1.1;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 1.1;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -367,7 +367,7 @@ TEST_F( CommonPlaneTest, separation_gap_check )
    tribol::CouplingScheme* couplingScheme = 
       couplingSchemeManager.getCoupling( 0 );
 
-   real gap = z_min2 - z_max1;
+   RealT gap = z_min2 - z_max1;
 
    compareGaps( couplingScheme, gap, 1.E-8, "kinematic_separation" );
 
@@ -390,19 +390,19 @@ TEST_F( CommonPlaneTest, constant_penalty_check )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -433,8 +433,8 @@ TEST_F( CommonPlaneTest, constant_penalty_check )
    checkMeshPenalties( couplingScheme, parameters.const_penalty, 1.E-8, "constant" );
 
    // check the pressures
-   real gap = z_min2 - z_max1;
-   real pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
+   RealT gap = z_min2 - z_max1;
+   RealT pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
    checkPressures( couplingScheme, pressure, 1.E-8 );
    checkForceSense( couplingScheme );
 
@@ -457,23 +457,23 @@ TEST_F( CommonPlaneTest, element_penalty_check )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -483,15 +483,15 @@ TEST_F( CommonPlaneTest, element_penalty_check )
                                      x_max2, y_max2, z_max2,
                                      0., 0. );
 
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0; // something simple
-   real bulk_mod2 = 1.0;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 0.; 
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = 0.; 
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0; // something simple
+   RealT bulk_mod2 = 1.0;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 0.; 
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = 0.; 
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -525,10 +525,10 @@ TEST_F( CommonPlaneTest, element_penalty_check )
    /////////////////////////
    // check the pressures // 
    /////////////////////////
-   real gap = z_min2 - z_max1;
+   RealT gap = z_min2 - z_max1;
   
    // this uses the same face-springs-in-parallel calculation as the common plane + penalty method: K1/t_1 * K2/t_2 / (K1/t_1 + K2/t_2)
-   real pressure = (bulk_mod1 / element_thickness1 * bulk_mod2 / element_thickness2) /
+   RealT pressure = (bulk_mod1 / element_thickness1 * bulk_mod2 / element_thickness2) /
                    (bulk_mod1 / element_thickness1 + bulk_mod2 / element_thickness2) * gap;
    checkPressures( couplingScheme, pressure, 1.E-8 );
    checkForceSense( couplingScheme );
@@ -552,19 +552,19 @@ TEST_F( CommonPlaneTest, tied_contact_check )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 separation gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 1.01;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 1.01;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -592,8 +592,8 @@ TEST_F( CommonPlaneTest, tied_contact_check )
       couplingSchemeManager.getCoupling( 0 );
 
    // check the pressures
-   real gap = z_min2 - z_max1;
-   real pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
+   RealT gap = z_min2 - z_max1;
+   RealT pressure = tribol::ComputePenaltyStiffnessPerArea( parameters.const_penalty, parameters.const_penalty ) * gap;
    checkPressures( couplingScheme, pressure, 1.E-8 );
    checkForceSense( couplingScheme, true );
 

--- a/src/tests/tribol_comp_geom.cpp
+++ b/src/tests/tribol_comp_geom.cpp
@@ -35,7 +35,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test 
@@ -82,19 +82,19 @@ TEST_F( CompGeomTest, common_plane_check )
    int userSpecifiedNumOverlaps = 25;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = -0.1;
-   real y_min2 = 0.0001;
-   real z_min2 = 0.95;
-   real x_max2 = 1.1;
-   real y_max2 = 0.9999;
-   real z_max2 = 2.;
+   RealT x_min2 = -0.1;
+   RealT y_min2 = 0.0001;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.1;
+   RealT y_max2 = 0.9999;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -141,19 +141,19 @@ TEST_F( CompGeomTest, single_mortar_check )
    int userSpecifiedNumOverlaps = 64;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -191,7 +191,7 @@ TEST_F( CompGeomTest, poly_area_centroid_1 )
    // the results are the same
    constexpr int dim = 3;
    constexpr int numVerts = 4;
-   real x[ dim * numVerts ];
+   RealT x[ dim * numVerts ];
 
    for (int i=0; i<dim*numVerts; ++i)
    {
@@ -214,21 +214,21 @@ TEST_F( CompGeomTest, poly_area_centroid_1 )
    x[dim*2+2] = 0.1; 
    x[dim*3+2] = 0.1;
 
-   real cX_avg, cY_avg, cZ_avg;
-   real cX_area, cY_area, cZ_area;
+   RealT cX_avg, cY_avg, cZ_avg;
+   RealT cX_area, cY_area, cZ_area;
 
    tribol::VertexAvgCentroid( x, dim, numVerts, cX_avg, cY_avg, cZ_avg );
    tribol::PolyAreaCentroid( x, dim, numVerts, cX_area, cY_area, cZ_area );
 
-   real diff[3] { 0., 0., 0. };
+   RealT diff[3] { 0., 0., 0. };
 
    diff[0] = std::abs(cX_avg - cX_area);
    diff[1] = std::abs(cY_avg - cY_area);
    diff[2] = std::abs(cZ_avg - cZ_area);
 
-   real diff_mag = tribol::magnitude( diff[0], diff[1], diff[2] );
+   RealT diff_mag = tribol::magnitude( diff[0], diff[1], diff[2] );
 
-   real tol = 1.e-5;
+   RealT tol = 1.e-5;
    EXPECT_LE( diff_mag, tol );
 }
 
@@ -239,9 +239,9 @@ TEST_F( CompGeomTest, poly_area_centroid_2 )
    // closed polygon
    constexpr int dim = 3;
    constexpr int numVerts = 4;
-   real x[ numVerts ];
-   real y[ numVerts ];
-   real z[ numVerts ];
+   RealT x[ numVerts ];
+   RealT y[ numVerts ];
+   RealT z[ numVerts ];
 
    for (int i=0; i<numVerts; ++i)
    {
@@ -267,7 +267,7 @@ TEST_F( CompGeomTest, poly_area_centroid_2 )
    z[3] = 0.1;
 
    // create stacked array of coordinates
-   real x_bar[ dim*numVerts];
+   RealT x_bar[ dim*numVerts];
    for (int i=0; i<numVerts; ++i)
    {
       x_bar[dim*i]   = x[i];
@@ -275,23 +275,23 @@ TEST_F( CompGeomTest, poly_area_centroid_2 )
       x_bar[dim*i+2] = z[i];
    }
 
-   real cX_area, cY_area, cZ_area;
-   real cX_poly, cY_poly, cZ_poly;
+   RealT cX_area, cY_area, cZ_area;
+   RealT cX_poly, cY_poly, cZ_poly;
 
    tribol::PolyAreaCentroid( x_bar, dim, numVerts, cX_area, cY_area, cZ_area );
    tribol::PolyCentroid( x, y, numVerts, cX_poly, cY_poly );
 
    cZ_poly = z[0];
 
-   real diff[3] { 0., 0., 0. };
+   RealT diff[3] { 0., 0., 0. };
 
    diff[0] = std::abs(cX_poly - cX_area);
    diff[1] = std::abs(cY_poly - cY_area);
    diff[2] = std::abs(cZ_poly - cZ_area);
 
-   real diff_mag = tribol::magnitude( diff[0], diff[1], diff[2] );
+   RealT diff_mag = tribol::magnitude( diff[0], diff[1], diff[2] );
 
-   real tol = 1.e-5;
+   RealT tol = 1.e-5;
    EXPECT_LE( diff_mag, tol );
 }
 
@@ -299,8 +299,8 @@ TEST_F( CompGeomTest, 2d_projections_1 )
 {
    constexpr int dim = 2;
    constexpr int numVerts = 2;
-   real xy1[dim*numVerts];
-   real xy2[dim*numVerts];
+   RealT xy1[dim*numVerts];
+   RealT xy2[dim*numVerts];
 
 // Notice how the face vertices are flipped between register mesh and the segment basis eval!
 
@@ -338,58 +338,58 @@ TEST_F( CompGeomTest, 2d_projections_1 )
    xy2[3] = 0.;
 
    // compute face normal
-   real faceNormal1[dim];
-   real faceNormal2[dim];
+   RealT faceNormal1[dim];
+   RealT faceNormal2[dim];
 
-   real lambdaX1 = xy1[2]-xy1[0];
-   real lambdaY1 = xy1[3]-xy1[1];
+   RealT lambdaX1 = xy1[2]-xy1[0];
+   RealT lambdaY1 = xy1[3]-xy1[1];
 
    faceNormal1[0] = lambdaY1;
    faceNormal1[1] = -lambdaX1;
 
-   real lambdaX2 = xy2[2]-xy2[0];
-   real lambdaY2 = xy2[3]-xy2[1];
+   RealT lambdaX2 = xy2[2]-xy2[0];
+   RealT lambdaY2 = xy2[3]-xy2[1];
 
    faceNormal2[0] = lambdaY2;
    faceNormal2[1] = -lambdaX2;
 
-   real cxf1[3] = {0., 0., 0.};
-   real cxf2[3] = {0., 0., 0.};
+   RealT cxf1[3] = {0., 0., 0.};
+   RealT cxf2[3] = {0., 0., 0.};
 
    tribol::VertexAvgCentroid( xy1, dim, numVerts, cxf1[0], cxf1[1], cxf1[2] );
    tribol::VertexAvgCentroid( xy2, dim, numVerts, cxf2[0], cxf2[1], cxf2[2] );
 
    // average the vertex averaged centroids of each face to get a pretty good 
    // estimate of the common plane centroid
-   real cx[dim];
+   RealT cx[dim];
    cx[0] = 0.5*(cxf1[0] + cxf2[0]);
    cx[1] = 0.5*(cxf1[1] + cxf2[1]);
 
-   real cxProj1[3] = {0., 0., 0.}; 
-   real cxProj2[3] = {0., 0., 0.}; 
+   RealT cxProj1[3] = {0., 0., 0.}; 
+   RealT cxProj2[3] = {0., 0., 0.}; 
 
    tribol::ProjectPointToSegment( cx[0], cx[1], faceNormal1[0], faceNormal1[1], 
                                   cxf1[0], cxf1[1], cxProj1[0], cxProj1[1] );
    tribol::ProjectPointToSegment( cx[0], cx[1], faceNormal2[0], faceNormal2[1], 
                                   cxf2[0], cxf2[1], cxProj2[0], cxProj2[1] );
 
-   real diffx1 = std::abs(cxProj1[0] - 0.738595);
-   real diffy1 = std::abs(cxProj1[1] - 0.0915028);
-   real diffx2 = std::abs(cxProj2[0] - 0.738591);
-   real diffy2 = std::abs(cxProj2[1] - 0.0915022);
+   RealT diffx1 = std::abs(cxProj1[0] - 0.738595);
+   RealT diffy1 = std::abs(cxProj1[1] - 0.0915028);
+   RealT diffx2 = std::abs(cxProj2[0] - 0.738591);
+   RealT diffy2 = std::abs(cxProj2[1] - 0.0915022);
    EXPECT_LE(diffx1, 1.e-6);  
    EXPECT_LE(diffy1, 1.e-6); 
    EXPECT_LE(diffx2, 1.e-6); 
    EXPECT_LE(diffy2, 1.e-6); 
 
    // check with call to tribol::update()
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 2, problem_comm );
 
-   real x1[numVerts];
-   real y1[numVerts];
-   real x2[numVerts];
-   real y2[numVerts];
+   RealT x1[numVerts];
+   RealT y1[numVerts];
+   RealT x2[numVerts];
+   RealT y2[numVerts];
 
    for (int i=0; i<numVerts; ++i)
    {
@@ -399,16 +399,16 @@ TEST_F( CompGeomTest, 2d_projections_1 )
       y2[i] = xy2[i*dim+1];
    }
 
-   tribol::IndexType conn1[2] = {0,1};
-   tribol::IndexType conn2[2] = {0,1};
+   tribol::IndexT conn1[2] = {0,1};
+   tribol::IndexT conn2[2] = {0,1};
 
    tribol::registerMesh( 0, 1, 2, &conn1[0], (int)(tribol::LINEAR_EDGE), &x1[0], &y1[0], nullptr );
    tribol::registerMesh( 1, 1, 2, &conn2[0], (int)(tribol::LINEAR_EDGE), &x2[0], &y2[0], nullptr );
 
-   real fx1[2] = {0., 0.};
-   real fy1[2] = {0., 0.};
-   real fx2[2] = {0., 0.};
-   real fy2[2] = {0., 0.};
+   RealT fx1[2] = {0., 0.};
+   RealT fy1[2] = {0., 0.};
+   RealT fx2[2] = {0., 0.};
+   RealT fy2[2] = {0., 0.};
 
    tribol::registerNodalResponse( 0, &fx1[0], &fy1[0], nullptr );
    tribol::registerNodalResponse( 1, &fx2[0], &fy2[0], nullptr );
@@ -429,7 +429,7 @@ TEST_F( CompGeomTest, 2d_projections_1 )
 
    // TODO check penetration and overlap tolerance with what is being used in host-code
 
-   double dt = 1.;
+   RealT dt = 1.;
    int update_err = tribol::update( 1, 1., dt );
 
    EXPECT_EQ( update_err, 0 );
@@ -440,8 +440,8 @@ TEST_F( CompGeomTest, 2d_projections_2 )
 {
    constexpr int dim = 2;
    constexpr int numVerts = 2;
-   real xy1[dim*numVerts];
-   real xy2[dim*numVerts];
+   RealT xy1[dim*numVerts];
+   RealT xy2[dim*numVerts];
 
    // face coordinates from testing
    xy1[0] = 0.75;
@@ -455,45 +455,45 @@ TEST_F( CompGeomTest, 2d_projections_2 )
    xy2[3] = 0.;
 
    // compute face normal
-   real faceNormal1[dim];
-   real faceNormal2[dim];
+   RealT faceNormal1[dim];
+   RealT faceNormal2[dim];
 
-   real lambdaX1 = xy1[2]-xy1[0];
-   real lambdaY1 = xy1[3]-xy1[1];
+   RealT lambdaX1 = xy1[2]-xy1[0];
+   RealT lambdaY1 = xy1[3]-xy1[1];
 
    faceNormal1[0] = lambdaY1;
    faceNormal1[1] = -lambdaX1;
 
-   real lambdaX2 = xy2[2]-xy2[0];
-   real lambdaY2 = xy2[3]-xy2[1];
+   RealT lambdaX2 = xy2[2]-xy2[0];
+   RealT lambdaY2 = xy2[3]-xy2[1];
 
    faceNormal2[0] = lambdaY2;
    faceNormal2[1] = -lambdaX2;
 
-   real cxf1[3] = {0., 0., 0.};
-   real cxf2[3] = {0., 0., 0.};
+   RealT cxf1[3] = {0., 0., 0.};
+   RealT cxf2[3] = {0., 0., 0.};
 
    tribol::VertexAvgCentroid( xy1, dim, numVerts, cxf1[0], cxf1[1], cxf1[2] );
    tribol::VertexAvgCentroid( xy2, dim, numVerts, cxf2[0], cxf2[1], cxf2[2] );
 
    // average the vertex averaged centroids of each face to get a pretty good 
    // estimate of the common plane centroid
-   real cx[dim];
+   RealT cx[dim];
    cx[0] = 0.5*(cxf1[0] + cxf2[0]);
    cx[1] = 0.5*(cxf1[1] + cxf2[1]);
 
-   real cxProj1[3] = {0., 0., 0.}; 
-   real cxProj2[3] = {0., 0., 0.}; 
+   RealT cxProj1[3] = {0., 0., 0.}; 
+   RealT cxProj2[3] = {0., 0., 0.}; 
 
    tribol::ProjectPointToSegment( cx[0], cx[1], faceNormal1[0], faceNormal1[1], 
                                   cxf1[0], cxf1[1], cxProj1[0], cxProj1[1] );
    tribol::ProjectPointToSegment( cx[0], cx[1], faceNormal2[0], faceNormal2[1], 
                                   cxf2[0], cxf2[1], cxProj2[0], cxProj2[1] );
 
-   real diffx1 = std::abs(cxProj1[0] - cx[0]); 
-   real diffy1 = std::abs(cxProj1[1] - cx[1]);
-   real diffx2 = std::abs(cxProj2[0] - cx[0]); 
-   real diffy2 = std::abs(cxProj2[1] - cx[1]); 
+   RealT diffx1 = std::abs(cxProj1[0] - cx[0]); 
+   RealT diffy1 = std::abs(cxProj1[1] - cx[1]);
+   RealT diffx2 = std::abs(cxProj2[0] - cx[0]); 
+   RealT diffy2 = std::abs(cxProj2[1] - cx[1]); 
    EXPECT_LE(diffx1, 1.e-6);  
    EXPECT_LE(diffy1, 1.e-6); 
    EXPECT_LE(diffx2, 1.e-6); 
@@ -508,10 +508,10 @@ TEST_F( CompGeomTest, codirectional_normals_3d )
    constexpr int numVerts = 4;
    constexpr int numCells = 2;
    constexpr int lengthNodalData = numCells * numVerts;
-   real element_thickness[numCells];
-   real x[lengthNodalData];
-   real y[lengthNodalData];
-   real z[lengthNodalData];
+   RealT element_thickness[numCells];
+   RealT x[lengthNodalData];
+   RealT y[lengthNodalData];
+   RealT z[lengthNodalData];
 
    for (int i=0; i<numCells; ++i)
    {
@@ -552,35 +552,35 @@ TEST_F( CompGeomTest, codirectional_normals_3d )
    z[7] = -0.300001*element_thickness[1];
 
    // initialize tribol
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( dim, problem_comm );
 
    // register contact mesh
    int meshId = 0;
-   tribol::IndexType conn[8] = {0,1,2,3,4,5,6,7}; // hard coded for a two face problem
+   tribol::IndexT conn[8] = {0,1,2,3,4,5,6,7}; // hard coded for a two face problem
    tribol::registerMesh( meshId, numCells, numVerts, &conn[0], (int)(tribol::LINEAR_QUAD), &x[0], &y[0], &z[0] );
 
    tribol::enableTimestepVote(true);
 
-   real *fx;
-   real *fy;
-   real *fz; 
+   RealT *fx;
+   RealT *fy;
+   RealT *fz; 
    tribol::allocRealArray( &fx, lengthNodalData, 0. );
    tribol::allocRealArray( &fy, lengthNodalData, 0. );
    tribol::allocRealArray( &fz, lengthNodalData, 0. );
 
    tribol::registerNodalResponse( meshId, fx, fy, fz );
 
-   real *vx;
-   real *vy;
-   real *vz; 
-   real vel0 = -1.e-15;
+   RealT *vx;
+   RealT *vy;
+   RealT *vz; 
+   RealT vel0 = -1.e-15;
    tribol::allocRealArray( &vx, lengthNodalData, 0. );
    tribol::allocRealArray( &vy, lengthNodalData, 0. );
    tribol::allocRealArray( &vz, lengthNodalData, vel0 );
 
    // set second face to impacting velocity
-   real vel2 = 1.e-15;
+   RealT vel2 = 1.e-15;
    vz[4] = vel2;
    vz[5] = vel2;
    vz[6] = vel2;
@@ -588,7 +588,7 @@ TEST_F( CompGeomTest, codirectional_normals_3d )
 
    tribol::registerNodalVelocities( meshId, vx, vy, vz );
 
-   real bulk_mod = 1.;
+   RealT bulk_mod = 1.;
    tribol::registerRealElementField( meshId, tribol::BULK_MODULUS, &bulk_mod );
    tribol::registerRealElementField( meshId, tribol::ELEMENT_THICKNESS, &element_thickness[0] );
 
@@ -605,7 +605,7 @@ TEST_F( CompGeomTest, codirectional_normals_3d )
 
    tribol::setPenaltyOptions( csIndex, tribol::KINEMATIC, tribol::KINEMATIC_ELEMENT, tribol::NO_RATE_PENALTY );
 
-   real dt = 1.0;
+   RealT dt = 1.0;
    int err = tribol::update( 1, 1., dt );
  
    EXPECT_EQ( err, 0 );
@@ -637,10 +637,10 @@ TEST_F( CompGeomTest, auto_contact_lt_max_interpen )
    constexpr int numVerts = 4;
    constexpr int numCells = 2;
    constexpr int lengthNodalData = numCells * numVerts;
-   real element_thickness[numCells];
-   real x[lengthNodalData];
-   real y[lengthNodalData];
-   real z[lengthNodalData];
+   RealT element_thickness[numCells];
+   RealT x[lengthNodalData];
+   RealT y[lengthNodalData];
+   RealT z[lengthNodalData];
 
    for (int i=0; i<numCells; ++i)
    {
@@ -675,44 +675,44 @@ TEST_F( CompGeomTest, auto_contact_lt_max_interpen )
    y[7] = 1.; 
 
    // amount of interpenetration in the z-direction
-   real max_interpen_frac = 1.0;
+   RealT max_interpen_frac = 1.0;
    tribol::setAutoContactPenScale( max_interpen_frac );
-   real test_ratio = 0.90; // fraction of max interpen frac used for this test
+   RealT test_ratio = 0.90; // fraction of max interpen frac used for this test
    z[4] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[5] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[6] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[7] = -test_ratio * max_interpen_frac * element_thickness[1]; 
 
    // initialize tribol
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( dim, problem_comm );
 
    // register contact mesh
    int meshId = 0;
-   tribol::IndexType conn[8] = {0,1,2,3,4,7,6,5}; // hard coded for a two face problem
+   tribol::IndexT conn[8] = {0,1,2,3,4,7,6,5}; // hard coded for a two face problem
    tribol::registerMesh( meshId, numCells, numVerts, &conn[0], (int)(tribol::LINEAR_QUAD), &x[0], &y[0], &z[0] );
 
    tribol::enableTimestepVote(true);
 
-   real *fx;
-   real *fy;
-   real *fz; 
+   RealT *fx;
+   RealT *fy;
+   RealT *fz; 
    tribol::allocRealArray( &fx, lengthNodalData, 0. );
    tribol::allocRealArray( &fy, lengthNodalData, 0. );
    tribol::allocRealArray( &fz, lengthNodalData, 0. );
 
    tribol::registerNodalResponse( meshId, fx, fy, fz );
 
-   real *vx;
-   real *vy;
-   real *vz; 
-   real vel0 = -1.;
+   RealT *vx;
+   RealT *vy;
+   RealT *vz; 
+   RealT vel0 = -1.;
    tribol::allocRealArray( &vx, lengthNodalData, 0. );
    tribol::allocRealArray( &vy, lengthNodalData, 0. );
    tribol::allocRealArray( &vz, lengthNodalData, vel0 );
 
    // set second face to impacting velocity
-   real vel2 = 1.0;
+   RealT vel2 = 1.0;
    vz[4] = vel2;
    vz[5] = vel2;
    vz[6] = vel2;
@@ -736,7 +736,7 @@ TEST_F( CompGeomTest, auto_contact_lt_max_interpen )
 
    tribol::setKinematicConstantPenalty( meshId, 1.0 );
 
-   real dt = 1.0;
+   RealT dt = 1.0;
    int err = tribol::update( 1, 1., dt );
  
    EXPECT_EQ( err, 0 );
@@ -767,10 +767,10 @@ TEST_F( CompGeomTest, auto_contact_gt_max_interpen )
    constexpr int numVerts = 4;
    constexpr int numCells = 2;
    constexpr int lengthNodalData = numCells * numVerts;
-   real element_thickness[numCells];
-   real x[lengthNodalData];
-   real y[lengthNodalData];
-   real z[lengthNodalData];
+   RealT element_thickness[numCells];
+   RealT x[lengthNodalData];
+   RealT y[lengthNodalData];
+   RealT z[lengthNodalData];
 
    for (int i=0; i<numCells; ++i)
    {
@@ -805,44 +805,44 @@ TEST_F( CompGeomTest, auto_contact_gt_max_interpen )
    y[7] = 1.; 
 
    // amount of interpenetration in the z-direction
-   real max_interpen_frac = 1.0;
+   RealT max_interpen_frac = 1.0;
    tribol::setAutoContactPenScale( max_interpen_frac );
-   real test_ratio = 1.01; // fraction of max interpen frac used for this test
+   RealT test_ratio = 1.01; // fraction of max interpen frac used for this test
    z[4] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[5] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[6] = -test_ratio * max_interpen_frac * element_thickness[1]; 
    z[7] = -test_ratio * max_interpen_frac * element_thickness[1]; 
 
    // initialize tribol
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( dim, problem_comm );
 
    // register contact mesh
    int meshId = 0;
-   tribol::IndexType conn[8] = {0,1,2,3,4,7,6,5}; // hard coded for a two face problem
+   tribol::IndexT conn[8] = {0,1,2,3,4,7,6,5}; // hard coded for a two face problem
    tribol::registerMesh( meshId, numCells, numVerts, &conn[0], (int)(tribol::LINEAR_QUAD), &x[0], &y[0], &z[0] );
 
    tribol::enableTimestepVote(true);
 
-   real *fx;
-   real *fy;
-   real *fz; 
+   RealT *fx;
+   RealT *fy;
+   RealT *fz; 
    tribol::allocRealArray( &fx, lengthNodalData, 0. );
    tribol::allocRealArray( &fy, lengthNodalData, 0. );
    tribol::allocRealArray( &fz, lengthNodalData, 0. );
 
    tribol::registerNodalResponse( meshId, fx, fy, fz );
 
-   real *vx;
-   real *vy;
-   real *vz; 
-   real vel0 = -1.;
+   RealT *vx;
+   RealT *vy;
+   RealT *vz; 
+   RealT vel0 = -1.;
    tribol::allocRealArray( &vx, lengthNodalData, 0. );
    tribol::allocRealArray( &vy, lengthNodalData, 0. );
    tribol::allocRealArray( &vz, lengthNodalData, vel0 );
 
    // set second face to impacting velocity
-   real vel2 = 1.0;
+   RealT vel2 = 1.0;
    vz[4] = vel2;
    vz[5] = vel2;
    vz[6] = vel2;
@@ -866,7 +866,7 @@ TEST_F( CompGeomTest, auto_contact_gt_max_interpen )
 
    tribol::setKinematicConstantPenalty( meshId, 1.0 );
 
-   real dt = 1.0;
+   RealT dt = 1.0;
    int err = tribol::update( 1, 1., dt );
  
    EXPECT_EQ( err, 0 );

--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -30,7 +30,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class to test valid coupling schemes.
@@ -51,12 +51,12 @@ public:
    int m_lengthNodalData;
    int * m_connectivity {nullptr};
    int m_elementType;
-   real* m_x {nullptr};
-   real* m_y {nullptr};
-   real* m_z {nullptr};
-   real* m_fx {nullptr};
-   real* m_fy {nullptr};
-   real* m_fz {nullptr};
+   RealT* m_x {nullptr};
+   RealT* m_y {nullptr};
+   RealT* m_z {nullptr};
+   RealT* m_fx {nullptr};
+   RealT* m_fy {nullptr};
+   RealT* m_fz {nullptr};
 
 protected:
 
@@ -81,12 +81,12 @@ protected:
       {
 
          m_connectivity = new int[ m_lengthNodalData ];
-         m_x = new real[ m_lengthNodalData ];
-         m_y = new real[ m_lengthNodalData ];
+         m_x = new RealT[ m_lengthNodalData ];
+         m_y = new RealT[ m_lengthNodalData ];
          if (set_response)
          {
-            m_fx = new real[ m_lengthNodalData ];
-            m_fy = new real[ m_lengthNodalData ];
+            m_fx = new RealT[ m_lengthNodalData ];
+            m_fy = new RealT[ m_lengthNodalData ];
          }
 
          for (int i=0; i<m_lengthNodalData; ++i)
@@ -135,14 +135,14 @@ protected:
       if (m_numCells > 0)
       {
          m_connectivity = new int[ m_lengthNodalData ];
-         m_x = new real[ m_lengthNodalData ];
-         m_y = new real[ m_lengthNodalData ];
-         m_z = new real[ m_lengthNodalData ];
+         m_x = new RealT[ m_lengthNodalData ];
+         m_y = new RealT[ m_lengthNodalData ];
+         m_z = new RealT[ m_lengthNodalData ];
          if (set_response)
          {
-            m_fx = new real[ m_lengthNodalData ];
-            m_fy = new real[ m_lengthNodalData ];
-            m_fz = new real[ m_lengthNodalData ];
+            m_fx = new RealT[ m_lengthNodalData ];
+            m_fy = new RealT[ m_lengthNodalData ];
+            m_fz = new RealT[ m_lengthNodalData ];
          }
 
          for (int i=0; i<m_lengthNodalData; ++i)
@@ -241,7 +241,7 @@ TEST_F( CouplingSchemeTest, single_mortar_2D )
 {
    // expect the coupling scheme to fail because 2D 
    // is not yet implemented
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 2, problem_comm );
 
    registerDummy2DMesh( 0 );
@@ -249,8 +249,8 @@ TEST_F( CouplingSchemeTest, single_mortar_2D )
 
    // register dummy nodal fields so error doesn't return from field 
    // registration
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -277,7 +277,7 @@ TEST_F( CouplingSchemeTest, single_mortar_2D )
 
 TEST_F( CouplingSchemeTest, aligned_mortar_2D )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 2, problem_comm );
 
    registerDummy2DMesh( 0 );
@@ -285,8 +285,8 @@ TEST_F( CouplingSchemeTest, aligned_mortar_2D )
 
    // register dummy nodal fields so error doesn't return from field 
    // registration
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -313,7 +313,7 @@ TEST_F( CouplingSchemeTest, aligned_mortar_2D )
 
 TEST_F( CouplingSchemeTest, mortar_weights_2D )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 2, problem_comm );
 
    registerDummy2DMesh( 0 );
@@ -341,7 +341,7 @@ TEST_F( CouplingSchemeTest, mortar_weights_2D )
 
 TEST_F( CouplingSchemeTest, single_mortar_3D_penalty )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
@@ -349,8 +349,8 @@ TEST_F( CouplingSchemeTest, single_mortar_3D_penalty )
 
    // register dummy nodal fields so error doesn't return from field 
    // registration
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -377,7 +377,7 @@ TEST_F( CouplingSchemeTest, single_mortar_3D_penalty )
 
 TEST_F( CouplingSchemeTest, common_plane_lagrange_multiplier )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
@@ -403,7 +403,7 @@ TEST_F( CouplingSchemeTest, common_plane_lagrange_multiplier )
 
 TEST_F( CouplingSchemeTest, mortar_no_nodal_gaps_or_pressures )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
@@ -431,7 +431,7 @@ TEST_F( CouplingSchemeTest, mortar_no_nodal_gaps_or_pressures )
 
 TEST_F( CouplingSchemeTest, mortar_tied )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
@@ -439,8 +439,8 @@ TEST_F( CouplingSchemeTest, mortar_tied )
 
    // register dummy nodal fields so error doesn't return from field 
    // registration
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -467,7 +467,7 @@ TEST_F( CouplingSchemeTest, mortar_tied )
 
 TEST_F( CouplingSchemeTest, mortar_coulomb )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
@@ -475,8 +475,8 @@ TEST_F( CouplingSchemeTest, mortar_coulomb )
 
    // register dummy nodal fields so error doesn't return from field 
    // registration
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -503,13 +503,13 @@ TEST_F( CouplingSchemeTest, mortar_coulomb )
 
 TEST_F( CouplingSchemeTest, common_plane_tied )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
    registerDummy3DMesh( 1 );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -535,13 +535,13 @@ TEST_F( CouplingSchemeTest, common_plane_tied )
 
 TEST_F( CouplingSchemeTest, common_plane_coulomb )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
    registerDummy3DMesh( 1 );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -567,7 +567,7 @@ TEST_F( CouplingSchemeTest, common_plane_coulomb )
 
 TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    ////////////////////////////////////////////////
@@ -588,19 +588,19 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                              x_min1, y_min1, z_min1,
@@ -624,7 +624,7 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
                          mesh.x, mesh.y, mesh.z );
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
@@ -656,7 +656,7 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
                               tribol::KINEMATIC_CONSTANT ); 
 
    // call update so binning on coupling scheme is performed.
-   double dt = 1.0;
+   RealT dt = 1.0;
    EXPECT_EQ(tribol::update(1, 1., dt), 0);
 
    tribol::CouplingSchemeManager& csManager =
@@ -728,7 +728,7 @@ TEST_F( CouplingSchemeTest, non_null_to_null_meshes )
 
 TEST_F( CouplingSchemeTest, invalid_mesh_in_coupling_scheme )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    // register meshes
@@ -740,14 +740,14 @@ TEST_F( CouplingSchemeTest, invalid_mesh_in_coupling_scheme )
    constexpr int numTotalNodes2 = 4;
    int faceConn1[numTotalNodes1] = {0, 1};    // dummy triangle connectivity (invalid)
    int faceConn2[numTotalNodes2] = {4, 5, 6, 7}; // dummy quadrilateral connectivity (valid)
-   real x1[numTotalNodes1] = {0., 0.5};
-   real y1[numTotalNodes1] = {0., 0.};
-   real z1[numTotalNodes1] = {0., 0.};
-   real x2[numTotalNodes2] = {0., 0.5, 0.5, 0.};
-   real y2[numTotalNodes2] = {0., 0., 0.5, 0.5};
-   real z2[numTotalNodes2] = {-0.1, -0.1, -0.1, -0.1};
-   real fx1[numTotalNodes1], fy1[numTotalNodes1], fz1[numTotalNodes1];
-   real fx2[numTotalNodes2], fy2[numTotalNodes2], fz2[numTotalNodes2];
+   RealT x1[numTotalNodes1] = {0., 0.5};
+   RealT y1[numTotalNodes1] = {0., 0.};
+   RealT z1[numTotalNodes1] = {0., 0.};
+   RealT x2[numTotalNodes2] = {0., 0.5, 0.5, 0.};
+   RealT y2[numTotalNodes2] = {0., 0., 0.5, 0.5};
+   RealT z2[numTotalNodes2] = {-0.1, -0.1, -0.1, -0.1};
+   RealT fx1[numTotalNodes1], fy1[numTotalNodes1], fz1[numTotalNodes1];
+   RealT fx2[numTotalNodes2], fy2[numTotalNodes2], fz2[numTotalNodes2];
 
    tribol::initRealArray( &fx1[0], numTotalNodes1, 0. );
    tribol::initRealArray( &fy1[0], numTotalNodes1, 0. );
@@ -766,7 +766,7 @@ TEST_F( CouplingSchemeTest, invalid_mesh_in_coupling_scheme )
                          &x2[0], &y2[0], &z2[0] );
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
@@ -798,7 +798,7 @@ TEST_F( CouplingSchemeTest, invalid_mesh_in_coupling_scheme )
 
 TEST_F( CouplingSchemeTest, finalize )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    ////////////////////////////////////////////////
@@ -819,19 +819,19 @@ TEST_F( CouplingSchemeTest, finalize )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                              x_min1, y_min1, z_min1,
@@ -855,7 +855,7 @@ TEST_F( CouplingSchemeTest, finalize )
                          mesh.x, mesh.y, mesh.z );
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -887,7 +887,7 @@ TEST_F( CouplingSchemeTest, finalize )
                               tribol::KINEMATIC_CONSTANT ); 
   
    // call update so binning on coupling scheme is performed.
-   double dt = 1.0;
+   RealT dt = 1.0;
    EXPECT_EQ(tribol::update(1, 1., dt), 0);
 
    tribol::finalize();
@@ -900,13 +900,13 @@ TEST_F( CouplingSchemeTest, finalize )
 
 TEST_F( CouplingSchemeTest, null_velocity_kinematic_penalty )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
    registerDummy3DMesh( 1 );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -923,9 +923,9 @@ TEST_F( CouplingSchemeTest, null_velocity_kinematic_penalty )
 
    // register null nodal velocity pointers. The coupling scheme 
    // should initialize correctly for kinematic penalty only.
-   real* v_x {nullptr};
-   real* v_y {nullptr};
-   real* v_z {nullptr};
+   RealT* v_x {nullptr};
+   RealT* v_y {nullptr};
+   RealT* v_z {nullptr};
    tribol::registerNodalVelocities(0, v_x, v_y, v_z);
    tribol::registerNodalVelocities(1, v_x, v_y, v_z);
 
@@ -940,13 +940,13 @@ TEST_F( CouplingSchemeTest, null_velocity_kinematic_penalty )
 
 TEST_F( CouplingSchemeTest, null_velocity_kinematic_and_rate_penalty )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    registerDummy3DMesh( 0 );
    registerDummy3DMesh( 1 );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -963,9 +963,9 @@ TEST_F( CouplingSchemeTest, null_velocity_kinematic_and_rate_penalty )
 
    // register null nodal velocity pointers. The coupling scheme 
    // should NOT initialize correctly for kinematic-and-rate penalty.
-   real* v_x {nullptr};
-   real* v_y {nullptr};
-   real* v_z {nullptr};
+   RealT* v_x {nullptr};
+   RealT* v_y {nullptr};
+   RealT* v_z {nullptr};
    tribol::registerNodalVelocities(0, v_x, v_y, v_z);
    tribol::registerNodalVelocities(1, v_x, v_y, v_z);
 
@@ -980,7 +980,7 @@ TEST_F( CouplingSchemeTest, null_velocity_kinematic_and_rate_penalty )
 
 TEST_F( CouplingSchemeTest, mortar_weights_null_response_pointers )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    bool setResponse = false;
@@ -1010,7 +1010,7 @@ TEST_F( CouplingSchemeTest, mortar_weights_null_response_pointers )
 
 TEST_F( CouplingSchemeTest, single_mortar_null_response_pointers )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    bool setResponse = false;
@@ -1018,8 +1018,8 @@ TEST_F( CouplingSchemeTest, single_mortar_null_response_pointers )
    registerDummy3DMesh( 0, numCells, setResponse );
    registerDummy3DMesh( 1, numCells, setResponse );
 
-   real gaps[this->m_lengthNodalData];
-   real pressures[this->m_lengthNodalData];
+   RealT gaps[this->m_lengthNodalData];
+   RealT pressures[this->m_lengthNodalData];
 
    tribol::registerMortarGaps( 1, &gaps[0] );
    tribol::registerMortarPressures( 1, &pressures[0] );
@@ -1046,7 +1046,7 @@ TEST_F( CouplingSchemeTest, single_mortar_null_response_pointers )
 
 TEST_F( CouplingSchemeTest, common_plane_null_response_pointers )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    int numCells = 1;
@@ -1054,7 +1054,7 @@ TEST_F( CouplingSchemeTest, common_plane_null_response_pointers )
    registerDummy3DMesh( 0, numCells, setResponse );
    registerDummy3DMesh( 1, numCells, setResponse );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -1080,7 +1080,7 @@ TEST_F( CouplingSchemeTest, common_plane_null_response_pointers )
 
 TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    int numCells = 0;
@@ -1088,7 +1088,7 @@ TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
    registerDummy3DMesh( 0, numCells, setResponse );
    registerDummy3DMesh( 1, numCells, setResponse );
 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty(0, penalty);
    tribol::setKinematicConstantPenalty(1, penalty);
 
@@ -1102,9 +1102,9 @@ TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
 
    // register null nodal velocity pointers. The coupling scheme 
    // should NOT initialize correctly for kinematic-and-rate penalty.
-   real* v_x {nullptr};
-   real* v_y {nullptr};
-   real* v_z {nullptr};
+   RealT* v_x {nullptr};
+   RealT* v_y {nullptr};
+   RealT* v_z {nullptr};
    tribol::registerNodalVelocities(0, v_x, v_y, v_z);
    tribol::registerNodalVelocities(1, v_x, v_y, v_z);
 
@@ -1132,7 +1132,7 @@ TEST_F( CouplingSchemeTest, null_mesh_with_null_pointers )
 
 TEST_F( CouplingSchemeTest, auto_common_plane_no_element_thickness )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    int meshId = 0;
@@ -1161,7 +1161,7 @@ TEST_F( CouplingSchemeTest, auto_common_plane_no_element_thickness )
 
 TEST_F( CouplingSchemeTest, auto_common_plane_with_element_thickness )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    int meshId = 0;
@@ -1182,7 +1182,7 @@ TEST_F( CouplingSchemeTest, auto_common_plane_with_element_thickness )
    tribol::setPenaltyOptions( csId, tribol::KINEMATIC,
                               tribol::KINEMATIC_CONSTANT ); 
 
-   real element_thick = 1.0;
+   RealT element_thick = 1.0;
    tribol::registerRealElementField( meshId, tribol::ELEMENT_THICKNESS, &element_thick );
 
    tribol::CouplingSchemeManager& csManager = tribol::CouplingSchemeManager::getInstance();
@@ -1194,7 +1194,7 @@ TEST_F( CouplingSchemeTest, auto_common_plane_with_element_thickness )
 
 TEST_F( CouplingSchemeTest, two_meshes_with_auto_case )
 {
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( 3, problem_comm );
 
    int meshId1 = 0;

--- a/src/tests/tribol_coupling_scheme_manager.cpp
+++ b/src/tests/tribol_coupling_scheme_manager.cpp
@@ -68,11 +68,11 @@ protected:
 
    int meshId[2];
 
-   tribol::real x[4] { 0., 1., 1., 0. };
-   tribol::real y[4] { 0., 0., 1., 1. };
-   tribol::real z[4] { 0., 0., 0., 0. };
+   tribol::RealT x[4] { 0., 1., 1., 0. };
+   tribol::RealT y[4] { 0., 0., 1., 1. };
+   tribol::RealT z[4] { 0., 0., 0., 0. };
 
-   tribol::IndexType connectivity[4] { 0, 1, 2, 3 };
+   tribol::IndexT connectivity[4] { 0, 1, 2, 3 };
 
 };
 

--- a/src/tests/tribol_enforcement_options.cpp
+++ b/src/tests/tribol_enforcement_options.cpp
@@ -30,7 +30,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class to test valid enforcement options
@@ -53,7 +53,7 @@ protected:
    // Setup boiler plate data and register mesh, nodal response, and coupling scheme
    void SetupTest( tribol::TestMesh* mesh )
    {
-      tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+      tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
       tribol::initialize( 3, problem_comm );
 
       ////////////////////////////////////////////////
@@ -73,19 +73,19 @@ protected:
       int nElemsZS = nNonmortarElems;
 
       // mesh bounding box with 0.1 interpenetration gap
-      real x_min1 = 0.;
-      real y_min1 = 0.;
-      real z_min1 = 0.; 
-      real x_max1 = 1.;
-      real y_max1 = 1.;
-      real z_max1 = 1.05;
+      RealT x_min1 = 0.;
+      RealT y_min1 = 0.;
+      RealT z_min1 = 0.; 
+      RealT x_max1 = 1.;
+      RealT y_max1 = 1.;
+      RealT z_max1 = 1.05;
 
-      real x_min2 = 0.;
-      real y_min2 = 0.;
-      real z_min2 = 0.95;
-      real x_max2 = 1.;
-      real y_max2 = 1.;
-      real z_max2 = 2.;
+      RealT x_min2 = 0.;
+      RealT y_min2 = 0.;
+      RealT z_min2 = 0.95;
+      RealT x_max2 = 1.;
+      RealT y_max2 = 1.;
+      RealT z_max2 = 2.;
 
       mesh->setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                  x_min1, y_min1, z_min1,
@@ -124,12 +124,12 @@ protected:
 
 
       // allocate velocity arrays on test mesh
-      real velX1 = 0.;
-      real velY1 = 0.;
-      real velZ1 = -1.;
-      real velX2 = 0.;
-      real velY2 = 0.;
-      real velZ2 = 1.;
+      RealT velX1 = 0.;
+      RealT velY1 = 0.;
+      RealT velZ1 = -1.;
+      RealT velX2 = 0.;
+      RealT velY2 = 0.;
+      RealT velZ2 = 1.;
       mesh->allocateAndSetVelocities( mesh->mortarMeshId, velX1, velY1, velZ1 );
       mesh->allocateAndSetVelocities( mesh->nonmortarMeshId,  velX2, velY2, velZ2 );
 
@@ -169,7 +169,7 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_error )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
@@ -196,10 +196,10 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_element_error )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real* bulk_modulus_1;
-   real* bulk_modulus_2;
-   real* element_thickness_1;
-   real* element_thickness_2;
+   RealT* bulk_modulus_1;
+   RealT* bulk_modulus_2;
+   RealT* element_thickness_1;
+   RealT* element_thickness_2;
 
    tribol::allocRealArray( &bulk_modulus_1, mesh->numMortarFaces, 0. );
    tribol::allocRealArray( &bulk_modulus_2, mesh->numNonmortarFaces, 0. );
@@ -236,11 +236,11 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_constant_error )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
-   real rate_penalty = 0.5;
+   RealT rate_penalty = 0.5;
    tribol::setRateConstantPenalty( 0, rate_penalty );
    tribol::setRateConstantPenalty( 1, rate_penalty );
 
@@ -268,11 +268,11 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_percent_error_1 
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
-   real rate_percent = 0.5;
+   RealT rate_percent = 0.5;
    tribol::setRatePercentPenalty( 0, rate_percent );
    tribol::setRatePercentPenalty( 1, rate_percent );
 
@@ -300,12 +300,12 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_percent_error_2 
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
    // incorrectly set the rate_percent value outside of acceptable bounds
-   real rate_percent = 1.2;
+   RealT rate_percent = 1.2;
    tribol::setRatePercentPenalty( 0, rate_percent );
    tribol::setRatePercentPenalty( 1, rate_percent );
 
@@ -334,7 +334,7 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_pass )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
@@ -360,10 +360,10 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_element_pass )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real* bulk_modulus_1;
-   real* bulk_modulus_2;
-   real* element_thickness_1;
-   real* element_thickness_2;
+   RealT* bulk_modulus_1;
+   RealT* bulk_modulus_2;
+   RealT* element_thickness_1;
+   RealT* element_thickness_2;
 
    tribol::allocRealArray( &bulk_modulus_1, mesh->numMortarFaces, 1. );
    tribol::allocRealArray( &bulk_modulus_2, mesh->numNonmortarFaces, 1. );
@@ -399,10 +399,10 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_element_invalid_element_input 
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real* bulk_modulus_1;
-   real* bulk_modulus_2;
-   real* element_thickness_1;
-   real* element_thickness_2;
+   RealT* bulk_modulus_1;
+   RealT* bulk_modulus_2;
+   RealT* element_thickness_1;
+   RealT* element_thickness_2;
 
    tribol::allocRealArray( &bulk_modulus_1, mesh->numMortarFaces, 0. );
    tribol::allocRealArray( &bulk_modulus_2, mesh->numNonmortarFaces, 0. );
@@ -438,11 +438,11 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_constant_pass )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
-   real rate_penalty = 0.5;
+   RealT rate_penalty = 0.5;
    tribol::setRateConstantPenalty( 0, rate_penalty );
    tribol::setRateConstantPenalty( 1, rate_penalty );
 
@@ -469,11 +469,11 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_percent_pass )
    SetupTest(mesh);
 
    // set penalty data so coupling scheme initialization passes 
-   real penalty = 1.0;
+   RealT penalty = 1.0;
    tribol::setKinematicConstantPenalty( 0, penalty );
    tribol::setKinematicConstantPenalty( 1, penalty );
 
-   real rate_percent = 0.5;
+   RealT rate_percent = 0.5;
    tribol::setRatePercentPenalty( 0, rate_percent );
    tribol::setRatePercentPenalty( 1, rate_percent );
 

--- a/src/tests/tribol_hex_mesh.cpp
+++ b/src/tests/tribol_hex_mesh.cpp
@@ -22,7 +22,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test 
@@ -66,19 +66,19 @@ TEST_F( HexMeshTest, build_and_check_hex_mesh )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -120,19 +120,19 @@ TEST_F( HexMeshTest, build_and_check_mfem_hex_mesh )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,

--- a/src/tests/tribol_inv_iso.cpp
+++ b/src/tests/tribol_inv_iso.cpp
@@ -15,7 +15,7 @@
 // gtest includes
 #include "gtest/gtest.h"
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to use the
@@ -27,36 +27,36 @@ class InvIsoTest : public ::testing::Test
 public:
    int numNodes;
 
-   real* getXCoords() 
+   RealT* getXCoords() 
    {
       return this->x;
    }
 
-   real* getYCoords() 
+   RealT* getYCoords() 
    {
       return this->y;
    }
 
-   real* getZCoords() 
+   RealT* getZCoords() 
    {
       return this->z;
    }
 
    
-   bool InvMap( real point[3], real const tol )
+   bool InvMap( RealT point[3], RealT const tol )
    {
 
-      real x_sol[2];
+      RealT x_sol[2];
       tribol::InvIso( point, this->x, this->y, this->z, 4, x_sol );
 
       // test (xi,eta) obtained from inverse isoparametric 
       // mapping by performing forward map of that point and 
       // compare to original point.
-      real map_point[3] = {0., 0, 0};
+      RealT map_point[3] = {0., 0, 0};
       tribol::FwdMapLinQuad( x_sol, this->x, this->y, this->z, map_point );
 
       bool convrg = false;
-      real res = tribol::magnitude((point[0] - map_point[0]), 
+      RealT res = tribol::magnitude((point[0] - map_point[0]), 
                                   (point[1] - map_point[1]),
                                   (point[2] - map_point[2]));
   
@@ -76,32 +76,32 @@ protected:
       this->numNodes = 4;
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
    }
 
@@ -126,18 +126,18 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
 };
 
 
 TEST_F( InvIsoTest, nonaffine_centroid )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -154,7 +154,7 @@ TEST_F( InvIsoTest, nonaffine_centroid )
    z[2] = 0.1; 
    z[3] = 0.1;
 
-   real point[3];
+   RealT point[3];
 
    // initialize physical point array
    for (int i=0; i<3; ++i)
@@ -184,9 +184,9 @@ TEST_F( InvIsoTest, nonaffine_centroid )
 
 TEST_F( InvIsoTest, nonaffine_test_point )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -204,7 +204,7 @@ TEST_F( InvIsoTest, nonaffine_test_point )
    z[3] = 0.1;
 
    // hard code point
-   real point[3] = { 0.215, 0.116, 0.1 };
+   RealT point[3] = { 0.215, 0.116, 0.1 };
 
    bool convrg = this->InvMap( point, 1.e-6 );
 
@@ -214,9 +214,9 @@ TEST_F( InvIsoTest, nonaffine_test_point )
 
 TEST_F( InvIsoTest, affine_test_point )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -233,7 +233,7 @@ TEST_F( InvIsoTest, affine_test_point )
    z[2] = 0.1; 
    z[3] = 0.1;
 
-   real point[3];
+   RealT point[3];
 
    // hard-code point
    point[0] = 0.25;

--- a/src/tests/tribol_iso_integ.cpp
+++ b/src/tests/tribol_iso_integ.cpp
@@ -20,7 +20,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to use the
@@ -39,29 +39,29 @@ public:
    int numNodes;
    int dim;
 
-   real* getXCoords() 
+   RealT* getXCoords() 
    {
       return x;
    }
 
-   real* getYCoords() 
+   RealT* getYCoords() 
    {
       return y;
    }
 
-   real* getZCoords() 
+   RealT* getZCoords() 
    {
       return z;
    }
 
-   bool integrate ( real const tol )
+   bool integrate ( RealT const tol )
    {
-      real xyz[ this->dim * this->numNodes ];
-      real* xy = xyz;
+      RealT xyz[ this->dim * this->numNodes ];
+      RealT* xy = xyz;
 
-      real * x = this->x;
-      real * y = this->y;
-      real * z = this->z;
+      RealT * x = this->x;
+      RealT * y = this->y;
+      RealT * z = this->z;
 
       // generate stacked coordinate array
       for (int j=0; j<this->numNodes; ++j)
@@ -98,8 +98,8 @@ public:
 
       // evaluate sum_a (integral_face (phi_a) da) with outer loop over nodes, a, and 
       // inner loop over number of integration points
-      real areaTest = 0.;
-      real phi = 0.;
+      RealT areaTest = 0.;
+      RealT phi = 0.;
 
       for (int a=0; a<this->numNodes; ++a)
       {
@@ -107,8 +107,8 @@ public:
          {
             // perform inverse isoparametric mapping of current configuration 
             // integration point to four node quad parent space
-            real xp[3] = { integ.xy[dim*ip], integ.xy[dim*ip+1], integ.xy[dim*ip+2] };
-            real xi[2] = { 0., 0. };
+            RealT xp[3] = { integ.xy[dim*ip], integ.xy[dim*ip+1], integ.xy[dim*ip+2] };
+            RealT xi[2] = { 0., 0. };
             tribol::InvIso( xp, x, y, z, this->numNodes, xi );
             tribol::LinIsoQuadShapeFunc( xi[0], xi[1], a, phi );
        
@@ -117,7 +117,7 @@ public:
          }
       }
 
-      real area = tribol::Area2DPolygon( x, y, this->numNodes );
+      RealT area = tribol::Area2DPolygon( x, y, this->numNodes );
 
       bool convrg = (std::abs(areaTest - area) <= tol) ? true : false;
   
@@ -134,32 +134,32 @@ protected:
 
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
    }
 
@@ -184,9 +184,9 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
 };
 
@@ -194,9 +194,9 @@ protected:
 TEST_F( IsoIntegTest, square )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -221,9 +221,9 @@ TEST_F( IsoIntegTest, square )
 TEST_F( IsoIntegTest, rect )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -247,9 +247,9 @@ TEST_F( IsoIntegTest, rect )
 
 TEST_F( IsoIntegTest, affine )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -273,9 +273,9 @@ TEST_F( IsoIntegTest, affine )
 
 TEST_F( IsoIntegTest, nonaffine )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;

--- a/src/tests/tribol_math.cpp
+++ b/src/tests/tribol_math.cpp
@@ -16,7 +16,7 @@
 // c++ includes
 #include <cmath>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  *  Test fixture class to test math functions
@@ -26,169 +26,169 @@ class MathTest : public ::testing::Test
    
 public:
   
-   void get3DVectorComps( real& x, real& y, real& z )
+   void get3DVectorComps( RealT& x, RealT& y, RealT& z )
    {
       x = m_vx;
       y = m_vy;
       z = m_vz;
    }
 
-   void set3DVectorComps( real vx, real vy, real vz )
+   void set3DVectorComps( RealT vx, RealT vy, RealT vz )
    {
       m_vx = vx;
       m_vy = vy;
       m_vz = vz;
    }
 
-   real get3DMag()
+   RealT get3DMag()
    {
       return m_3VecMag;
    }
 
-   void setSecond3DVectorComps( real vx, real vy, real vz )
+   void setSecond3DVectorComps( RealT vx, RealT vy, RealT vz )
    {
       m_ux = vx;
       m_uy = vy;
       m_uz = vz;
    } 
 
-   void getSecond3DVectorComps( real& x, real& y, real& z )
+   void getSecond3DVectorComps( RealT& x, RealT& y, RealT& z )
    {
       x = m_ux;
       y = m_uy;
       z = m_uz;
    }
 
-   real getSecond3DMag()
+   RealT getSecond3DMag()
    {
       return m_Second3VecMag;
    }
 
-   void get2DVectorComps( real& x, real& y )
+   void get2DVectorComps( RealT& x, RealT& y )
    {
       x = m_wx;
       y = m_wy;
    }
 
-   void set2DVectorComps( real vx, real vy )
+   void set2DVectorComps( RealT vx, RealT vy )
    {
       m_wx = vx;
       m_wy = vy;
    }
 
-   real get2DMag()
+   RealT get2DMag()
    {
       return m_2VecMag;
    }
 
-   void setTol( real tol )
+   void setTol( RealT tol )
    {
       m_tol = tol;
    }
   
-   real getTol()
+   RealT getTol()
    {
       return m_tol;
    } 
 
 protected:
-   real m_tol { 1.E-8 };
+   RealT m_tol { 1.E-8 };
 
    // components of a three dimensional vector
-   real m_vx { 1.5 };
-   real m_vy { 2.32 };
-   real m_vz { 3.1 };
-   real m_3VecMag { 4.152396898 };
+   RealT m_vx { 1.5 };
+   RealT m_vy { 2.32 };
+   RealT m_vz { 3.1 };
+   RealT m_3VecMag { 4.152396898 };
 
    // components of another three dimensional vector
-   real m_ux {2.1};
-   real m_uy {4.23};
-   real m_uz {5.35};
-   real m_Second3VecMag { 7.136203472 };
+   RealT m_ux {2.1};
+   RealT m_uy {4.23};
+   RealT m_uz {5.35};
+   RealT m_Second3VecMag { 7.136203472 };
 
    // components of a two dimensional vector
-   real m_wx { 1.5 };
-   real m_wy { 2.32 };
-   real m_2VecMag { 2.762679858 };
+   RealT m_wx { 1.5 };
+   RealT m_wy { 2.32 };
+   RealT m_2VecMag { 2.762679858 };
 };
 
 TEST_F( MathTest, magnitude )
 {
-   real vx;
-   real vy;
-   real vz;
+   RealT vx;
+   RealT vy;
+   RealT vz;
    get3DVectorComps( vx, vy, vz );
 
-   real mag1 = tribol::magnitude( vx, vy, vz );
+   RealT mag1 = tribol::magnitude( vx, vy, vz );
 
-   real diff1 = std::abs( mag1 - get3DMag() );
+   RealT diff1 = std::abs( mag1 - get3DMag() );
 
    EXPECT_LE( diff1, getTol() );
 
-   real wx, wy;
+   RealT wx, wy;
    get2DVectorComps( wx, wy );
 
-   real mag2 = tribol::magnitude( wx, wy );
+   RealT mag2 = tribol::magnitude( wx, wy );
 
-   real diff2 = std::abs( mag2 - get2DMag() );
+   RealT diff2 = std::abs( mag2 - get2DMag() );
 
    EXPECT_LE( diff2, getTol() );
 }
 
 TEST_F( MathTest, dotProd )
 {
-   real vx;
-   real vy;
-   real vz;
+   RealT vx;
+   RealT vy;
+   RealT vz;
    get3DVectorComps( vx, vy, vz );
 
-   real prod = tribol::dotProd( vx, vy, vz, 
+   RealT prod = tribol::dotProd( vx, vy, vz, 
                                 vx, vy, vz );
 
-   real diff = std::abs( prod - (vx*vx + vy*vy + vz*vz) );
+   RealT diff = std::abs( prod - (vx*vx + vy*vy + vz*vz) );
 
    EXPECT_LE( diff, getTol() );
 
    // test pointer input to dot product routine
-   real vec[3] {0., 0., 0.,};
-   real *w;
+   RealT vec[3] {0., 0., 0.,};
+   RealT *w;
    w = vec;
    w[0] = vx;
    w[1] = vy;
    w[2] = vz;
 
-   real prod2 = tribol::dotProd( w, w, 3 );
+   RealT prod2 = tribol::dotProd( w, w, 3 );
     
-   real diff2 = std::abs( prod2 - (vx*vx + vy*vy + vz*vz) );  
+   RealT diff2 = std::abs( prod2 - (vx*vx + vy*vy + vz*vz) );  
 
    EXPECT_LE( diff2, getTol() );
 }
 
 TEST_F( MathTest, crossProd )
 {
-   real vx, vy, vz;
-   real ux, uy, uz;
+   RealT vx, vy, vz;
+   RealT ux, uy, uz;
    get3DVectorComps( vx, vy, vz );
    getSecond3DVectorComps( ux, uy, uz );
 
-   real prod_x, prod_y, prod_z;
+   RealT prod_x, prod_y, prod_z;
    tribol::crossProd( vx, vy, vz, 
                       ux, uy, uz,
                       prod_x, prod_y, prod_z );
 
-   real vec_mag = tribol::magnitude( prod_x, prod_y, prod_z );
+   RealT vec_mag = tribol::magnitude( prod_x, prod_y, prod_z );
 
-   real prod_test_i = vy*uz - vz*uy;
-   real prod_test_j = vz*ux - vx*uz;
-   real prod_test_k = vx*uy - vy*ux;
-   real mag_test = tribol::magnitude( prod_test_i, prod_test_j, prod_test_k );
-   real diff = std::abs( vec_mag - mag_test );
+   RealT prod_test_i = vy*uz - vz*uy;
+   RealT prod_test_j = vz*ux - vx*uz;
+   RealT prod_test_k = vx*uy - vy*ux;
+   RealT mag_test = tribol::magnitude( prod_test_i, prod_test_j, prod_test_k );
+   RealT diff = std::abs( vec_mag - mag_test );
 
    EXPECT_LE( diff, getTol() );
 
    // test pointer input to dot product routine
-   real a[3] {0., 0., 0.};
-   real b[3] {0., 0., 0.};
+   RealT a[3] {0., 0., 0.};
+   RealT b[3] {0., 0., 0.};
    a[0] = vx;
    a[1] = vy;
    a[2] = vz;
@@ -219,7 +219,7 @@ TEST_F( MathTest, sort_and_search )
    EXPECT_EQ( a[5], 12 );
 
    // search array for integer value = 7
-   real index = tribol::binary_search( &a[0], 6, 7 );
+   RealT index = tribol::binary_search( &a[0], 6, 7 );
    EXPECT_EQ( index, 3 );
    
    // search array for integer value = 2

--- a/src/tests/tribol_mfem_common_plane.cpp
+++ b/src/tests/tribol_mfem_common_plane.cpp
@@ -40,7 +40,7 @@
  */
 class MfemCommonPlaneTest : public testing::TestWithParam<std::pair<int, tribol::KinematicPenaltyCalculation>> {
 protected:
-  double max_disp_;
+  tribol::RealT max_disp_;
   void SetUp() override
   {
     // number of times to uniformly refine the serial mesh before constructing the
@@ -49,20 +49,20 @@ protected:
     // polynomial order of the finite element discretization
     int order = GetParam().first;
     // initial velocity
-    double initial_v = 0.02;
+    tribol::RealT initial_v = 0.02;
     // timestep size
-    double dt = 0.001;
+    tribol::RealT dt = 0.001;
     // end time
-    double t_end = 2.0;
+    tribol::RealT t_end = 2.0;
     // material density
-    double rho = 1000.0;
+    tribol::RealT rho = 1000.0;
     // lame parameter
-    double lambda = 100000.0;
+    tribol::RealT lambda = 100000.0;
     // lame parameter (shear modulus)
-    double mu = 100000.0;
+    tribol::RealT mu = 100000.0;
     // kinematic constant penalty stiffness equivalent to the element-wise calculation, 
     // which is bulk-modulus over element thickness.
-    double p_kine = (lambda + 2.0 / 3.0 * mu) / (1.0 / std::pow(2.0, ref_levels));
+    tribol::RealT p_kine = (lambda + 2.0 / 3.0 * mu) / (1.0 / std::pow(2.0, ref_levels));
 
     // fixed options
     // location of mesh file. TRIBOL_REPO_DIR is defined in tribol/config.hpp
@@ -215,7 +215,7 @@ protected:
     }
 
     int cycle {0};
-    for (double t {0.0}; t < t_end; t+=dt)
+    for (tribol::RealT t {0.0}; t < t_end; t+=dt)
     {
       // build new parallel decomposed redecomp mesh and update grid functions
       // on each mesh

--- a/src/tests/tribol_mfem_mortar_lm.cpp
+++ b/src/tests/tribol_mfem_mortar_lm.cpp
@@ -35,7 +35,7 @@
  */
 class MfemCommonPlaneTest : public testing::TestWithParam<int> {
 protected:
-  double max_disp_;
+  tribol::RealT max_disp_;
   void SetUp() override
   {
     // number of times to uniformly refine the serial mesh before constructing the
@@ -175,7 +175,7 @@ protected:
 
     // update tribol (compute contact contribution to force and stiffness)
     tribol::updateMfemParallelDecomposition();
-    double dt {1.0};  // time is arbitrary here (no timesteps)
+    tribol::RealT dt {1.0};  // time is arbitrary here (no timesteps)
     tribol::update(1, 1.0, dt);
 
     // retrieve block stiffness matrix

--- a/src/tests/tribol_mortar_data_geom.cpp
+++ b/src/tests/tribol_mortar_data_geom.cpp
@@ -42,7 +42,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 namespace axom_fs = axom::utilities::filesystem;
 
 /*!
@@ -142,21 +142,21 @@ TEST_F( MortarGeomTest, mortar_good_patch )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -188,7 +188,7 @@ TEST_F( MortarGeomTest, mortar_good_patch )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ(err, 0);
@@ -256,21 +256,21 @@ TEST_F( MortarGeomTest, mortar_bad_patch )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -302,7 +302,7 @@ TEST_F( MortarGeomTest, mortar_bad_patch )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ(err, 0);
@@ -371,21 +371,21 @@ TEST_F( MortarGeomTest, mortar_ironing )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -417,7 +417,7 @@ TEST_F( MortarGeomTest, mortar_ironing )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ( err, 0 );
@@ -427,8 +427,8 @@ TEST_F( MortarGeomTest, mortar_ironing )
   
    tribol::CouplingScheme* couplingScheme = couplingSchemeManager.getCoupling( 0 );
 
-   tribol::IndexType const mortarId = couplingScheme->getMeshId1();
-   //tribol::IndexType const nonmortarId = couplingScheme->getMeshId2();
+   tribol::IndexT const mortarId = couplingScheme->getMeshId1();
+   //tribol::IndexT const nonmortarId = couplingScheme->getMeshId2();
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
 
@@ -441,7 +441,7 @@ TEST_F( MortarGeomTest, mortar_ironing )
 
    int *I = nullptr;
    int *J = nullptr;
-   real *wts = nullptr;
+   RealT *wts = nullptr;
    int nOffsets = 0;
    int nNonZeros = 0;
    int csr_err = GetSimpleCouplingCSR( &I, &J, &wts, &nOffsets, &nNonZeros );
@@ -530,21 +530,21 @@ TEST_F( MortarGeomTest, mortar_ironing_block_sub_mesh )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -576,7 +576,7 @@ TEST_F( MortarGeomTest, mortar_ironing_block_sub_mesh )
                         gaps,
                         pressures);
 
-   double dt = 1.0; 
+   RealT dt = 1.0; 
    err = Update( dt );
 
    EXPECT_EQ( err, 0 );

--- a/src/tests/tribol_mortar_data_weights.cpp
+++ b/src/tests/tribol_mortar_data_weights.cpp
@@ -42,10 +42,10 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 namespace axom_fs = axom::utilities::filesystem;
 
-void TestMortarWeights( tribol::CouplingScheme const * cs, double exact_area, double tol )
+void TestMortarWeights( tribol::CouplingScheme const * cs, RealT exact_area, RealT tol )
 {
    ////////////////////////////////////////////////////////////////////////
    //
@@ -53,8 +53,8 @@ void TestMortarWeights( tribol::CouplingScheme const * cs, double exact_area, do
    //
    ////////////////////////////////////////////////////////////////////////
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
-   tribol::IndexType const mortarId = cs->getMeshId1();
-   //tribol::IndexType const nonmortarId = cs->getMeshId2();
+   tribol::IndexT const mortarId = cs->getMeshId1();
+   //tribol::IndexT const nonmortarId = cs->getMeshId2();
 
    tribol::MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    //tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarId );
@@ -62,7 +62,7 @@ void TestMortarWeights( tribol::CouplingScheme const * cs, double exact_area, do
    // get CSR weights data
    int *I = nullptr;
    int *J = nullptr;
-   double *wts = nullptr;
+   RealT *wts = nullptr;
    int nOffsets = 0;
    int nNonZeros = 0;
    int csr_err = GetSimpleCouplingCSR( &I, &J, &wts, &nOffsets, &nNonZeros );
@@ -80,7 +80,7 @@ void TestMortarWeights( tribol::CouplingScheme const * cs, double exact_area, do
 
    // int nodeOffset = mortarMesh.m_sortedSurfaceNodeIds[ mortarMesh.m_numSurfaceNodes-1 ] + 1;
 
-   double area = 0.;
+   RealT area = 0.;
    int numTotalNodes = static_cast<tribol::MortarData*>( cs->getMethodData() )->m_numTotalNodes;
    for (int a=0; a<numTotalNodes; ++a)
    {
@@ -101,7 +101,7 @@ void TestMortarWeights( tribol::CouplingScheme const * cs, double exact_area, do
 
    SLIC_DEBUG("area: " << area << ".");
 
-   double diff = std::abs( area - exact_area );
+   RealT diff = std::abs( area - exact_area );
    EXPECT_LE( diff, tol );
 
 } // end TestMortarWeights()
@@ -204,21 +204,21 @@ TEST_F( MortarSparseWtsTest, mortar_sphere )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -250,7 +250,7 @@ TEST_F( MortarSparseWtsTest, mortar_sphere )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ(err, 0);
@@ -318,21 +318,21 @@ TEST_F( MortarSparseWtsTest, mortar_sphere_offset )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -364,7 +364,7 @@ TEST_F( MortarSparseWtsTest, mortar_sphere_offset )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ(err, 0);
@@ -432,21 +432,21 @@ TEST_F( MortarSparseWtsTest, mortar_one_seg_rotated )
    // get pointers to mfem vector data
    int* ixm_data   = this->v_ixm.GetData();
    int* ixs_data   = this->v_ixs.GetData();
-   double* xm_data = this->v_xm.GetData();
-   double* ym_data = this->v_ym.GetData();
-   double* zm_data = this->v_zm.GetData();
-   double* xs_data = this->v_xs.GetData();
-   double* ys_data = this->v_ys.GetData();
-   double* zs_data = this->v_zs.GetData();
+   RealT* xm_data = this->v_xm.GetData();
+   RealT* ym_data = this->v_ym.GetData();
+   RealT* zm_data = this->v_zm.GetData();
+   RealT* xs_data = this->v_xs.GetData();
+   RealT* ys_data = this->v_ys.GetData();
+   RealT* zs_data = this->v_zs.GetData();
 
    // set gaps and pressure arrays. Note that for this test 
    // the length of the nonmortar nodes array is the same as the mortar, 
    // which means that it is the total number of nodes in the whole 
    // mesh
-   double* gaps, * pressures;
+   RealT* gaps, * pressures;
    int numTotalNodes = this->lengthNonmortarNodes;
-   gaps = new double[ numTotalNodes ];
-   pressures = new double[ numTotalNodes ];
+   gaps = new RealT[ numTotalNodes ];
+   pressures = new RealT[ numTotalNodes ];
 
    // initialize arrays
    for (int i=0; i<numTotalNodes; ++i)
@@ -478,7 +478,7 @@ TEST_F( MortarSparseWtsTest, mortar_one_seg_rotated )
                         gaps,
                         pressures);
 
-   double dt = 1.0;
+   RealT dt = 1.0;
    err = Update( dt );
 
    EXPECT_EQ(err, 0);

--- a/src/tests/tribol_mortar_force.cpp
+++ b/src/tests/tribol_mortar_force.cpp
@@ -23,7 +23,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to compute 
@@ -40,32 +40,32 @@ public:
    int numOverlapNodes;
    int dim;
 
-   real* getXCoords( )
+   RealT* getXCoords( )
    {
       return x;
    }
 
-   real* getYCoords( )
+   RealT* getYCoords( )
    {
       return y;
    }
 
-   real* getZCoords( )
+   RealT* getZCoords( )
    {
       return z;
    }
 
-   real* getXOverlapCoords()
+   RealT* getXOverlapCoords()
    {
       return xOverlap;
    }
 
-   real* getYOverlapCoords()
+   RealT* getYOverlapCoords()
    {
       return yOverlap;
    }
 
-   real* getZOverlapCoords()
+   RealT* getZOverlapCoords()
    {
       return zOverlap;
    }
@@ -75,9 +75,9 @@ public:
                            tribol::ContactMethod method )
    {
       // grab coordinate data
-      real * x = this->x;
-      real * y = this->y;
-      real * z = this->z;
+      RealT * x = this->x;
+      RealT * y = this->y;
+      RealT * z = this->z;
 
       // register the mesh with tribol
       int cellType = static_cast<int>(tribol::UNDEFINED_ELEMENT);
@@ -98,7 +98,7 @@ public:
       const int nonmortarMeshId = 1;
 
       // initialize tribol
-      tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+      tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
       tribol::initialize( dim, problem_comm );
 
       // register mesh
@@ -112,16 +112,16 @@ public:
                             x, y, z );
 
       // register nodal forces
-      real *fx1, *fy1, *fz1;
-      real *fx2, *fy2, *fz2;
+      RealT *fx1, *fy1, *fz1;
+      RealT *fx2, *fy2, *fz2;
 
-      real forceX1[ this->numNodes ];
-      real forceY1[ this->numNodes ];
-      real forceZ1[ this->numNodes ];     
+      RealT forceX1[ this->numNodes ];
+      RealT forceY1[ this->numNodes ];
+      RealT forceZ1[ this->numNodes ];     
 
-      real forceX2[ this->numNodes ];
-      real forceY2[ this->numNodes ];
-      real forceZ2[ this->numNodes ];     
+      RealT forceX2[ this->numNodes ];
+      RealT forceY2[ this->numNodes ];
+      RealT forceZ2[ this->numNodes ];     
 
       fx1 = forceX1; 
       fy1 = forceY1;
@@ -146,10 +146,10 @@ public:
       tribol::registerNodalResponse( nonmortarMeshId, fx2, fy2, fz2 );
 
       // register nodal pressure and nodal gap array for the nonmortar mesh
-      real *gaps, *pressures;
+      RealT *gaps, *pressures;
 
-      gaps = new real [ this->numNodes ];
-      pressures = new real [ this->numNodes ];
+      gaps = new RealT [ this->numNodes ];
+      pressures = new RealT [ this->numNodes ];
 
       // initialize gaps and pressures. Initialize all 
       // nonmortar pressures to 1.0
@@ -178,7 +178,7 @@ public:
                                             tribol::SparseMode::MFEM_LINKED_LIST );
 
       // call tribol update
-      double dt = 1.0;
+      RealT dt = 1.0;
       int tribol_update_err = tribol::update( 1, 1., dt );
 
       EXPECT_EQ( tribol_update_err, 0 );      
@@ -189,13 +189,13 @@ public:
       tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarMeshId );
 
       // compute the sum of the nodal forces
-      real fx1Sum = 0.;
-      real fy1Sum = 0.;
-      real fz1Sum = 0.;
+      RealT fx1Sum = 0.;
+      RealT fy1Sum = 0.;
+      RealT fz1Sum = 0.;
 
-      real fx2Sum = 0.;
-      real fy2Sum = 0.;
-      real fz2Sum = 0.;
+      RealT fx2Sum = 0.;
+      RealT fy2Sum = 0.;
+      RealT fz2Sum = 0.;
       for (int i=0; i<this->numNodesPerFace; ++i)
       {
          int nonmortarNodeId = nonmortarMesh.getFaceNodeId( 0, i );
@@ -211,22 +211,22 @@ public:
       }
 
       // sum nonmortar pressure
-      real pSum = 0.;
+      RealT pSum = 0.;
       for (int i=0; i<this->numNodesPerFace; ++i)
       {
          int nonmortarNodeId = nonmortarMesh.getFaceNodeId( 0, i );
          pSum += nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarNodeId ];
       }
 
-      real diffX1 = std::abs(fx1Sum) - std::abs(pSum);
-      real diffY1 = std::abs(fy1Sum) - std::abs(pSum);
-      real diffZ1 = std::abs(fz1Sum) - std::abs(pSum);
+      RealT diffX1 = std::abs(fx1Sum) - std::abs(pSum);
+      RealT diffY1 = std::abs(fy1Sum) - std::abs(pSum);
+      RealT diffZ1 = std::abs(fz1Sum) - std::abs(pSum);
 
-      real diffX2 = std::abs(fx2Sum) - std::abs(pSum);
-      real diffY2 = std::abs(fy2Sum) - std::abs(pSum);
-      real diffZ2 = std::abs(fz2Sum) - std::abs(pSum);
+      RealT diffX2 = std::abs(fx2Sum) - std::abs(pSum);
+      RealT diffY2 = std::abs(fy2Sum) - std::abs(pSum);
+      RealT diffZ2 = std::abs(fz2Sum) - std::abs(pSum);
 
-      real tol = 1.e-8;
+      RealT tol = 1.e-8;
       EXPECT_LE( diffX1, tol);
       EXPECT_LE( diffY1, tol);
       EXPECT_LE( diffZ1, tol);
@@ -254,61 +254,61 @@ protected:
 
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
 
       if (this->xOverlap == nullptr)
       {
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->xOverlap;
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
 
       if (this->yOverlap == nullptr)
       {
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->yOverlap;
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       if (this->zOverlap == nullptr)
       {
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->zOverlap;
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
    }
 
@@ -348,26 +348,26 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
-   real* xOverlap {nullptr};
-   real* yOverlap {nullptr};
-   real* zOverlap {nullptr};
+   RealT* xOverlap {nullptr};
+   RealT* yOverlap {nullptr};
+   RealT* zOverlap {nullptr};
 
 };
 
 TEST_F( MortarForceTest, parallel_misaligned )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -432,13 +432,13 @@ TEST_F( MortarForceTest, parallel_misaligned )
 TEST_F( MortarForceTest, parallel_aligned )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -503,13 +503,13 @@ TEST_F( MortarForceTest, parallel_aligned )
 TEST_F( MortarForceTest, non_parallel_misaligned )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -574,13 +574,13 @@ TEST_F( MortarForceTest, non_parallel_misaligned )
 TEST_F( MortarForceTest, non_parallel_aligned )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -645,13 +645,13 @@ TEST_F( MortarForceTest, non_parallel_aligned )
 TEST_F( MortarForceTest, parallel_simple_aligned )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x[0] = -1.;
    x[1] = -1.;

--- a/src/tests/tribol_mortar_gap.cpp
+++ b/src/tests/tribol_mortar_gap.cpp
@@ -24,7 +24,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to compute
@@ -40,7 +40,7 @@ public:
    int numOverlapNodes;
    int dim;
 
-   real* getXCoords( int id )
+   RealT* getXCoords( int id )
    {
       if (id == 0)
       {
@@ -52,7 +52,7 @@ public:
       }
    }
 
-   real* getYCoords( int id )
+   RealT* getYCoords( int id )
    {
       if (id == 0)
       {
@@ -64,7 +64,7 @@ public:
       }
    }
 
-   real* getZCoords( int id )
+   RealT* getZCoords( int id )
    {
       if (id == 0)
       {
@@ -76,17 +76,17 @@ public:
       }
    }
 
-   real* getXOverlapCoords()
+   RealT* getXOverlapCoords()
    {
       return xOverlap;
    }
 
-   real* getYOverlapCoords()
+   RealT* getYOverlapCoords()
    {
       return yOverlap;
    }
 
-   real* getZOverlapCoords()
+   RealT* getZOverlapCoords()
    {
       return zOverlap;
    }
@@ -97,28 +97,28 @@ public:
    {
       // declare arrays to hold stacked coordinates for each
       // face used in initializing a SurfaceContactElem struct
-      real xyz1[ this->dim * this->numNodesPerFace ];
-      real xyz2[ this->dim * this->numNodesPerFace ];
+      RealT xyz1[ this->dim * this->numNodesPerFace ];
+      RealT xyz2[ this->dim * this->numNodesPerFace ];
 
       // declare array to hold overlap vertices used for
       // initializing a SurfaceContactElem struct
-      real xyzOverlap[ this->dim * this->numOverlapNodes ];
+      RealT xyzOverlap[ this->dim * this->numOverlapNodes ];
 
       // assign pointers to arrays
-      real* xy1 = xyz1;
-      real* xy2 = xyz2;
-      real* xyOverlap = xyzOverlap;
+      RealT* xy1 = xyz1;
+      RealT* xy2 = xyz2;
+      RealT* xyOverlap = xyzOverlap;
 
       // grab coordinate data
-      real * x1 = this->x1;
-      real * y1 = this->y1;
-      real * z1 = this->z1;
-      real * x2 = this->x2;
-      real * y2 = this->y2;
-      real * z2 = this->z2;
-      real * xo = this->xOverlap;
-      real * yo = this->yOverlap;
-      real * zo = this->zOverlap;
+      RealT * x1 = this->x1;
+      RealT * y1 = this->y1;
+      RealT * z1 = this->z1;
+      RealT * x2 = this->x2;
+      RealT * y2 = this->y2;
+      RealT * z2 = this->z2;
+      RealT * xo = this->xOverlap;
+      RealT * yo = this->yOverlap;
+      RealT * zo = this->zOverlap;
 
       // generate stacked coordinate array
       for (int j=0; j<this->numNodesPerFace; ++j)
@@ -164,7 +164,7 @@ public:
       }
 
       int dim = 3;
-      tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+      tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
       tribol::initialize( dim, problem_comm );
 
       const int mortarMeshId = 0;
@@ -187,9 +187,9 @@ public:
       mortarMesh.computeFaceData(dim);
       nonmortarMesh.computeFaceData(dim);
 
-      real* gaps;
+      RealT* gaps;
       int size = 2*this->numNodesPerFace;
-      gaps = new real[ size ];
+      gaps = new RealT[ size ];
 
       for (int i=0; i<size; ++i)
       {
@@ -250,91 +250,91 @@ protected:
 
       if (this->x1 == nullptr)
       {
-         this->x1 = new real [this->numNodes];
+         this->x1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x1;
-         this->x1 = new real [this->numNodes];
+         this->x1 = new RealT [this->numNodes];
       }
 
       if (this->x2 == nullptr)
       {
-         this->x2 = new real [this->numNodes];
+         this->x2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x2;
-         this->x2 = new real [this->numNodes];
+         this->x2 = new RealT [this->numNodes];
       }
 
       if (this->y1 == nullptr)
       {
-         this->y1 = new real [this->numNodes];
+         this->y1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y1;
-         this->y1 = new real [this->numNodes];
+         this->y1 = new RealT [this->numNodes];
       }
 
       if (this->y2 == nullptr)
       {
-         this->y2 = new real [this->numNodes];
+         this->y2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y2;
-         this->y2 = new real [this->numNodes];
+         this->y2 = new RealT [this->numNodes];
       }
 
       if (this->z1 == nullptr)
       {
-         this->z1 = new real [this->numNodes];
+         this->z1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z1;
-         this->z1 = new real [this->numNodes];
+         this->z1 = new RealT [this->numNodes];
       }
 
       if (this->z2 == nullptr)
       {
-         this->z2 = new real [this->numNodes];
+         this->z2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z2;
-         this->z2 = new real [this->numNodes];
+         this->z2 = new RealT [this->numNodes];
       }
 
       if (this->xOverlap == nullptr)
       {
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->xOverlap;
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
 
       if (this->yOverlap == nullptr)
       {
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->yOverlap;
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       if (this->zOverlap == nullptr)
       {
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->zOverlap;
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
    }
 
@@ -389,34 +389,34 @@ protected:
 
 protected:
 
-   real* x1 {nullptr};
-   real* y1 {nullptr};
-   real* z1 {nullptr};
+   RealT* x1 {nullptr};
+   RealT* y1 {nullptr};
+   RealT* z1 {nullptr};
 
-   real* x2 {nullptr};
-   real* y2 {nullptr};
-   real* z2 {nullptr};
+   RealT* x2 {nullptr};
+   RealT* y2 {nullptr};
+   RealT* z2 {nullptr};
 
-   real* xOverlap {nullptr};
-   real* yOverlap {nullptr};
-   real* zOverlap {nullptr};
+   RealT* xOverlap {nullptr};
+   RealT* yOverlap {nullptr};
+   RealT* zOverlap {nullptr};
 
 };
 
 TEST_F( MortarGapTest, parallel_misaligned )
 {
 
-   real* x1 = this->getXCoords(0);
-   real* y1 = this->getYCoords(0);
-   real* z1 = this->getZCoords(0);
+   RealT* x1 = this->getXCoords(0);
+   RealT* y1 = this->getYCoords(0);
+   RealT* z1 = this->getZCoords(0);
 
-   real* x2 = this->getXCoords(1);
-   real* y2 = this->getYCoords(1);
-   real* z2 = this->getZCoords(1);
+   RealT* x2 = this->getXCoords(1);
+   RealT* y2 = this->getYCoords(1);
+   RealT* z2 = this->getZCoords(1);
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x1[0] = -1.;
    x1[1] = -1.;
@@ -480,7 +480,7 @@ TEST_F( MortarGapTest, parallel_misaligned )
    tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( 1 );
 
    // compute the sum of the nodal gaps
-   real gap = 0.;
+   RealT gap = 0.;
    for (int i=0; i<numNodesPerFace; ++i)
    {
       gap += nonmortarMesh.m_nodalFields.m_node_gap[i];
@@ -488,9 +488,9 @@ TEST_F( MortarGapTest, parallel_misaligned )
 
    // note the face-gap of 0.1 is hard coded based on the
    // hard-coded face coordinates in this test
-   real gapDiff = std::abs(0.1 + gap);
+   RealT gapDiff = std::abs(0.1 + gap);
 
-   real tol = 1.e-8;
+   RealT tol = 1.e-8;
    EXPECT_LE( gapDiff, tol );
 
    if (nonmortarMesh.m_nodalFields.m_node_gap != nullptr)
@@ -503,17 +503,17 @@ TEST_F( MortarGapTest, parallel_misaligned )
 TEST_F( MortarGapTest, parallel_aligned )
 {
 
-   real* x1 = this->getXCoords(0);
-   real* y1 = this->getYCoords(0);
-   real* z1 = this->getZCoords(0);
+   RealT* x1 = this->getXCoords(0);
+   RealT* y1 = this->getYCoords(0);
+   RealT* z1 = this->getZCoords(0);
 
-   real* x2 = this->getXCoords(1);
-   real* y2 = this->getYCoords(1);
-   real* z2 = this->getZCoords(1);
+   RealT* x2 = this->getXCoords(1);
+   RealT* y2 = this->getYCoords(1);
+   RealT* z2 = this->getZCoords(1);
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x1[0] = 0.; //-1.;
    x1[1] = 0.; //-1.;
@@ -577,7 +577,7 @@ TEST_F( MortarGapTest, parallel_aligned )
    tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( 1 );
 
    // compute the sum of the nodal gaps
-   real gap = 0.;
+   RealT gap = 0.;
    for (int i=0; i<numNodesPerFace; ++i)
    {
       gap += nonmortarMesh.m_nodalFields.m_node_gap[i];
@@ -585,9 +585,9 @@ TEST_F( MortarGapTest, parallel_aligned )
 
    // note the face-gap of 0.1 is hard coded based on the
    // hard-coded face coordinates in this test
-   real gapDiff = std::abs(0.1 + gap);
+   RealT gapDiff = std::abs(0.1 + gap);
 
-   real tol = 1.e-8;
+   RealT tol = 1.e-8;
    EXPECT_LE( gapDiff, tol );
 
    if (nonmortarMesh.m_nodalFields.m_node_gap != nullptr)
@@ -600,17 +600,17 @@ TEST_F( MortarGapTest, parallel_aligned )
 TEST_F( MortarGapTest, parallel_simple_aligned )
 {
 
-   real* x1 = this->getXCoords(0);
-   real* y1 = this->getYCoords(0);
-   real* z1 = this->getZCoords(0);
+   RealT* x1 = this->getXCoords(0);
+   RealT* y1 = this->getYCoords(0);
+   RealT* z1 = this->getZCoords(0);
 
-   real* x2 = this->getXCoords(1);
-   real* y2 = this->getYCoords(1);
-   real* z2 = this->getZCoords(1);
+   RealT* x2 = this->getXCoords(1);
+   RealT* y2 = this->getYCoords(1);
+   RealT* z2 = this->getZCoords(1);
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x1[0] = -1.;
    x1[1] = -1.;
@@ -674,8 +674,8 @@ TEST_F( MortarGapTest, parallel_simple_aligned )
    tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( 1 );
 
    // compute the sum of the nodal gaps
-   real gap = 0.;
-   real gapTest = 0;
+   RealT gap = 0.;
+   RealT gapTest = 0;
    for (int i=0; i<numNodesPerFace; ++i)
    {
       gap += nonmortarMesh.m_nodalFields.m_node_gap[i];
@@ -684,9 +684,9 @@ TEST_F( MortarGapTest, parallel_simple_aligned )
 
    // note the face-gap of 0.1 is hard coded based on the
    // hard-coded face coordinates in this test
-   real gapDiff = std::abs(gapTest + gap);
+   RealT gapDiff = std::abs(gapTest + gap);
 
-   real tol = 1.e-8;
+   RealT tol = 1.e-8;
    EXPECT_LE( gapDiff, tol );
 
    if (nonmortarMesh.m_nodalFields.m_node_gap != nullptr)

--- a/src/tests/tribol_mortar_jacobian.cpp
+++ b/src/tests/tribol_mortar_jacobian.cpp
@@ -33,7 +33,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test
@@ -50,17 +50,17 @@ public:
    int numOverlapNodes;
    int dim;
 
-   real* getXCoords( )
+   RealT* getXCoords( )
    {
       return x;
    }
 
-   real* getYCoords( )
+   RealT* getYCoords( )
    {
       return y;
    }
 
-   real* getZCoords( )
+   RealT* getZCoords( )
    {
       return z;
    }
@@ -75,9 +75,9 @@ public:
       // reflect a global, contiguous index space
 
       // grab coordinate data
-      real * x = this->x;
-      real * y = this->y;
-      real * z = this->z;
+      RealT * x = this->x;
+      RealT * y = this->y;
+      RealT * z = this->z;
 
       // register the mesh with tribol
       int cellType = static_cast<int>(tribol::UNDEFINED_ELEMENT);
@@ -98,7 +98,7 @@ public:
       const int nonmortarMeshId = 1;
 
       // initialize tribol
-      tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+      tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
       tribol::initialize( dim, problem_comm );
 
       // register mesh
@@ -117,16 +117,16 @@ public:
       // I created two sets of nodal force arrays with their own pointers 
       // to the data that are registered with tribol and there is no longer
       // a seg fault.
-      real *fx1, *fy1, *fz1;
-      real *fx2, *fy2, *fz2;
+      RealT *fx1, *fy1, *fz1;
+      RealT *fx2, *fy2, *fz2;
 
-      real forceX1[ this->numNodes ];
-      real forceY1[ this->numNodes ];
-      real forceZ1[ this->numNodes ];     
+      RealT forceX1[ this->numNodes ];
+      RealT forceY1[ this->numNodes ];
+      RealT forceZ1[ this->numNodes ];     
 
-      real forceX2[ this->numNodes ];
-      real forceY2[ this->numNodes ];
-      real forceZ2[ this->numNodes ];     
+      RealT forceX2[ this->numNodes ];
+      RealT forceY2[ this->numNodes ];
+      RealT forceZ2[ this->numNodes ];     
 
       fx1 = forceX1; 
       fy1 = forceY1;
@@ -152,10 +152,10 @@ public:
       tribol::registerNodalResponse( nonmortarMeshId, fx2, fy2, fz2 );
 
       // register nodal pressure and nodal gap array for the nonmortar mesh
-      real *gaps, *pressures;
+      RealT *gaps, *pressures;
 
-      gaps = new real [ this->numNodes ]; // length of total mesh to use global connectivity to index
-      pressures = new real [ this->numNodes ]; // length of total mesh to use global connectivity to index
+      gaps = new RealT [ this->numNodes ]; // length of total mesh to use global connectivity to index
+      pressures = new RealT [ this->numNodes ]; // length of total mesh to use global connectivity to index
 
       // initialize gaps and pressures. Initialize all 
       // nonmortar pressures to 1.0
@@ -183,7 +183,7 @@ public:
       tribol::setLagrangeMultiplierOptions( csIndex, tribol::ImplicitEvalMode::MORTAR_RESIDUAL_JACOBIAN, 
                                             tribol::SparseMode::MFEM_LINKED_LIST );
 
-      double dt = 1.0;
+      RealT dt = 1.0;
       int tribol_update_err = tribol::update( 1, 1., dt );
 
       EXPECT_EQ( tribol_update_err, 0 );
@@ -202,32 +202,32 @@ protected:
 
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
   
    }
@@ -253,18 +253,18 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
 };
 
 TEST_F( MortarJacTest, jac_input_test )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -360,9 +360,9 @@ TEST_F( MortarJacTest, jac_input_test )
 TEST_F( MortarJacTest, update_jac_test )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -1.;
    x[1] = -1.;
@@ -435,7 +435,7 @@ TEST_F( MortarJacTest, update_jac_test )
    {
       for (int j=0; j<numCols; ++j)
       {
-         double val = dJac(i,j);
+         RealT val = dJac(i,j);
          matrix << val << "  ";
       }
       matrix << "\n";

--- a/src/tests/tribol_mortar_lm_patch_test.cpp
+++ b/src/tests/tribol_mortar_lm_patch_test.cpp
@@ -33,7 +33,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test
@@ -49,15 +49,15 @@ public:
 
    void computeContactSolution( int nMortarElemsX, int nMortarElemsY, int nMortarElemsZ,
                                 int nNonmortarElemsX, int nNonmortarElemsY, int nNonmortarElemsZ,
-                                real xMin1, real yMin1, real zMin1,
-                                real xMax1, real yMax1, real zMax1,
-                                real xMin2, real yMin2, real zMin2,
-                                real xMax2, real yMax2, real zMax2,
-                                real thetaM, real thetaS,
+                                RealT xMin1, RealT yMin1, RealT zMin1,
+                                RealT xMax1, RealT yMax1, RealT zMax1,
+                                RealT xMin2, RealT yMin2, RealT zMin2,
+                                RealT xMax2, RealT yMax2, RealT zMax2,
+                                RealT thetaM, RealT thetaS,
                                 tribol::ContactMethod method,
                                 std::string test_name,
                                 bool cntct, bool writeOutput, bool debug, bool vis,
-                                mfem::Vector &sol, real &pressure_rel_error );
+                                mfem::Vector &sol, RealT &pressure_rel_error );
 
 protected:
 
@@ -77,18 +77,18 @@ protected:
 
 void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarElemsY, int nMortarElemsZ,
                                                 int nNonmortarElemsX, int nNonmortarElemsY, int nNonmortarElemsZ,
-                                                real xMin1, real yMin1, real zMin1,
-                                                real xMax1, real yMax1, real zMax1,
-                                                real xMin2, real yMin2, real zMin2,
-                                                real xMax2, real yMax2, real zMax2,
-                                                real thetaM, real thetaS,
+                                                RealT xMin1, RealT yMin1, RealT zMin1,
+                                                RealT xMax1, RealT yMax1, RealT zMax1,
+                                                RealT xMin2, RealT yMin2, RealT zMin2,
+                                                RealT xMax2, RealT yMax2, RealT zMax2,
+                                                RealT thetaM, RealT thetaS,
                                                 tribol::ContactMethod method,
                                                 std::string test_name,
                                                 bool cntct, bool writeOutput, bool TRIBOL_UNUSED_PARAM(debug), bool vis,
-                                                mfem::Vector &sol, real &pressure_rel_error )
+                                                mfem::Vector &sol, RealT &pressure_rel_error )
 {
    bool inHomogeneous = false;
-   real inHomogeneousVal = 0.;
+   RealT inHomogeneousVal = 0.;
    if (!cntct)
    {
       inHomogeneous = true;
@@ -141,8 +141,8 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
    // setup a temporary stacked array of nodal coordinates for use in the instantiation 
    // of a reference configuration grid function. The nodal coordinates are stacked x, then 
    // y, then z. Also setup a local interleaved array of incremental nodal displacements.
-   real xyz[ this->m_mesh.dim * this->m_mesh.numTotalNodes ];
-   real xyz_inc[ this->m_mesh.dim * this->m_mesh.numTotalNodes ];
+   RealT xyz[ this->m_mesh.dim * this->m_mesh.numTotalNodes ];
+   RealT xyz_inc[ this->m_mesh.dim * this->m_mesh.numTotalNodes ];
    for (int i=0; i<this->m_mesh.numTotalNodes; ++i)
    {
       xyz[ i ] = this->m_mesh.x[i];
@@ -168,7 +168,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
 
    // add hex8 equilibrium contributions for linear elasticity
    // define the lambda and mu constant coefficients
-   double lambda_val, mu_val, nu_val, youngs_val;
+   RealT lambda_val, mu_val, nu_val, youngs_val;
    nu_val = 0.33;
    youngs_val = 3.E7; 
    lambda_val = (youngs_val * nu_val) / ((1. + nu_val) * (1. - 2. * nu_val));
@@ -194,7 +194,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
    // where the last addition is for the pressure lagrange multiplier field
    int rhs_size = this->m_mesh.dim * this->m_mesh.numTotalNodes +
                   this->m_mesh.numNonmortarSurfaceNodes;
-   double b[ rhs_size ];
+   RealT b[ rhs_size ];
 
    // initialize b vector
    for (int i=0; i<rhs_size; ++i)
@@ -252,7 +252,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
    invJ.Mult( rhs, sol );
 
    // get solution data
-   double * sol_data = sol.GetData();
+   RealT * sol_data = sol.GetData();
 
    // update the tribol nodal pressure array. This traverses 
    // the connectivity array, which will populate nonmortar pressures 
@@ -263,7 +263,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
    // instead I exploit the fact that the nonmortar pressure nodes are 
    // ordered consecutively with an offset that is the number of 
    // mortar nodes in the mortar block
-   double nonmortarForceSum = 0.;
+   RealT nonmortarForceSum = 0.;
    if (contact)
    {
       int connSize = this->m_mesh.numNonmortarFaces * this->m_mesh.numNodesPerFace;
@@ -296,7 +296,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
       tribol::setLagrangeMultiplierOptions( 0, tribol::ImplicitEvalMode::MORTAR_RESIDUAL, 
                                             tribol::SparseMode::MFEM_LINKED_LIST );
 
-      double dt = 1.0;
+      RealT dt = 1.0;
       int tribol_update_err = tribol::update( 1, 1., dt );
 
       EXPECT_EQ( tribol_update_err, 0 );
@@ -344,14 +344,14 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
    {
       mfem::Vector node_vals;
       stress.GetNodalValues( node_vals, 3 );
-      real *data = stress.GetData();
+      RealT *data = stress.GetData();
       pressure_rel_error 
          -= data[2*this->m_mesh.numTotalNodes + this->m_mesh.faceConn2[0]];
       pressure_rel_error 
          /= data[2*this->m_mesh.numTotalNodes + this->m_mesh.faceConn2[0]];
       pressure_rel_error = std::abs(pressure_rel_error);
 
-      real * error_data = stress33_rel_error.GetData();
+      RealT * error_data = stress33_rel_error.GetData();
       for (int i=(2*this->m_mesh.numTotalNodes); i<(2*this->m_mesh.numTotalNodes+this->m_mesh.numTotalNodes); ++i)
       {
          error_data[i] -= nonmortarForceSum;
@@ -419,7 +419,7 @@ void MortarLMPatchTest::computeContactSolution( int nMortarElemsX, int nMortarEl
          sol_vec << sol_data[i] << "\n";
          for (int j=0; j<jac.NumCols(); ++j)
          {
-            double val = dJac(i,j);
+            RealT val = dJac(i,j);
             matrix << val << "  ";
          }
          matrix << "\n";
@@ -453,29 +453,29 @@ TEST_F( MortarLMPatchTest, single_mortar_uniform_patch )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = 1;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    bool output = false; // solution vector and rhs
    bool contact = true;
    bool debug = false;  // element matrix writes to .txt files
    bool visualization = false; // output of .vtk with mesh and stress output
 
-   real thetaM = 0.;
-   real thetaS = 0.;
+   RealT thetaM = 0.;
+   RealT thetaS = 0.;
 
-   real press_rel_error = 0.;
+   RealT press_rel_error = 0.;
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM,
                                  nElemsXS, nElemsYS, nElemsZS,
                                  x_min1, y_min1, z_min1,
@@ -495,7 +495,7 @@ TEST_F( MortarLMPatchTest, single_mortar_uniform_patch )
    debug = false;
    visualization = false;
 
-   real press_rel_error_null = 0.;
+   RealT press_rel_error_null = 0.;
 
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM, 
                                  nElemsXS, nElemsYS, nElemsZS,
@@ -512,14 +512,14 @@ TEST_F( MortarLMPatchTest, single_mortar_uniform_patch )
    mfem::Vector diff(xsol_cntct.Size());
    subtract(xsol_cntct, xsol_base, diff);
 
-   double tol = 5.e-4; // 1/100th of the gap
+   RealT tol = 5.e-4; // 1/100th of the gap
    int size = this->m_mesh.dim * this->m_mesh.numTotalNodes;
    for (int i=0; i<size; ++i)
    {
       EXPECT_LE( std::abs(diff(i)), tol );
    }
 
-   double press_tol = 1.e-2; // 0.02% error in pressure
+   RealT press_tol = 1.e-2; // 0.02% error in pressure
    SLIC_DEBUG( "press_rel_error: " << press_rel_error );
    EXPECT_LE( std::abs(press_rel_error), press_tol );
 }
@@ -540,29 +540,29 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_mortar_fine_patch )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = 1;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    bool output = false; // solution vector and rhs
    bool contact = true;
    bool debug = false;  // element matrix writes to .txt files
    bool visualization = false; // output of .vtk with mesh and stress output
 
-   real thetaM = 3.; // 0.; // keep for a nice non-uniform mesh
-   real thetaS = -5.; // 3.; // keep for a nice non-uniform mesh
+   RealT thetaM = 3.; // 0.; // keep for a nice non-uniform mesh
+   RealT thetaS = -5.; // 3.; // keep for a nice non-uniform mesh
 
-   real press_rel_error = 0.;
+   RealT press_rel_error = 0.;
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM,
                                  nElemsXS, nElemsYS, nElemsZS,
                                  x_min1, y_min1, z_min1,
@@ -582,7 +582,7 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_mortar_fine_patch )
    debug = false;
    visualization = false;
 
-   real press_rel_error_null = 0.;
+   RealT press_rel_error_null = 0.;
 
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM, 
                                  nElemsXS, nElemsYS, nElemsZS,
@@ -599,14 +599,14 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_mortar_fine_patch )
    mfem::Vector diff(xsol_cntct.Size());
    subtract(xsol_cntct, xsol_base, diff);
 
-   double tol = 5.e-4; // 1/100th of the gap
+   RealT tol = 5.e-4; // 1/100th of the gap
    int size = this->m_mesh.dim * this->m_mesh.numTotalNodes;
    for (int i=0; i<size; ++i)
    {
       EXPECT_LE( std::abs(diff(i)), tol );
    }
 
-   double press_tol = 5.e-3; // 0.5% error in pressure
+   RealT press_tol = 5.e-3; // 0.5% error in pressure
    SLIC_DEBUG( "press_rel_error: " << press_rel_error );
    EXPECT_LE( std::abs(press_rel_error), press_tol );
 }
@@ -627,26 +627,26 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_nonmortar_fine_patch )
    int nElemsYS = 7; //nNonmortarElems;
    int nElemsZS = 1;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    bool output = false; // solution vector and rhs
    bool contact = true;
    bool debug = false;  // element matrix writes to .txt files
    bool visualization = false; // output of .vtk with mesh and stress output
 
-   real press_rel_error = 0.;
+   RealT press_rel_error = 0.;
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM,
                                  nElemsXS, nElemsYS, nElemsZS,
                                  x_min1, y_min1, z_min1,
@@ -666,7 +666,7 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_nonmortar_fine_patch )
    debug = false;
    visualization = false;
 
-   real press_rel_error_null = 0.;
+   RealT press_rel_error_null = 0.;
 
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM, 
                                  nElemsXS, nElemsYS, nElemsZS,
@@ -683,14 +683,14 @@ TEST_F( MortarLMPatchTest, single_mortar_nonuniform_nonmortar_fine_patch )
    mfem::Vector diff(xsol_cntct.Size());
    subtract(xsol_cntct, xsol_base, diff);
 
-   double tol = 1.e-10;
+   RealT tol = 1.e-10;
    int size = this->m_mesh.dim * this->m_mesh.numTotalNodes;
    for (int i=0; i<size; ++i)
    {
       EXPECT_LE( std::abs(diff(i)), tol );
    }
 
-   double press_tol = 1.e-7;
+   RealT press_tol = 1.e-7;
    SLIC_DEBUG( "press_rel_error: " << press_rel_error );
    EXPECT_LE( std::abs(press_rel_error), press_tol );
 }
@@ -711,26 +711,26 @@ TEST_F( MortarLMPatchTest, aligned_mortar_patch )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = 1;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    bool output = false; // solution output and rhs
    bool contact = true; 
    bool debug = false; // debug matrix writes to .txt files
    bool visualization = false; // visualize mesh and stress
 
-   real press_rel_error = 0.;
+   RealT press_rel_error = 0.;
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM,
                                  nElemsXS, nElemsYS, nElemsZS,
                                  x_min1, y_min1, z_min1,
@@ -750,7 +750,7 @@ TEST_F( MortarLMPatchTest, aligned_mortar_patch )
    debug = false;
    visualization = false;
 
-   real press_rel_error_null = 0.;
+   RealT press_rel_error_null = 0.;
 
    this->computeContactSolution( nElemsXM, nElemsYM, nElemsZM, 
                                  nElemsXS, nElemsYS, nElemsZS,
@@ -767,14 +767,14 @@ TEST_F( MortarLMPatchTest, aligned_mortar_patch )
    mfem::Vector diff(xsol_cntct.Size());
    subtract(xsol_cntct, xsol_base, diff);
 
-   double tol = 1.e-10;
+   RealT tol = 1.e-10;
    int size = this->m_mesh.dim * this->m_mesh.numTotalNodes;
    for (int i=0; i<size; ++i)
    {
       EXPECT_LE( std::abs(diff(i)), tol );
    }
 
-   double press_tol = 1.e-7;
+   RealT press_tol = 1.e-7;
    SLIC_DEBUG( "press_rel_error: " << press_rel_error );
    EXPECT_LE( std::abs(press_rel_error), press_tol );
 }

--- a/src/tests/tribol_mortar_sparse_weights.cpp
+++ b/src/tests/tribol_mortar_sparse_weights.cpp
@@ -41,21 +41,21 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
-void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
+void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, RealT * gaps )
 {
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
    tribol::parameters_t& parameters = tribol::parameters_t::getInstance();
-   tribol::integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    ////////////////////////////////////////////////////////////////////////
    //
    // Grab pointers to mesh data
    //
    ////////////////////////////////////////////////////////////////////////
-   tribol::IndexType const mortarId = cs->getMeshId1();
-   tribol::IndexType const nonmortarId = cs->getMeshId2();
+   tribol::IndexT const mortarId = cs->getMeshId1();
+   tribol::IndexT const nonmortarId = cs->getMeshId2();
 
    tribol::MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarId );
@@ -65,7 +65,7 @@ void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
    // namespace is getting tested.
    int *I = nullptr;
    int *J = nullptr;
-   real *wts = nullptr;
+   RealT *wts = nullptr;
    int nOffsets = 0;
    int nNonZeros = 0;
    int csr_err = GetSimpleCouplingCSR( &I, &J, &wts, &nOffsets, &nNonZeros );
@@ -91,7 +91,7 @@ void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
    for (int a=0; a<numTotalNodes; ++a)
    {
       // get nonmortar nodal normal
-      real nrml_a[dim];
+      RealT nrml_a[dim];
       nrml_a[0] = nonmortarMesh.m_node_nX[ a ]; // array is global length; no index out (?)
       nrml_a[1] = nonmortarMesh.m_node_nY[ a ];
       if (dim == 3 )
@@ -103,8 +103,8 @@ void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
       for (int b=I[a]; b<I[a+1]; ++b)
       {
          // get face coordinates for node J[b], i.e. column node id
-         real mortar_xyz[ dim ]; 
-         real nonmortar_xyz[ dim ]; 
+         RealT mortar_xyz[ dim ]; 
+         RealT nonmortar_xyz[ dim ]; 
 
          for (int i=0; i<dim; ++i)
          {
@@ -112,7 +112,7 @@ void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
             nonmortar_xyz[i]  = 0.;
          }
 
-         real n_ab = wts[b];
+         RealT n_ab = wts[b];
 
          if ( J[b] < nodeOffset ) // nonmortar/mortar  weight
          {
@@ -144,17 +144,17 @@ void computeGapsFromSparseWts( tribol::CouplingScheme const * cs, real * gaps )
 
 } // end ComputeGapsFromSparseWts()
 
-void compareGaps( tribol::CouplingScheme const * cs, real * gaps, const real tol )
+void compareGaps( tribol::CouplingScheme const * cs, RealT * gaps, const RealT tol )
 {
    tribol::MeshManager& meshManager = tribol::MeshManager::getInstance();
-   tribol::IndexType const nonmortarId = cs->getMeshId2();
+   tribol::IndexT const nonmortarId = cs->getMeshId2();
    tribol::MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarId );
 
    int numTotalNodes = cs->getNumTotalNodes();
 
    for (int i=0; i<numTotalNodes; ++i)
    {
-      real diff = nonmortarMesh.m_nodalFields.m_node_gap[i] - gaps[i];
+      RealT diff = nonmortarMesh.m_nodalFields.m_node_gap[i] - gaps[i];
       EXPECT_LE( diff, tol );
    }
 
@@ -199,19 +199,19 @@ TEST_F( MortarSparseWtsTest, mortar_weights_uniform )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = nNonmortarElems;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -235,9 +235,9 @@ TEST_F( MortarSparseWtsTest, mortar_weights_uniform )
    tribol::CouplingScheme* couplingScheme = couplingSchemeManager.getCoupling( 0 );
 
    // allocate storage for gap computations using sparse mortar weights
-   real * gaps = nullptr;
+   RealT * gaps = nullptr;
    int size = static_cast<tribol::MortarData*>( couplingScheme->getMethodData() )->m_numTotalNodes;
-   gaps = new real[ size ];
+   gaps = new RealT[ size ];
 
    // initialize gap storage
    for (int i=0; i<size; ++i)
@@ -267,19 +267,19 @@ TEST_F( MortarSparseWtsTest, simple_api_mortar_weights_uniform )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = nNonmortarElems;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -303,9 +303,9 @@ TEST_F( MortarSparseWtsTest, simple_api_mortar_weights_uniform )
    tribol::CouplingScheme* couplingScheme = couplingSchemeManager.getCoupling( 0 );
 
    // allocate storage for gap computations using sparse mortar weights
-   real * gaps = nullptr;
+   RealT * gaps = nullptr;
    int size = static_cast<tribol::MortarData*>( couplingScheme->getMethodData() )->m_numTotalNodes;
-   gaps = new real[ size ];
+   gaps = new RealT[ size ];
 
    // initialize gap storage
    for (int i=0; i<size; ++i)
@@ -335,19 +335,19 @@ TEST_F( MortarSparseWtsTest, mortar_weights_nonuniform_mortar_fine )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = nNonmortarElems;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -372,9 +372,9 @@ TEST_F( MortarSparseWtsTest, mortar_weights_nonuniform_mortar_fine )
    tribol::CouplingScheme* couplingScheme = couplingSchemeManager.getCoupling( 0 );
 
    // allocate storage for gap computations using sparse mortar weights
-   real * gaps = nullptr;
+   RealT * gaps = nullptr;
    int size = static_cast<tribol::MortarData*>( couplingScheme->getMethodData() )->m_numTotalNodes;
-   gaps = new real[ size ];
+   gaps = new RealT[ size ];
 
    // initialize gap storage
    for (int i=0; i<size; ++i)
@@ -404,19 +404,19 @@ TEST_F( MortarSparseWtsTest, mortar_weights_nonuniform_nonmortar_fine )
    int nElemsYS = nNonmortarElems;
    int nElemsZS = nNonmortarElems;
 
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -441,9 +441,9 @@ TEST_F( MortarSparseWtsTest, mortar_weights_nonuniform_nonmortar_fine )
    tribol::CouplingScheme* couplingScheme = couplingSchemeManager.getCoupling( 0 );
 
    // allocate storage for gap computations using sparse mortar weights
-   real * gaps = nullptr;
+   RealT * gaps = nullptr;
    int size = static_cast<tribol::MortarData*>( couplingScheme->getMethodData() )->m_numTotalNodes;
-   gaps = new real[ size ];
+   gaps = new RealT[ size ];
 
    // initialize gap storage
    for (int i=0; i<size; ++i)

--- a/src/tests/tribol_mortar_wts.cpp
+++ b/src/tests/tribol_mortar_wts.cpp
@@ -19,7 +19,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to compute 
@@ -36,7 +36,7 @@ public:
    int numOverlapNodes;
    int dim;
 
-   real* getXCoords( int id ) 
+   RealT* getXCoords( int id ) 
    {
       if (id == 0)
       {
@@ -48,7 +48,7 @@ public:
       }
    }
 
-   real* getYCoords( int id ) 
+   RealT* getYCoords( int id ) 
    {
       if (id == 0)
       {
@@ -60,7 +60,7 @@ public:
       }
    }
 
-   real* getZCoords( int id ) 
+   RealT* getZCoords( int id ) 
    {
       if (id == 0)
       {
@@ -72,44 +72,44 @@ public:
       }
    }
 
-   real* getXOverlapCoords()
+   RealT* getXOverlapCoords()
    {
       return xOverlap;
    }
 
-   real* getYOverlapCoords()
+   RealT* getYOverlapCoords()
    {
       return yOverlap;
    }
 
-   real* getZOverlapCoords()
+   RealT* getZOverlapCoords()
    {
       return zOverlap;
    }
 
-   void checkMortarWts ( real pTestNonmortar[4], real pTestMortar[4])
+   void checkMortarWts ( RealT pTestNonmortar[4], RealT pTestMortar[4])
    {
       if (this->numNodesPerFace != 4)
       {
          SLIC_ERROR("checkMortarWts: number of nodes per face not equal to 4.");
       }
 
-      real xyz1[ this->dim * this->numNodesPerFace ];
-      real xyz2[ this->dim * this->numNodesPerFace ];
-      real xyzOverlap[ this->dim * this->numOverlapNodes ];
-      real* xy1 = xyz1;
-      real* xy2 = xyz2;
-      real* xyOverlap = xyzOverlap;
+      RealT xyz1[ this->dim * this->numNodesPerFace ];
+      RealT xyz2[ this->dim * this->numNodesPerFace ];
+      RealT xyzOverlap[ this->dim * this->numOverlapNodes ];
+      RealT* xy1 = xyz1;
+      RealT* xy2 = xyz2;
+      RealT* xyOverlap = xyzOverlap;
 
-      real * x1 = this->x1;
-      real * y1 = this->y1;
-      real * z1 = this->z1;
-      real * x2 = this->x2;
-      real * y2 = this->y2;
-      real * z2 = this->z2;
-      real * xo = this->xOverlap;
-      real * yo = this->yOverlap;
-      real * zo = this->zOverlap;
+      RealT * x1 = this->x1;
+      RealT * y1 = this->y1;
+      RealT * z1 = this->z1;
+      RealT * x2 = this->x2;
+      RealT * y2 = this->y2;
+      RealT * z2 = this->z2;
+      RealT * xo = this->xOverlap;
+      RealT * yo = this->yOverlap;
+      RealT * zo = this->zOverlap;
 
       // generate stacked coordinate array
       for (int j=0; j<this->numNodesPerFace; ++j)
@@ -149,7 +149,7 @@ public:
       tribol::ComputeMortarWeights( elem );
 
       // test the projection on an arbitrary vector
-      real p[4] = {1., 1., 1., 1.};
+      RealT p[4] = {1., 1., 1., 1.};
       for (int i=0; i<this->numNodesPerFace; ++i)
       {
          for (int j=0; j<this->numNodesPerFace; ++j)
@@ -175,91 +175,91 @@ protected:
 
       if (this->x1 == nullptr)
       {
-         this->x1 = new real [this->numNodes];
+         this->x1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x1;
-         this->x1 = new real [this->numNodes];
+         this->x1 = new RealT [this->numNodes];
       }
 
       if (this->x2 == nullptr)
       {
-         this->x2 = new real [this->numNodes];
+         this->x2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x2;
-         this->x2 = new real [this->numNodes];
+         this->x2 = new RealT [this->numNodes];
       }
 
       if (this->y1 == nullptr)
       {
-         this->y1 = new real [this->numNodes];
+         this->y1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y1;
-         this->y1 = new real [this->numNodes];
+         this->y1 = new RealT [this->numNodes];
       }
 
       if (this->y2 == nullptr)
       {
-         this->y2 = new real [this->numNodes];
+         this->y2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y2;
-         this->y2 = new real [this->numNodes];
+         this->y2 = new RealT [this->numNodes];
       }
 
       if (this->z1 == nullptr)
       {
-         this->z1 = new real [this->numNodes];
+         this->z1 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z1;
-         this->z1 = new real [this->numNodes];
+         this->z1 = new RealT [this->numNodes];
       }
 
       if (this->z2 == nullptr)
       {
-         this->z2 = new real [this->numNodes];
+         this->z2 = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z2;
-         this->z2 = new real [this->numNodes];
+         this->z2 = new RealT [this->numNodes];
       }
   
       if (this->xOverlap == nullptr)
       {
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->xOverlap;
-         this->xOverlap = new real [this->numOverlapNodes];
+         this->xOverlap = new RealT [this->numOverlapNodes];
       }
 
       if (this->yOverlap == nullptr)
       {
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->yOverlap;
-         this->yOverlap = new real [this->numOverlapNodes];
+         this->yOverlap = new RealT [this->numOverlapNodes];
       }
       if (this->zOverlap == nullptr)
       {
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
       else
       {
          delete [] this->zOverlap;
-         this->zOverlap = new real [this->numOverlapNodes];
+         this->zOverlap = new RealT [this->numOverlapNodes];
       }
    }
 
@@ -314,34 +314,34 @@ protected:
 
 protected:
 
-   real* x1 {nullptr};
-   real* y1 {nullptr};
-   real* z1 {nullptr};
+   RealT* x1 {nullptr};
+   RealT* y1 {nullptr};
+   RealT* z1 {nullptr};
 
-   real* x2 {nullptr};
-   real* y2 {nullptr};
-   real* z2 {nullptr};
+   RealT* x2 {nullptr};
+   RealT* y2 {nullptr};
+   RealT* z2 {nullptr};
 
-   real* xOverlap {nullptr};
-   real* yOverlap {nullptr};
-   real* zOverlap {nullptr};
+   RealT* xOverlap {nullptr};
+   RealT* yOverlap {nullptr};
+   RealT* zOverlap {nullptr};
 
 };
 
 TEST_F( MortarWeightTest, simple_projection )
 {
 
-   real* x1 = this->getXCoords(0);
-   real* y1 = this->getYCoords(0);
-   real* z1 = this->getZCoords(0);
+   RealT* x1 = this->getXCoords(0);
+   RealT* y1 = this->getYCoords(0);
+   RealT* z1 = this->getZCoords(0);
 
-   real* x2 = this->getXCoords(1);
-   real* y2 = this->getYCoords(1);
-   real* z2 = this->getZCoords(1);
+   RealT* x2 = this->getXCoords(1);
+   RealT* y2 = this->getYCoords(1);
+   RealT* z2 = this->getZCoords(1);
 
-   real* xOvrlp = this->getXOverlapCoords();
-   real* yOvrlp = this->getYOverlapCoords();
-   real* zOvrlp = this->getZOverlapCoords();
+   RealT* xOvrlp = this->getXOverlapCoords();
+   RealT* yOvrlp = this->getYOverlapCoords();
+   RealT* zOvrlp = this->getZOverlapCoords();
 
    x1[0] = -1.;
    x1[1] = -1.;
@@ -388,24 +388,24 @@ TEST_F( MortarWeightTest, simple_projection )
    zOvrlp[2] = 0.1;
    zOvrlp[3] = 0.1;
 
-   real pNonmortar[4] = {0., 0., 0., 0.};
-   real pMortar[4] = {0., 0., 0., 0};
+   RealT pNonmortar[4] = {0., 0., 0., 0.};
+   RealT pMortar[4] = {0., 0., 0., 0};
    this->checkMortarWts( pNonmortar, pMortar );
 
    // hard-code diffs for each element in pNonmortar and pMortar. 
    // Note, these hard coded values DEPEND on the ordering of 
    // the nodes in this function (above).
-   real diffNonmortar1 = std::abs(0.5625 - pNonmortar[0]);
-   real diffNonmortar2 = std::abs(0.1875 - pNonmortar[1]);
-   real diffNonmortar3 = std::abs(0.0625 - pNonmortar[2]);
-   real diffNonmortar4 = std::abs(0.1875 - pNonmortar[3]);
+   RealT diffNonmortar1 = std::abs(0.5625 - pNonmortar[0]);
+   RealT diffNonmortar2 = std::abs(0.1875 - pNonmortar[1]);
+   RealT diffNonmortar3 = std::abs(0.0625 - pNonmortar[2]);
+   RealT diffNonmortar4 = std::abs(0.1875 - pNonmortar[3]);
 
-   real diffMortar1 = std::abs(0.0625 - pMortar[0]);
-   real diffMortar2 = std::abs(0.1875 - pMortar[1]);
-   real diffMortar3 = std::abs(0.5625 - pMortar[2]);
-   real diffMortar4 = std::abs(0.1875 - pMortar[3]);
+   RealT diffMortar1 = std::abs(0.0625 - pMortar[0]);
+   RealT diffMortar2 = std::abs(0.1875 - pMortar[1]);
+   RealT diffMortar3 = std::abs(0.5625 - pMortar[2]);
+   RealT diffMortar4 = std::abs(0.1875 - pMortar[3]);
 
-   real tol = 1.e-8;
+   RealT tol = 1.e-8;
    EXPECT_LE( diffNonmortar1, tol );
    EXPECT_LE( diffNonmortar2, tol );
    EXPECT_LE( diffNonmortar3, tol );

--- a/src/tests/tribol_nodal_nrmls.cpp
+++ b/src/tests/tribol_nodal_nrmls.cpp
@@ -20,7 +20,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup for registering a mesh 
@@ -34,9 +34,9 @@ public:
    int dim;
 
    void computeNodalNormals( int cell_type,
-                             real const * const x, 
-                             real const * const y, 
-                             real const * const z,
+                             RealT const * const x, 
+                             RealT const * const y, 
+                             RealT const * const z,
                              int const * const conn,
                              int const numCells,
                              int const numNodes,
@@ -102,9 +102,9 @@ TEST_F( NodalNormalTest, two_quad_inverted_v )
    conn[7] = 1;
 
    // setup the nodal coordinates of the mesh
-   real x[numNodesPerFace + 2]; 
-   real y[numNodesPerFace + 2]; 
-   real z[numNodesPerFace + 2]; 
+   RealT x[numNodesPerFace + 2]; 
+   RealT y[numNodesPerFace + 2]; 
+   RealT z[numNodesPerFace + 2]; 
 
    x[0] =  0.;
    x[1] =  0.;
@@ -135,26 +135,26 @@ TEST_F( NodalNormalTest, two_quad_inverted_v )
    tribol::MeshData& mesh = meshManager.GetMeshInstance( 0 );
 
    // check each normal...hard coded
-   real n1check = tribol::magnitude( mesh.m_node_nX[0] - 0., 
+   RealT n1check = tribol::magnitude( mesh.m_node_nX[0] - 0., 
                                      mesh.m_node_nY[0] - 0., 
                                      mesh.m_node_nZ[0] - 1. );
-   real n2check = tribol::magnitude( mesh.m_node_nX[1] - 0., 
+   RealT n2check = tribol::magnitude( mesh.m_node_nX[1] - 0., 
                                      mesh.m_node_nY[1] - 0., 
                                      mesh.m_node_nZ[1] - 1. );
-   real n3check = tribol::magnitude( mesh.m_node_nX[2] - (-1./std::sqrt(2.)), 
+   RealT n3check = tribol::magnitude( mesh.m_node_nX[2] - (-1./std::sqrt(2.)), 
                                      mesh.m_node_nY[2] - 0., 
                                      mesh.m_node_nZ[2] - (1./std::sqrt(2.)) );
-   real n4check = tribol::magnitude( mesh.m_node_nX[3] - (-1./std::sqrt(2.)), 
+   RealT n4check = tribol::magnitude( mesh.m_node_nX[3] - (-1./std::sqrt(2.)), 
                                      mesh.m_node_nY[3] - 0., 
                                      mesh.m_node_nZ[3] - (1./std::sqrt(2.)) );
-   real n5check = tribol::magnitude( mesh.m_node_nX[4] - (1./std::sqrt(2.)), 
+   RealT n5check = tribol::magnitude( mesh.m_node_nX[4] - (1./std::sqrt(2.)), 
                                      mesh.m_node_nY[4] - 0., 
                                      mesh.m_node_nZ[4] - (1./std::sqrt(2.)) );
-   real n6check = tribol::magnitude( mesh.m_node_nX[4] - (1./std::sqrt(2.)), 
+   RealT n6check = tribol::magnitude( mesh.m_node_nX[4] - (1./std::sqrt(2.)), 
                                      mesh.m_node_nY[4] - 0., 
                                      mesh.m_node_nZ[4] - (1./std::sqrt(2.)) );
 
-   real tol = 1.e-12;
+   RealT tol = 1.e-12;
 
    EXPECT_LE( n1check, tol );
    EXPECT_LE( n2check, tol );

--- a/src/tests/tribol_quad_integ.cpp
+++ b/src/tests/tribol_quad_integ.cpp
@@ -20,7 +20,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class; some setup is necessary to test the evaluation of 
@@ -34,29 +34,29 @@ public:
    int numNodes;
    int dim;
 
-   real* getXCoords() 
+   RealT* getXCoords() 
    {
       return x;
    }
 
-   real* getYCoords() 
+   RealT* getYCoords() 
    {
       return y;
    }
 
-   real* getZCoords() 
+   RealT* getZCoords() 
    {
       return z;
    }
 
-   bool integrate ( real const tol )
+   bool integrate ( RealT const tol )
    {
-      real xyz[ this->dim * this->numNodes ];
-      real* xy = xyz;
+      RealT xyz[ this->dim * this->numNodes ];
+      RealT* xy = xyz;
 
-      real * x = this->x;
-      real * y = this->y;
-      real * z = this->z;
+      RealT * x = this->x;
+      RealT * y = this->y;
+      RealT * z = this->z;
 
       // generate stacked coordinate array
       for (int j=0; j<this->numNodes; ++j)
@@ -93,14 +93,14 @@ public:
 
       // evaluate sum_a (integral_face (phi_a) da) with outer loop over nodes, a, and 
       // inner loop over number of integration points
-      real areaTest = 0.;
-      real phi = 0.;
+      RealT areaTest = 0.;
+      RealT phi = 0.;
 
       for (int a=0; a<this->numNodes; ++a)
       {
          for (int ip=0; ip<integ.numIPs; ++ip)
          {
-            real xi[2];
+            RealT xi[2];
 
             // access (xi,eta) coordinates. Note that the integration point coordinates 
             // for this method are not using a zeta=0 component. That is, the stride is 2, 
@@ -111,7 +111,7 @@ public:
             tribol::LinIsoQuadShapeFunc( xi[0], xi[1], a, phi );
        
             // compute determinant of the Jacobian of the transformation
-            real dJ;
+            RealT dJ;
             tribol::DetJQuad( xi[0], xi[1], elem.overlapCoords, elem.dim, dJ );
 
             areaTest += integ.wts[ip]*phi*dJ;
@@ -119,7 +119,7 @@ public:
          }
       }
 
-      real area = tribol::Area2DPolygon( x, y, this->numNodes );
+      RealT area = tribol::Area2DPolygon( x, y, this->numNodes );
 
       bool convrg = (std::abs(areaTest - area) <= tol) ? true : false;
   
@@ -136,32 +136,32 @@ protected:
 
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
    }
 
@@ -186,9 +186,9 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
 };
 
@@ -196,9 +196,9 @@ protected:
 TEST_F( IsoIntegTest, square )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -223,9 +223,9 @@ TEST_F( IsoIntegTest, square )
 TEST_F( IsoIntegTest, rect )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -249,9 +249,9 @@ TEST_F( IsoIntegTest, rect )
 
 TEST_F( IsoIntegTest, affine )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -275,9 +275,9 @@ TEST_F( IsoIntegTest, affine )
 
 TEST_F( IsoIntegTest, nonaffine )
 {
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;

--- a/src/tests/tribol_tet_mesh.cpp
+++ b/src/tests/tribol_tet_mesh.cpp
@@ -22,7 +22,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test 
@@ -66,19 +66,19 @@ TEST_F( TetMeshTest, build_and_check_tet_mesh )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshTet( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,
@@ -120,19 +120,19 @@ TEST_F( TetMeshTest, build_and_check_mfem_tet_mesh )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    this->m_mesh.setupContactMeshTet( nElemsXM, nElemsYM, nElemsZM,
                                      x_min1, y_min1, z_min1,

--- a/src/tests/tribol_timestep_vote.cpp
+++ b/src/tests/tribol_timestep_vote.cpp
@@ -31,7 +31,7 @@
 #include <iomanip>
 #include <fstream>
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to test 
@@ -77,23 +77,23 @@ TEST_F( CommonPlaneTest, zero_velocity_small_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 'small' (0.055) interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.005;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.005;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -109,15 +109,15 @@ TEST_F( CommonPlaneTest, zero_velocity_small_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0; // something simple
-   real bulk_mod2 = 1.0; 
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 0.; 
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = 0.; 
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0; // something simple
+   RealT bulk_mod2 = 1.0; 
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 0.; 
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = 0.; 
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -160,23 +160,23 @@ TEST_F( CommonPlaneTest, large_velocity_small_gap_no_api_call )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 'small' (0.055) interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.005;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.005;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -192,16 +192,16 @@ TEST_F( CommonPlaneTest, large_velocity_small_gap_no_api_call )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 100.;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 100.;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -249,23 +249,23 @@ TEST_F( CommonPlaneTest, numerically_zero_velocity_small_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 'small' (0.055) interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.005;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.005;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -281,15 +281,15 @@ TEST_F( CommonPlaneTest, numerically_zero_velocity_small_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0; // something simple
-   real bulk_mod2 = 1.0; 
-   real velX1 = 1.e-12;
-   real velY1 = 1.e-12;
-   real velZ1 = 1.e-12; 
-   real velX2 = -1.e-12;
-   real velY2 = -1.e-12;
-   real velZ2 = -1.e-12; 
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0; // something simple
+   RealT bulk_mod2 = 1.0; 
+   RealT velX1 = 1.e-12;
+   RealT velY1 = 1.e-12;
+   RealT velZ1 = 1.e-12; 
+   RealT velX2 = -1.e-12;
+   RealT velY2 = -1.e-12;
+   RealT velZ2 = -1.e-12; 
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -333,23 +333,23 @@ TEST_F( CommonPlaneTest, zero_velocity_large_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -365,15 +365,15 @@ TEST_F( CommonPlaneTest, zero_velocity_large_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = 0.; 
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = 0.; 
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = 0.; 
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = 0.; 
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -419,23 +419,23 @@ TEST_F( CommonPlaneTest, large_velocity_small_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 'small' (0.055) interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.005;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.005;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -451,16 +451,16 @@ TEST_F( CommonPlaneTest, large_velocity_small_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 100.;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 100.;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -484,8 +484,8 @@ TEST_F( CommonPlaneTest, large_velocity_small_gap )
 
    EXPECT_EQ( test_mesh_update_err, 0 );
 
-   real dt_diff = std::abs(parameters.dt - 0.000997297);
-   real dt_tol = 1.e-8;
+   RealT dt_diff = std::abs(parameters.dt - 0.000997297);
+   RealT dt_tol = 1.e-8;
    EXPECT_LT( dt_diff, dt_tol );
 
    tribol::finalize();
@@ -507,23 +507,23 @@ TEST_F( CommonPlaneTest, large_velocity_large_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.1 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.05;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.05;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -539,16 +539,16 @@ TEST_F( CommonPlaneTest, large_velocity_large_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 100.;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 100.;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -572,8 +572,8 @@ TEST_F( CommonPlaneTest, large_velocity_large_gap )
 
    EXPECT_EQ( test_mesh_update_err, 0 );
 
-   real dt_diff = std::abs(parameters.dt - 2.69841e-06);
-   real dt_tol = 1.e-8;
+   RealT dt_diff = std::abs(parameters.dt - 2.69841e-06);
+   RealT dt_tol = 1.e-8;
    EXPECT_LT( dt_diff, dt_tol );
 
    tribol::finalize();
@@ -595,23 +595,23 @@ TEST_F( CommonPlaneTest, separation_velocity_small_gap )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with 0.055 interpenetration gap
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.005;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.005;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 0.95;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 0.95;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -627,16 +627,16 @@ TEST_F( CommonPlaneTest, separation_velocity_small_gap )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 100.;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 100.;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, -velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, velZ2 ); 
@@ -682,23 +682,23 @@ TEST_F( CommonPlaneTest, large_velocity_separation )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with initial separation
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 2.1;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 3.1;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 2.1;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 3.1;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -714,16 +714,16 @@ TEST_F( CommonPlaneTest, large_velocity_separation )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 10.;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 10.;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -770,23 +770,23 @@ TEST_F( CommonPlaneTest, large_velocity_small_separation )
    int nElemsZS = nNonmortarElems;
 
    // mesh bounding box with initial separation
-   real x_min1 = 0.;
-   real y_min1 = 0.;
-   real z_min1 = 0.; 
-   real x_max1 = 1.;
-   real y_max1 = 1.;
-   real z_max1 = 1.;
+   RealT x_min1 = 0.;
+   RealT y_min1 = 0.;
+   RealT z_min1 = 0.; 
+   RealT x_max1 = 1.;
+   RealT y_max1 = 1.;
+   RealT z_max1 = 1.;
 
-   real x_min2 = 0.;
-   real y_min2 = 0.;
-   real z_min2 = 1.0001;
-   real x_max2 = 1.;
-   real y_max2 = 1.;
-   real z_max2 = 2.0001;
+   RealT x_min2 = 0.;
+   RealT y_min2 = 0.;
+   RealT z_min2 = 1.0001;
+   RealT x_max2 = 1.;
+   RealT y_max2 = 1.;
+   RealT z_max2 = 2.0001;
 
    // compute element thickness for each block
-   real element_thickness1 = (z_max1 - z_min1) / nElemsZM;
-   real element_thickness2 = (z_max2 - z_min2) / nElemsZS;
+   RealT element_thickness1 = (z_max1 - z_min1) / nElemsZM;
+   RealT element_thickness2 = (z_max2 - z_min2) / nElemsZS;
 
    // setup mesh
    this->m_mesh.setupContactMeshHex( nElemsXM, nElemsYM, nElemsZM,
@@ -802,16 +802,16 @@ TEST_F( CommonPlaneTest, large_velocity_small_separation )
    // timestep. This velocity is computed on the high side using the 
    // hardcoded rule that one face cannot interpen the other 
    // exceeding 30% of the other's element thickness.
-   real dt = 1.e-3;
-   real bulk_mod1 = 1.0;
-   real bulk_mod2 = 1.0;
-   real vel_factor = 1.e6;
-   real velX1 = 0.;
-   real velY1 = 0.;
-   real velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
-   real velX2 = 0.;
-   real velY2 = 0.;
-   real velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
+   RealT dt = 1.e-3;
+   RealT bulk_mod1 = 1.0;
+   RealT bulk_mod2 = 1.0;
+   RealT vel_factor = 1.e6;
+   RealT velX1 = 0.;
+   RealT velY1 = 0.;
+   RealT velZ1 = vel_factor * 0.3 * element_thickness1 / dt;
+   RealT velX2 = 0.;
+   RealT velY2 = 0.;
+   RealT velZ2 = vel_factor * 0.3 * element_thickness2 / dt;
 
    this->m_mesh.allocateAndSetVelocities( m_mesh.mortarMeshId, velX1, velY1, velZ1 );
    this->m_mesh.allocateAndSetVelocities( m_mesh.nonmortarMeshId,  velX2, velY2, -velZ2 ); 
@@ -834,8 +834,8 @@ TEST_F( CommonPlaneTest, large_velocity_small_separation )
                                          tribol::FRICTIONLESS, tribol::NO_CASE, false, parameters );
 
    EXPECT_EQ( test_mesh_update_err, 0 );
-   real dt_diff = std::abs(parameters.dt -0.00099999);
-   real dt_tol = 1.e-8;
+   RealT dt_diff = std::abs(parameters.dt -0.00099999);
+   RealT dt_tol = 1.e-8;
    EXPECT_LT( dt_diff, dt_tol );
 
    tribol::finalize();

--- a/src/tests/tribol_twb_integ.cpp
+++ b/src/tests/tribol_twb_integ.cpp
@@ -20,7 +20,7 @@
 // c++ includes
 #include <cmath> // std::abs
 
-using real = tribol::real;
+using RealT = tribol::RealT;
 
 /*!
  * Test fixture class with some setup necessary to use the
@@ -36,29 +36,29 @@ public:
    int numNodes;
    int dim;
 
-   real* getXCoords() 
+   RealT* getXCoords() 
    {
       return x;
    }
 
-   real* getYCoords() 
+   RealT* getYCoords() 
    {
       return y;
    }
 
-   real* getZCoords() 
+   RealT* getZCoords() 
    {
       return z;
    }
 
-   bool integrate( real const tol )
+   bool integrate( RealT const tol )
    {                
-      real xyz[ this->dim * this->numNodes ];
-      real* xy = xyz;
+      RealT xyz[ this->dim * this->numNodes ];
+      RealT* xy = xyz;
 
-      real* x = this->x;
-      real* y = this->y;
-      real* z = this->z;
+      RealT* x = this->x;
+      RealT* y = this->y;
+      RealT* z = this->z;
 
       // generate stacked coordinate array
       for (int j=0; j<this->numNodes; ++j)
@@ -95,8 +95,8 @@ public:
 
       // evaluate sum_a (integral_face (phi_a) da) with outer loop over nodes, a, and 
       // inner loop over number of integration points
-      real areaTest = 0.;
-      real phi = 0.;
+      RealT areaTest = 0.;
+      RealT phi = 0.;
 
       for (int a=0; a<this->numNodes; ++a)
       {
@@ -111,7 +111,7 @@ public:
          }
       }
 
-      real area = tribol::Area2DPolygon( x, y, this->numNodes );
+      RealT area = tribol::Area2DPolygon( x, y, this->numNodes );
 
       bool convrg = (std::abs(areaTest - area) <= tol) ? true : false;
 
@@ -126,32 +126,32 @@ protected:
 
       if (this->x == nullptr)
       {
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->x;
-         this->x = new real [this->numNodes];
+         this->x = new RealT [this->numNodes];
       }
 
       if (this->y == nullptr)
       {
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->y;
-         this->y = new real [this->numNodes];
+         this->y = new RealT [this->numNodes];
       }
 
       if (this->z == nullptr)
       {
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
       else
       {
          delete [] this->z;
-         this->z = new real [this->numNodes];
+         this->z = new RealT [this->numNodes];
       }
    }
 
@@ -176,9 +176,9 @@ protected:
 
 protected:
 
-   real* x {nullptr};
-   real* y {nullptr};
-   real* z {nullptr};
+   RealT* x {nullptr};
+   RealT* y {nullptr};
+   RealT* z {nullptr};
 
 };
 
@@ -186,9 +186,9 @@ protected:
 TEST_F( TWBIntegTest, square_wachspress_basis )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -213,9 +213,9 @@ TEST_F( TWBIntegTest, square_wachspress_basis )
 TEST_F( TWBIntegTest, rect_wachspress_basis )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;
@@ -239,9 +239,9 @@ TEST_F( TWBIntegTest, rect_wachspress_basis )
 TEST_F( TWBIntegTest, nonaffine_wachspress_basis )
 {
 
-   real* x = this->getXCoords();
-   real* y = this->getYCoords();
-   real* z = this->getZCoords();
+   RealT* x = this->getXCoords();
+   RealT* y = this->getYCoords();
+   RealT* z = this->getZCoords();
 
    x[0] = -0.5;
    x[1] =  0.5;

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -10,7 +10,6 @@
 #include "tribol/types.hpp"
 
 #include <string>
-#include <iostream>
 
 namespace tribol
 {
@@ -20,7 +19,7 @@ namespace
 {
 
 //------------------------------------------------------------------------------
-inline bool in_range( integer target, integer N )
+inline bool in_range( int target, int N )
 {
   // NOTE: assumes indexing starts from 0
   return( (target >= 0) && ( target < N ) );
@@ -28,7 +27,7 @@ inline bool in_range( integer target, integer N )
 
 } // end anonymous namespace
 
-constexpr integer ANY_MESH = -1;
+constexpr int ANY_MESH = -1;
 
 /*!
  * \brief Enumerates the logging level options
@@ -144,6 +143,7 @@ enum BinningMethod
 {
   BINNING_GRID,               ///! Uses a spatial index to compute the pairs
   BINNING_CARTESIAN_PRODUCT,  ///! Generates all element pairs between the meshes
+  BINNING_BVH,                ///! Uses a bounding volume hierarchy tree to compute the pairs
   NUM_BINNING_METHODS,
   DEFAULT_BINNING_METHOD = BINNING_GRID
 };
@@ -261,7 +261,7 @@ enum class SparseMode
 {
    MFEM_INDEX_SET,     ///! initialize mfem sparse matrix with I, J, and data
    MFEM_LINKED_LIST,   ///! initialize mfem sparse matrix with flexible, linked list option
-   MFEM_ELEMENT_DENSE  ///! Stores element Jacobian contributions in an axom::Array of mfem::DenseMatrixs
+   MFEM_ELEMENT_DENSE  ///! Stores element Jacobian contributions in an ArrayT of mfem::DenseMatrixs
 };
 
 /*!
@@ -402,6 +402,16 @@ enum EnforcementInfo
 };
 
 /*!
+ * \brief Enumerates the available loop execution modes
+ */
+enum class LoopExecMode
+{
+   SEQUENTIAL,                 ///! Execute serial (single-threaded) loops on CPU
+   CUDA_PARALLEL,              ///! Execute parallel loops on GPU using CUDA
+   OPENMP_PARALLEL             ///! Execute parallel loops on CPU using OpenMP
+};
+
+/*!
  * \brief Struct to hold Lagrange multiplier enforcement and implicit evaluation options
  */
 struct LagrangeMultiplierImplicitOptions
@@ -443,8 +453,8 @@ public:
    bool kinematic_calc_set  {false};
    bool rate_calc_set       {false};
 
-   double tiny_length   {1.e-12}; ///! Small length to avoid division by zero
-   double tiny_penalty  {1.e-12}; ///! Small penalty to avoid division by zero
+   RealT tiny_length   {1.e-12}; ///! Small length to avoid division by zero
+   RealT tiny_penalty  {1.e-12}; ///! Small penalty to avoid division by zero
 };
 
 /*!
@@ -480,24 +490,26 @@ struct parameters_t
   // disable move
   parameters_t( parameters_t&& ) = delete;
 
-  integer dimension;             ///! Spatial dimension of the problem
-  CommType problem_comm;         ///! MPI communicator for the problem
+  int dimension;             ///! Spatial dimension of the problem
+  CommT problem_comm;         ///! MPI communicator for the problem
 
-  double overlap_area_frac;      ///! Ratio of overlap area to largest face area for contact inclusion
-  double gap_tol_ratio;          ///! Ratio for determining tolerance for active contact gaps 
-  double gap_separation_ratio;   ///! Ratio for determining allowable separation in geometric filtering
-  double gap_tied_tol;           ///! Ratio for determining max separation tied contact can support
-  double len_collapse_ratio;     ///! Ratio of face length providing topology collapse length tolerance
-  double projection_ratio;       ///! Ratio for defining nonzero projections
-  double auto_contact_pen_frac;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
-  double timestep_pen_frac;      ///! Max allowable interpenetration as percent of element thickness prior to triggering timestep vote
+  RealT overlap_area_frac;      ///! Ratio of overlap area to largest face area for contact inclusion
+  RealT gap_tol_ratio;          ///! Ratio for determining tolerance for active contact gaps 
+  RealT gap_separation_ratio;   ///! Ratio for determining allowable separation in geometric filtering
+  RealT gap_tied_tol;           ///! Ratio for determining max separation tied contact can support
+  RealT len_collapse_ratio;     ///! Ratio of face length providing topology collapse length tolerance
+  RealT projection_ratio;       ///! Ratio for defining nonzero projections
+  RealT auto_contact_pen_frac;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
+  RealT timestep_pen_frac;      ///! Max allowable interpenetration as percent of element thickness prior to triggering timestep vote
+
+  LoopExecMode exec_mode;        ///! mode for loop execution
 
   int vis_cycle_incr;            ///! Frequency for visualizations dumps
   VisType vis_type;              ///! Type of interface physics visualization output
   std::string output_directory;  ///! Output directory for visualization dumps
   bool enable_timestep_vote;     ///! True if host-code desires the timestep vote to be calculated and returned
 
-  double auto_contact_len_scale_factor; ///! Sacle factor applied to element thickness for auto contact length scale
+  RealT auto_contact_len_scale_factor; ///! Sacle factor applied to element thickness for auto contact length scale
   bool auto_interpen_check;             ///! True if the auto-contact interpenetration check is used for full-overlap pairs
 
 private:
@@ -507,7 +519,7 @@ private:
 
 };
 
-} /* end namespace tribol */
+} // namespace tribol
 
 
 #endif /* TRIBOL_PARAMETERS_HPP_ */

--- a/src/tribol/common/types.hpp.in
+++ b/src/tribol/common/types.hpp.in
@@ -6,17 +6,17 @@
 #ifndef TRIBOL_TYPES_HPP_
 #define TRIBOL_TYPES_HPP_
 
+#include <axom/core/Types.hpp>
 #include <cstdint>
 #include <vector>
 
-#include "axom/config.hpp"
-#include "axom/core/Macros.hpp"
+#include "axom/core.hpp"
 
 #cmakedefine TRIBOL_USE_SINGLE_PRECISION
-#cmakedefine TRIBOL_USE_64BIT_INDEXTYPE
 #cmakedefine TRIBOL_DATA_DIR "@TRIBOL_DATA_DIR@"
 #cmakedefine TRIBOL_USE_MPI
 #cmakedefine TRIBOL_USE_UMPIRE
+#cmakedefine TRIBOL_USE_RAJA
 #cmakedefine BUILD_REDECOMP
 
 #ifdef TRIBOL_USE_MPI
@@ -27,39 +27,45 @@ namespace tribol
 {
 
 #ifdef TRIBOL_USE_MPI
-using CommType = MPI_Comm;
+
+using CommT = MPI_Comm;
 #define TRIBOL_COMM_WORLD MPI_COMM_WORLD
 #define TRIBOL_COMM_NULL MPI_COMM_NULL
+
 #else
-using CommType = int;
+
+using CommT = int;
 #define TRIBOL_COMM_WORLD 0
 #define TRIBOL_COMM_NULL -1
+
 #endif
 
-using integer = int;
-
-template<typename T>
-using array = T*;
-
-#ifdef TRIBOL_USE_64BIT_INDEXTYPE
-using IndexType = std::int64_t;
-#else
-using IndexType = std::int32_t;
-#endif
+// match index type used in axom (since data is held in axom data structures)
+using IndexT = axom::IndexType;
 
 #ifdef TRIBOL_USE_SINGLE_PRECISION
-using real = float;
+
+#error "Tribol does not support single precision."
+using RealT = float;
+
 #else
-using real= double;
+
+using RealT = double;
+
 #endif
 
-template< typename T >
-using containerArray = std::vector<T>;
+template< typename T, int DIM = 1, axom::MemorySpace SPACE = axom::MemorySpace::Dynamic >
+using ArrayT = axom::Array<T, DIM, SPACE>;
+
+constexpr int MAX_NUM_POLY_VERT = 16;     ///< Maximum allowed number of polygon vertices per contact plane
+constexpr int MAX_NUM_CELL_NODES = 8;     ///< Maximum allowed number of nodes per cell
 
 #if defined(__clang__)  
   #define RESTRICT __restrict__
   #define RESTRICT_THIS
-  #define CONSTEXPRFUNC constexpr  
+  #ifndef CONSTEXPRFUNC  
+    #define CONSTEXPRFUNC constexpr  
+  #endif
 #elif defined(__GNUC__)  
   #if defined(__INTEL_COMPILER)
     #define RESTRICT __restrict__
@@ -79,6 +85,6 @@ using containerArray = std::vector<T>;
 #define TRIBOL_UNUSED_VAR AXOM_UNUSED_VAR
 #define TRIBOL_UNUSED_PARAM AXOM_UNUSED_PARAM
 
-} 
+} // namespace tribol
 
-#endif // TRIBOL_TYPES_HPP_
+#endif /* TRIBOL_TYPES_HPP_ */

--- a/src/tribol/geom/ContactPlane.cpp
+++ b/src/tribol/geom/ContactPlane.cpp
@@ -53,8 +53,8 @@ FaceGeomError CheckInterfacePair( InterfacePair& pair,
          const bool full = (cMethod == COMMON_PLANE) ? false : true;
          const bool interpenOverlap = (full) ? false : true;
          const bool intermediatePlane = (cMethod == COMMON_PLANE) ? true : false;
-         real lenFrac = params.overlap_area_frac;
-         real areaFrac = lenFrac;
+         RealT lenFrac = params.overlap_area_frac;
+         RealT areaFrac = lenFrac;
 
          // Perform contact plane specific computations (2D and 3D)
          if (params.dimension == 3)
@@ -147,7 +147,7 @@ FaceGeomError CheckInterfacePair( InterfacePair& pair,
 
 //------------------------------------------------------------------------------
 bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2, 
-                     int fId1, int fId2, real tol, bool& allVerts )
+                     int fId1, int fId2, RealT tol, bool& allVerts )
 {
    bool check = false;
    allVerts = false;
@@ -160,12 +160,12 @@ bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
       const int f2NodeId = meshDat2.getFaceNodeId(fId2, i);
 
       // compute components of vector between face 1 center and face 2 vertex
-      real vX = meshDat1.m_cX[fId1] - meshDat2.m_positionX[f2NodeId];
-      real vY = meshDat1.m_cY[fId1] - meshDat2.m_positionY[f2NodeId];
-      real vZ = meshDat1.m_cZ[fId1] - meshDat2.m_positionZ[f2NodeId];
+      RealT vX = meshDat1.m_cX[fId1] - meshDat2.m_positionX[f2NodeId];
+      RealT vY = meshDat1.m_cY[fId1] - meshDat2.m_positionY[f2NodeId];
+      RealT vZ = meshDat1.m_cZ[fId1] - meshDat2.m_positionZ[f2NodeId];
 
       // project the vector onto face 1 normal
-      real proj = vX * meshDat1.m_nX[fId1] + vY * meshDat1.m_nY[fId1] 
+      RealT proj = vX * meshDat1.m_nX[fId1] + vY * meshDat1.m_nY[fId1] 
                 + vZ * meshDat1.m_nZ[fId1];
 
       // if a node of face 2 is on the other side of the plane defined by face 1 the 
@@ -209,12 +209,12 @@ bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
       const int f1NodeId = meshDat1.getFaceNodeId(fId1, i);
   
       // compute the components of vector between face 2 center and face 1 vertex
-      real vX = meshDat2.m_cX[fId2] - meshDat1.m_positionX[f1NodeId];
-      real vY = meshDat2.m_cY[fId2] - meshDat1.m_positionY[f1NodeId];
-      real vZ = meshDat2.m_cZ[fId2] - meshDat1.m_positionZ[f1NodeId];
+      RealT vX = meshDat2.m_cX[fId2] - meshDat1.m_positionX[f1NodeId];
+      RealT vY = meshDat2.m_cY[fId2] - meshDat1.m_positionY[f1NodeId];
+      RealT vZ = meshDat2.m_cZ[fId2] - meshDat1.m_positionZ[f1NodeId];
 
       // project the vector onto face 2 normal
-      real proj = vX * meshDat2.m_nX[fId2] + vY * meshDat2.m_nY[fId2] 
+      RealT proj = vX * meshDat2.m_nX[fId2] + vY * meshDat2.m_nY[fId2] 
                 + vZ * meshDat2.m_nZ[fId2];
 
       // if a node of face 1 is on the other side of the plane defined by face 2 the 
@@ -240,7 +240,7 @@ bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
 
 //------------------------------------------------------------------------------
 bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2, 
-                     int eId1, int eId2, real tol, bool& allVerts )
+                     int eId1, int eId2, RealT tol, bool& allVerts )
 {
    bool check = false;
    allVerts = false;
@@ -253,11 +253,11 @@ bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
       const int e2vId = meshDat2.getFaceNodeId( eId2, i );
    
       // compute components of vector between edge 1 center and edge 2 vertex
-      real vX = meshDat1.m_cX[eId1] - meshDat2.m_positionX[e2vId];
-      real vY = meshDat1.m_cY[eId1] - meshDat2.m_positionY[e2vId];
+      RealT vX = meshDat1.m_cX[eId1] - meshDat2.m_positionX[e2vId];
+      RealT vY = meshDat1.m_cY[eId1] - meshDat2.m_positionY[e2vId];
 
       // project the vector onto edge1 normal
-      real proj = vX * meshDat1.m_nX[eId1] + vY * meshDat1.m_nY[eId1];
+      RealT proj = vX * meshDat1.m_nX[eId1] + vY * meshDat1.m_nY[eId1];
 
       // check projection against tolerance
       if (proj > -tol)
@@ -282,11 +282,11 @@ bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
       const int e1vId = meshDat1.getFaceNodeId( eId1, i );
  
       // compute components of vector between edge 2 center and edge 1 vertex
-      real vX = meshDat2.m_cX[eId2] - meshDat1.m_positionX[e1vId];
-      real vY = meshDat2.m_cY[eId2] - meshDat1.m_positionY[e1vId];
+      RealT vX = meshDat2.m_cX[eId2] - meshDat1.m_positionX[e1vId];
+      RealT vY = meshDat2.m_cY[eId2] - meshDat1.m_positionY[e1vId];
 
       // project the vector onto edge2 normal
-      real proj = vX * meshDat2.m_nX[eId2] + vY * meshDat2.m_nY[eId2];
+      RealT proj = vX * meshDat2.m_nX[eId2] + vY * meshDat2.m_nY[eId2];
 
       // check projection against tolerance
       if (proj > -tol)
@@ -305,12 +305,12 @@ bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
 
 //------------------------------------------------------------------------------
 bool ExceedsMaxAutoInterpen( const MeshData& meshDat1, const MeshData& meshDat2,
-                             const int faceId1, const int faceId2, const real gap )
+                             const int faceId1, const int faceId2, const RealT gap )
 {
    parameters_t& params = parameters_t::getInstance();
    if (params.auto_interpen_check)
    {
-      real max_interpen = -1. * params.auto_contact_pen_frac * 
+      RealT max_interpen = -1. * params.auto_contact_pen_frac * 
                           axom::utilities::min( meshDat1.m_elemData.m_thickness[ faceId1 ],
                                                 meshDat2.m_elemData.m_thickness[ faceId2 ] );
 
@@ -324,10 +324,10 @@ bool ExceedsMaxAutoInterpen( const MeshData& meshDat1, const MeshData& meshDat2,
 
 //------------------------------------------------------------------------------
 void ProjectFaceNodesToPlane( const MeshData& mesh, int faceId, 
-                              real nrmlX, real nrmlY, real nrmlZ,
-                              real cX, real cY, real cZ,
-                              real* RESTRICT pX, real* RESTRICT pY, 
-                              real* RESTRICT pZ )
+                              RealT nrmlX, RealT nrmlY, RealT nrmlZ,
+                              RealT cX, RealT cY, RealT cZ,
+                              RealT* RESTRICT pX, RealT* RESTRICT pY, 
+                              RealT* RESTRICT pZ )
 {
 
    // loop over nodes and project onto the plane defined by the point-normal 
@@ -345,9 +345,9 @@ void ProjectFaceNodesToPlane( const MeshData& mesh, int faceId,
 
 //------------------------------------------------------------------------------
 void ProjectEdgeNodesToSegment( const MeshData& mesh, int edgeId, 
-                                real nrmlX, real nrmlY, real cX, 
-                                real cY, real* RESTRICT pX, 
-                                real* RESTRICT pY )
+                                RealT nrmlX, RealT nrmlY, RealT cX, 
+                                RealT cY, RealT* RESTRICT pX, 
+                                RealT* RESTRICT pY )
 {
    for (int i=0; i<mesh.m_numNodesPerCell; ++i)
    {
@@ -362,7 +362,7 @@ void ProjectEdgeNodesToSegment( const MeshData& mesh, int edgeId,
 //-----------------------------------------------------------------------------
 // 3D contact plane member functions
 //-----------------------------------------------------------------------------
-ContactPlane3D::ContactPlane3D( InterfacePair& pair, real areaFrac, 
+ContactPlane3D::ContactPlane3D( InterfacePair& pair, RealT areaFrac, 
                                 bool interpenOverlap, bool interPlane, 
                                 int dimension )
 {
@@ -524,10 +524,10 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    parameters_t& params = parameters_t::getInstance();
 
    // alias variables off the InterfacePair. 
-   IndexType& meshId1 = pair.meshId1;
-   IndexType& meshId2 = pair.meshId2;
-   IndexType& faceId1 = pair.pairIndex1;
-   IndexType& faceId2 = pair.pairIndex2;
+   IndexT& meshId1 = pair.meshId1;
+   IndexT& meshId2 = pair.meshId2;
+   IndexT& faceId1 = pair.pairIndex1;
+   IndexT& faceId2 = pair.pairIndex2;
   
    // get instance of mesh manager
    MeshManager & meshManager = MeshManager::getInstance();
@@ -543,7 +543,7 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    // plane defined by face1 AND vice-versa. For proximate faces 
    // that pass check #3 this check may easily indicate that the faces 
    // do in fact intersect. 
-   real separationTol = params.gap_separation_ratio * 
+   RealT separationTol = params.gap_separation_ratio * 
                         axom::utilities::max( mesh1.m_faceRadius[ faceId1 ], 
                                               mesh2.m_faceRadius[ faceId2 ] );
    bool all = false;
@@ -574,12 +574,12 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    // The mortar face may not be exactly planar so we still need to project 
    // the nodes onto the contact plane, which is defined by average normal of the 
    // nonmortar face.
-   real projX1[ mesh1.m_numNodesPerCell ];
-   real projY1[ mesh1.m_numNodesPerCell ];
-   real projZ1[ mesh1.m_numNodesPerCell ];
-   real projX2[ mesh2.m_numNodesPerCell ];
-   real projY2[ mesh2.m_numNodesPerCell ];
-   real projZ2[ mesh2.m_numNodesPerCell ];
+   RealT projX1[ mesh1.m_numNodesPerCell ];
+   RealT projY1[ mesh1.m_numNodesPerCell ];
+   RealT projZ1[ mesh1.m_numNodesPerCell ];
+   RealT projX2[ mesh2.m_numNodesPerCell ];
+   RealT projY2[ mesh2.m_numNodesPerCell ];
+   RealT projZ2[ mesh2.m_numNodesPerCell ];
     
    ProjectFaceNodesToPlane( mesh1, faceId1, cp.m_nX, cp.m_nY, cp.m_nZ, 
                             cp.m_cX, cp.m_cY, cp.m_cZ, 
@@ -593,10 +593,10 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
 
    // project the projected global nodal coordinates onto local 
    // contact plane 2D coordinate system. 
-   real projeX1[ mesh1.m_numNodesPerCell ];
-   real projeY1[ mesh1.m_numNodesPerCell ];
-   real projeX2[ mesh2.m_numNodesPerCell ];
-   real projeY2[ mesh2.m_numNodesPerCell ];
+   RealT projeX1[ mesh1.m_numNodesPerCell ];
+   RealT projeY1[ mesh1.m_numNodesPerCell ];
+   RealT projeX2[ mesh2.m_numNodesPerCell ];
+   RealT projeY2[ mesh2.m_numNodesPerCell ];
 
    cp.globalTo2DLocalCoords( &projX1[0], &projY1[0], &projZ1[0], 
                              &projeX1[0], &projeY1[0], 
@@ -631,10 +631,10 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    if (fullOverlap)
    {
       // compute the full intersection polygon vertex coordinates
-      real* X1 = &projeX1[0];
-      real* Y1 = &projeY1[0];
-      real* X2 = &projeX2[0];
-      real* Y2 = &projeY2[0];
+      RealT* X1 = &projeX1[0];
+      RealT* Y1 = &projeY1[0];
+      RealT* X2 = &projeX2[0];
+      RealT* Y2 = &projeY2[0];
  
       // assuming each face's vertices are ordered WRT that face's outward unit normal,
       // reorder face 2 vertices to be consistent with face 1. DO NOT CALL POLYREORDER() 
@@ -645,10 +645,10 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
       // compute intersection polygon and area. Note, the polygon centroid 
       // is stored from the previous intersection calc that just computes 
       // area and local centroid
-      real pos_tol = params.len_collapse_ratio * 
+      RealT pos_tol = params.len_collapse_ratio * 
                      axom::utilities::max( mesh1.m_faceRadius[ faceId1 ], 
                                            mesh2.m_faceRadius[ faceId2 ] );
-      real len_tol = pos_tol;
+      RealT len_tol = pos_tol;
       FaceGeomError inter_err = Intersection2DPolygon( X1, Y1, mesh1.m_numNodesPerCell,
                                                        X2, Y2, mesh2.m_numNodesPerCell,
                                                        pos_tol, len_tol, &cp.m_polyLocX, 
@@ -705,7 +705,7 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
       cp.m_area = cp.m_interpenArea;
 
       // compute the local vertex averaged centroid of overlapping polygon
-      real z;
+      RealT z;
       VertexAvgCentroid( cp.m_polyLocX, cp.m_polyLocY, nullptr, 
                          cp.m_numPolyVert, cp.m_overlapCX, 
                          cp.m_overlapCY, z );
@@ -732,9 +732,9 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
 
    // Tranform local vertex coordinates to global coordinates for the 
    // current projection of the polygonal overlap
-   cp.m_polyX = new real[ cp.m_numPolyVert ];
-   cp.m_polyY = new real[ cp.m_numPolyVert ];
-   cp.m_polyZ = new real[ cp.m_numPolyVert ];
+   cp.m_polyX = new RealT[ cp.m_numPolyVert ];
+   cp.m_polyY = new RealT[ cp.m_numPolyVert ];
+   cp.m_polyZ = new RealT[ cp.m_numPolyVert ];
 
    for (int i=0; i<cp.m_numPolyVert; ++i)
    {
@@ -755,9 +755,9 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
    // current polygonal overlap
    if (interpenOverlap)
    {
-      cp.m_interpenG1X = new real[ cp.m_numInterpenPoly1Vert ];
-      cp.m_interpenG1Y = new real[ cp.m_numInterpenPoly1Vert ];
-      cp.m_interpenG1Z = new real[ cp.m_numInterpenPoly1Vert ];
+      cp.m_interpenG1X = new RealT[ cp.m_numInterpenPoly1Vert ];
+      cp.m_interpenG1Y = new RealT[ cp.m_numInterpenPoly1Vert ];
+      cp.m_interpenG1Z = new RealT[ cp.m_numInterpenPoly1Vert ];
       for (int i=0; i<cp.m_numInterpenPoly1Vert; ++i)
       {
          Local2DToGlobalCoords( cp.m_interpenPoly1X[i], 
@@ -770,9 +770,9 @@ FaceGeomError CheckFacePair( InterfacePair& pair,
 
       }
 
-      cp.m_interpenG2X = new real[ cp.m_numInterpenPoly2Vert ];
-      cp.m_interpenG2Y = new real[ cp.m_numInterpenPoly2Vert ];
-      cp.m_interpenG2Z = new real[ cp.m_numInterpenPoly2Vert ];
+      cp.m_interpenG2X = new RealT[ cp.m_numInterpenPoly2Vert ];
+      cp.m_interpenG2Y = new RealT[ cp.m_numInterpenPoly2Vert ];
+      cp.m_interpenG2Z = new RealT[ cp.m_numInterpenPoly2Vert ];
       for (int i=0; i<cp.m_numInterpenPoly2Vert; ++i)
       {
          Local2DToGlobalCoords( cp.m_interpenPoly2X[i], 
@@ -859,13 +859,13 @@ ContactPlane3D CheckAlignedFacePair( InterfacePair& pair )
    parameters_t& params = parameters_t::getInstance();
 
    // get fraction of largest face we keep for overlap area
-   real areaFrac = params.overlap_area_frac;
+   RealT areaFrac = params.overlap_area_frac;
 
    // alias variables off the InterfacePair. 
-   IndexType& meshId1 = pair.meshId1;
-   IndexType& meshId2 = pair.meshId2;
-   IndexType& faceId1 = pair.pairIndex1;
-   IndexType& faceId2 = pair.pairIndex2;
+   IndexT& meshId1 = pair.meshId1;
+   IndexT& meshId2 = pair.meshId2;
+   IndexT& faceId1 = pair.pairIndex1;
+   IndexT& faceId2 = pair.pairIndex2;
   
    // get instance of mesh manager
    MeshManager & meshManager = MeshManager::getInstance();
@@ -911,15 +911,15 @@ ContactPlane3D CheckAlignedFacePair( InterfacePair& pair )
 
    // compute the vector centroid gap and scalar centroid gap to 
    // check the alignment criterion AND gap
-   real gapVecX =  mesh2.m_cX[faceId2] - mesh1.m_cX[faceId1]; 
-   real gapVecY =  mesh2.m_cY[faceId2] - mesh1.m_cY[faceId1];
-   real gapVecZ =  mesh2.m_cZ[faceId2] - mesh1.m_cZ[faceId1];
+   RealT gapVecX =  mesh2.m_cX[faceId2] - mesh1.m_cX[faceId1]; 
+   RealT gapVecY =  mesh2.m_cY[faceId2] - mesh1.m_cY[faceId1];
+   RealT gapVecZ =  mesh2.m_cZ[faceId2] - mesh1.m_cZ[faceId1];
 
-   real scalarGap = ( mesh2.m_cX[faceId2] - mesh1.m_cX[faceId1] ) * cp.m_nX + 
+   RealT scalarGap = ( mesh2.m_cX[faceId2] - mesh1.m_cX[faceId1] ) * cp.m_nX + 
                     ( mesh2.m_cY[faceId2] - mesh1.m_cY[faceId1] ) * cp.m_nY +
                     ( mesh2.m_cZ[faceId2] - mesh1.m_cZ[faceId1] ) * cp.m_nZ;
 
-   real gapVecMag = magnitude( gapVecX, gapVecY, gapVecZ );
+   RealT gapVecMag = magnitude( gapVecX, gapVecY, gapVecZ );
 
    if (gapVecMag > 1.1*std::abs(scalarGap)) 
    {
@@ -948,9 +948,9 @@ ContactPlane3D CheckAlignedFacePair( InterfacePair& pair )
 
    // if we are here we have contact between two aligned faces
    cp.m_numPolyVert = mesh1.m_numNodesPerCell;
-   cp.m_polyX = new real[ cp.m_numPolyVert ];
-   cp.m_polyY = new real[ cp.m_numPolyVert ];
-   cp.m_polyZ = new real[ cp.m_numPolyVert ];
+   cp.m_polyX = new RealT[ cp.m_numPolyVert ];
+   cp.m_polyY = new RealT[ cp.m_numPolyVert ];
+   cp.m_polyZ = new RealT[ cp.m_numPolyVert ];
 
    for (int a=0; a<cp.m_numPolyVert; ++a)
    {
@@ -980,8 +980,8 @@ void ContactPlane3D::computeNormal()
    MeshData& m1 = getCpMeshData( m_pair.meshId1 );
    MeshData& m2 = getCpMeshData( m_pair.meshId2 );
 
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
 
    if (m_intermediatePlane)
    {
@@ -1004,8 +1004,8 @@ void ContactPlane3D::computeNormal()
    }
 
    // normalize the cp normal
-   real mag = magnitude( m_nX, m_nY, m_nZ );
-   real invMag = 1.0 / mag;
+   RealT mag = magnitude( m_nX, m_nY, m_nZ );
+   RealT invMag = 1.0 / mag;
 
    m_nX *= invMag;
    m_nY *= invMag;
@@ -1024,8 +1024,8 @@ void ContactPlane3D::computePlanePoint()
 
    // compute the cp centroid as the average of the two face's centers. 
    // This is the default method of computing the cp centroid
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
 
 
    // INTERMEDIATE (I.E. COMMON) PLANE point calculation:
@@ -1061,7 +1061,7 @@ void ContactPlane3D::computeLocalBasis()
    const int nodeId = m1.getFaceNodeId(m_pair.pairIndex1, 0);
 
    // project to plane
-   real pX, pY, pZ;
+   RealT pX, pY, pZ;
    ProjectPointToPlane( m1.m_positionX[nodeId],
                         m1.m_positionY[nodeId],
                         m1.m_positionZ[nodeId],
@@ -1070,17 +1070,17 @@ void ContactPlane3D::computeLocalBasis()
 
    // check the square of the magnitude of the first basis vector to 
    // catch the case where pX = m_cX and so on.
-   real sqrMag = m_e1X * m_e1X + m_e1Y * m_e1Y + m_e1Z * m_e1Z;
+   RealT sqrMag = m_e1X * m_e1X + m_e1Y * m_e1Y + m_e1Z * m_e1Z;
 
    if (sqrMag < 1.E-12) // note: tolerance on the square of the magnitude
    {
       // translate projected first node by face radius
-      real radius = m1.m_faceRadius[ m_pair.pairIndex1 ];
-      real scale = 1.0 * radius;
+      RealT radius = m1.m_faceRadius[ m_pair.pairIndex1 ];
+      RealT scale = 1.0 * radius;
    
-      real pNewX = pX + scale;
-      real pNewY = pY + scale;
-      real pNewZ = pZ + scale;
+      RealT pNewX = pX + scale;
+      RealT pNewY = pY + scale;
+      RealT pNewZ = pZ + scale;
 
       // project point onto contact plane
       ProjectPointToPlane( pNewX, pNewY, pNewZ,
@@ -1094,8 +1094,8 @@ void ContactPlane3D::computeLocalBasis()
    }
 
    // recompute the magnitude
-   real mag = magnitude( m_e1X, m_e1Y, m_e1Z );
-   real invMag = 1.0 / mag;
+   RealT mag = magnitude( m_e1X, m_e1Y, m_e1Z );
+   RealT invMag = 1.0 / mag;
 
    // normalize the first basis vector 
    m_e1X *= invMag;
@@ -1126,18 +1126,18 @@ void ContactPlane3D::computeLocalBasis()
 } // end ContactPlane3D::computeLocalBasis()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::globalTo2DLocalCoords( real* RESTRICT pX, real* RESTRICT pY, 
-                                            real* RESTRICT pZ, real* RESTRICT pLX, 
-                                            real* RESTRICT pLY, int size )
+void ContactPlane3D::globalTo2DLocalCoords( RealT* RESTRICT pX, RealT* RESTRICT pY, 
+                                            RealT* RESTRICT pZ, RealT* RESTRICT pLX, 
+                                            RealT* RESTRICT pLY, int size )
 {
 
    // loop over projected nodes
    for (int i=0; i<size; ++i) {
 
       // compute the vector between the point on the plane and the contact plane point
-      real vX = pX[i] - m_cX;
-      real vY = pY[i] - m_cY;
-      real vZ = pZ[i] - m_cZ;
+      RealT vX = pX[i] - m_cX;
+      RealT vY = pY[i] - m_cY;
+      RealT vZ = pZ[i] - m_cZ;
 
       // project this vector onto the {e1,e2} local basis. This vector is 
       // in the plane so the out-of-plane component should be zero.
@@ -1151,13 +1151,13 @@ void ContactPlane3D::globalTo2DLocalCoords( real* RESTRICT pX, real* RESTRICT pY
 } // end ContactPlane3D::globalTo2DLocalCoords()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::globalTo2DLocalCoords( real pX, real pY, real pZ,
-                                            real& pLX, real& pLY, int TRIBOL_UNUSED_PARAM(size) )
+void ContactPlane3D::globalTo2DLocalCoords( RealT pX, RealT pY, RealT pZ,
+                                            RealT& pLX, RealT& pLY, int TRIBOL_UNUSED_PARAM(size) )
 {
    // compute the vector between the point on the plane and the contact plane point
-   real vX = pX - m_cX;
-   real vY = pY - m_cY;
-   real vZ = pZ - m_cZ;
+   RealT vX = pX - m_cX;
+   RealT vY = pY - m_cY;
+   RealT vZ = pZ - m_cZ;
 
    // project this vector onto the {e1,e2} local basis. This vector is 
    // in the plane so the out-of-plane component should be zero.
@@ -1171,7 +1171,6 @@ void ContactPlane3D::globalTo2DLocalCoords( real pX, real pY, real pZ,
 //------------------------------------------------------------------------------
 void ContactPlane3D::computeAreaTol()
 {
-
    parameters_t & parameters = parameters_t::getInstance();
 
    if (m_areaFrac < parameters.overlap_area_frac ) {
@@ -1192,16 +1191,16 @@ void ContactPlane3D::computeAreaTol()
 } // end ContactPlane3D::computeAreaTol()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::checkPolyOverlap( real* RESTRICT projLocX1, real* RESTRICT projLocY1, 
-                                       real* RESTRICT projLocX2, real* RESTRICT projLocY2, 
+void ContactPlane3D::checkPolyOverlap( RealT* RESTRICT projLocX1, RealT* RESTRICT projLocY1, 
+                                       RealT* RESTRICT projLocX2, RealT* RESTRICT projLocY2, 
                                        const int isym )
 {
    MeshData& mesh1 = getCpMeshData( m_pair.meshId1 );
    MeshData& mesh2 = getCpMeshData( m_pair.meshId2 );
 
    // change the vertex ordering of one of the faces so that the two match
-   real x2Temp[ mesh2.m_numNodesPerCell ];
-   real y2Temp[ mesh2.m_numNodesPerCell ];
+   RealT x2Temp[ mesh2.m_numNodesPerCell ];
+   RealT y2Temp[ mesh2.m_numNodesPerCell ];
 
    // set first vertex coordinates the same
    x2Temp[0] = projLocX2[0];
@@ -1237,15 +1236,15 @@ void ContactPlane3D::computeIntegralGap()
 } // end ContactPlane3D::computeIntegralGap()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::local2DToGlobalCoords( real xloc, real yloc, 
-                                            real& xg, real& yg, real& zg )
+void ContactPlane3D::local2DToGlobalCoords( RealT xloc, RealT yloc, 
+                                            RealT& xg, RealT& yg, RealT& zg )
 {
    // This projection takes the two input local vector components and uses 
    // them as coefficients in a linear combination of local basis vectors. 
    // This gives a 3-vector with origin at the contact plane centroid.
-   real vx = xloc * m_e1X + yloc * m_e2X;
-   real vy = xloc * m_e1Y + yloc * m_e2Y;
-   real vz = xloc * m_e1Z + yloc * m_e2Z;
+   RealT vx = xloc * m_e1X + yloc * m_e2X;
+   RealT vy = xloc * m_e1Y + yloc * m_e2Y;
+   RealT vz = xloc * m_e1Z + yloc * m_e2Z;
 
    // the vector in the global coordinate system requires the addition of the 
    // contact plane point vector (in global Cartesian basis) to the previously 
@@ -1259,20 +1258,20 @@ void ContactPlane3D::local2DToGlobalCoords( real xloc, real yloc,
 } // end ContactPlane3D::local2DToGlobalCoords()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::planePointAndCentroidGap( real scale )
+void ContactPlane3D::planePointAndCentroidGap( RealT scale )
 {
    // project the overlap centroid back to each face using a 
    // line-plane intersection method
-   real xc1 = 0.;
-   real yc1 = 0.;
-   real zc1 = 0.;
-   real xc2 = 0.;
-   real yc2 = 0.;
-   real zc2 = 0.;
+   RealT xc1 = 0.;
+   RealT yc1 = 0.;
+   RealT zc1 = 0.;
+   RealT xc2 = 0.;
+   RealT yc2 = 0.;
+   RealT zc2 = 0.;
 
-   real xcg = 0.;
-   real ycg = 0.;
-   real zcg = 0.;
+   RealT xcg = 0.;
+   RealT ycg = 0.;
+   RealT zcg = 0.;
 
    // first project the projected area of overlap's centroid in local 
    // coordinates to global coordinates
@@ -1283,21 +1282,21 @@ void ContactPlane3D::planePointAndCentroidGap( real scale )
    // set the line segment's first vertex at the contact plane centroid scaled 
    // in the direction opposite the contact plane normal
 
-   real xA = xcg + m_nX * scale;
-   real yA = ycg + m_nY * scale;
-   real zA = zcg + m_nZ * scale;
+   RealT xA = xcg + m_nX * scale;
+   RealT yA = ycg + m_nY * scale;
+   RealT zA = zcg + m_nZ * scale;
 
    // use the contact plane normal as the segment directional vector scale in 
    // the direction of the contact plane
-   real xB = xcg - m_nX * scale;
-   real yB = ycg - m_nY * scale;
-   real zB = zcg - m_nZ * scale;
+   RealT xB = xcg - m_nX * scale;
+   RealT yB = ycg - m_nY * scale;
+   RealT zB = zcg - m_nZ * scale;
 
    MeshData& m1 = getCpMeshData( m_pair.meshId1 );
    MeshData& m2 = getCpMeshData( m_pair.meshId2 );
    bool inPlane = false;
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
    bool intersect1 = LinePlaneIntersection( xA, yA, zA, xB, yB, zB,
                                             m1.m_cX[fId1], m1.m_cY[fId1], m1.m_cZ[fId1],
                                             m1.m_nX[fId1], m1.m_nY[fId1], m1.m_nZ[fId1],
@@ -1307,7 +1306,7 @@ void ContactPlane3D::planePointAndCentroidGap( real scale )
                                             m2.m_cX[fId2], m2.m_cY[fId2], m2.m_cZ[fId2],
                                             m2.m_nX[fId2], m2.m_nY[fId2], m2.m_nZ[fId2],
                                             xc2, yc2, zc2, inPlane );
-   TRIBOL_UNUSED_VAR(intersect1); // We don't currently use these bool variabeles
+   TRIBOL_UNUSED_VAR(intersect1); // We don't currently use these bool variables
    TRIBOL_UNUSED_VAR(intersect2); // but the above function calls modify some parameters
 
 
@@ -1339,20 +1338,20 @@ void ContactPlane3D::planePointAndCentroidGap( real scale )
 } // end ContactPlane3D::planePointAndCentroidGap()
 
 //------------------------------------------------------------------------------
-void ContactPlane3D::centroidGap( real scale )
+void ContactPlane3D::centroidGap( RealT scale )
 {
    // project the overlap centroid back to each face using a 
    // line-plane intersection method
-   real xc1 = 0.;
-   real yc1 = 0.;
-   real zc1 = 0.;
-   real xc2 = 0.;
-   real yc2 = 0.;
-   real zc2 = 0.;
+   RealT xc1 = 0.;
+   RealT yc1 = 0.;
+   RealT zc1 = 0.;
+   RealT xc2 = 0.;
+   RealT yc2 = 0.;
+   RealT zc2 = 0.;
 
-   real xcg = 0.;
-   real ycg = 0.;
-   real zcg = 0.;
+   RealT xcg = 0.;
+   RealT ycg = 0.;
+   RealT zcg = 0.;
 
    // first project the projected area of overlap's centroid in local 
    // coordinates to global coordinates
@@ -1362,21 +1361,21 @@ void ContactPlane3D::centroidGap( real scale )
 
    // set the line segment's first vertex at the contact plane centroid scaled 
    // in the direction opposite the contact plane normal
-   real xA = xcg + m_nX * scale;
-   real yA = ycg + m_nY * scale;
-   real zA = zcg + m_nZ * scale;
+   RealT xA = xcg + m_nX * scale;
+   RealT yA = ycg + m_nY * scale;
+   RealT zA = zcg + m_nZ * scale;
 
    // use the contact plane normal as the segment directional vector scale in 
    // the direction of the contact plane
-   real xB = xcg - m_nX * scale;
-   real yB = ycg - m_nY * scale;
-   real zB = zcg - m_nZ * scale;
+   RealT xB = xcg - m_nX * scale;
+   RealT yB = ycg - m_nY * scale;
+   RealT zB = zcg - m_nZ * scale;
 
    MeshData& m1 = getCpMeshData( m_pair.meshId1 );
    MeshData& m2 = getCpMeshData( m_pair.meshId2 );
    bool inPlane = false;
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
 
    bool intersect1 = LinePlaneIntersection( xA, yA, zA, xB, yB, zB,
                                             m1.m_cX[fId1], m1.m_cY[fId1], m1.m_cZ[fId1],
@@ -1409,7 +1408,7 @@ void ContactPlane3D::centroidGap( real scale )
 } // end ContactPlane3D::centroidGap()
 
 //------------------------------------------------------------------------------
-FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
+FaceGeomError ContactPlane3D::computeLocalInterpenOverlap( bool& interpen )
 {
    // for each face, loop over current configuration segments and 
    // determine the two (there should be at most two, or in the odd 
@@ -1422,9 +1421,9 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
    interpen = false;
    parameters_t & parameters = parameters_t::getInstance();
 
-   real xInter[4];
-   real yInter[4];
-   real zInter[4];
+   RealT xInter[4];
+   RealT yInter[4];
+   RealT zInter[4];
    bool inPlane = false;
    int numV[2];
    
@@ -1477,14 +1476,14 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
          int jb = (j == (mesh.m_numNodesPerCell-1)) ? 0 : (j+1);
 
          const int& fNodeIdA = mesh.getFaceNodeId(fId, ja);
-         const real& x1 = mesh.m_positionX[fNodeIdA];
-         const real& y1 = mesh.m_positionY[fNodeIdA];
-         const real& z1 = mesh.m_positionZ[fNodeIdA];
+         const RealT& x1 = mesh.m_positionX[fNodeIdA];
+         const RealT& y1 = mesh.m_positionY[fNodeIdA];
+         const RealT& z1 = mesh.m_positionZ[fNodeIdA];
 
          const int& fNodeIdB = mesh.getFaceNodeId(fId, jb);
-         const real& x2 = mesh.m_positionX[fNodeIdB];
-         const real& y2 = mesh.m_positionY[fNodeIdB];
-         const real& z2 = mesh.m_positionZ[fNodeIdB]; 
+         const RealT& x2 = mesh.m_positionX[fNodeIdB];
+         const RealT& y2 = mesh.m_positionY[fNodeIdB];
+         const RealT& z2 = mesh.m_positionZ[fNodeIdB]; 
 
          meshId = m_pair.meshId1; 
          fId =    m_pair.pairIndex1;
@@ -1511,12 +1510,12 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
          // we now have the two vertices for the ith face that represent segment-plane intersections.
          // Now determine the existing current configuration face vertices that lie 
          // "on the other side" of the contact plane.
-         real vX = x1 - m_cX;
-         real vY = y1 - m_cY; 
-         real vZ = z1 - m_cZ; 
+         RealT vX = x1 - m_cX;
+         RealT vY = y1 - m_cY; 
+         RealT vZ = z1 - m_cZ; 
 
          // project the vector onto the contact plane normal
-         real proj = vX*m_nX + vY*m_nY + vZ*m_nZ;
+         RealT proj = vX*m_nX + vY*m_nY + vZ*m_nZ;
        
          // if the projection for face 1 vertices is positive then that vertex crosses 
          // (i.e. interpenetrates) the contact plane. if the projection for face 2 vertices
@@ -1556,13 +1555,13 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
    } // end loop over faces
 
    // allocate arrays to store new clipped vertices for the current face
-   real cfx1[ numV[0] ]; // cfx = clipped face x-coordinate
-   real cfy1[ numV[0] ];
-   real cfz1[ numV[0] ];
+   RealT cfx1[ numV[0] ]; // cfx = clipped face x-coordinate
+   RealT cfy1[ numV[0] ];
+   RealT cfz1[ numV[0] ];
 
-   real cfx2[ numV[1] ]; // cfx = clipped face x-coordinate
-   real cfy2[ numV[1] ];
-   real cfz2[ numV[1] ];
+   RealT cfx2[ numV[1] ]; // cfx = clipped face x-coordinate
+   RealT cfy2[ numV[1] ];
+   RealT cfz2[ numV[1] ];
 
    // populate arrays
    for (int m=0; m<2; ++m) // populate segment-contact-plane intersection vertices
@@ -1605,13 +1604,13 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
    }
 
    // declare projected coordinate arrays
-   real cfx1_proj[ numV[0] ];
-   real cfy1_proj[ numV[0] ];
-   real cfz1_proj[ numV[0] ];
+   RealT cfx1_proj[ numV[0] ];
+   RealT cfy1_proj[ numV[0] ];
+   RealT cfz1_proj[ numV[0] ];
 
-   real cfx2_proj[ numV[1] ];
-   real cfy2_proj[ numV[1] ];
-   real cfz2_proj[ numV[1] ];
+   RealT cfx2_proj[ numV[1] ];
+   RealT cfy2_proj[ numV[1] ];
+   RealT cfz2_proj[ numV[1] ];
 
    // project clipped face coordinates to contact plane
    for (int i=0; i<numV[0]; ++i)
@@ -1631,11 +1630,11 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
    }
  
    // declare local coordinate pointers
-   real cfx1_loc[ numV[0] ];
-   real cfy1_loc[ numV[0] ];
+   RealT cfx1_loc[ numV[0] ];
+   RealT cfy1_loc[ numV[0] ];
 
-   real cfx2_loc[ numV[1] ];
-   real cfy2_loc[ numV[1] ];
+   RealT cfx2_loc[ numV[1] ];
+   RealT cfy2_loc[ numV[1] ];
 
    // convert global coords to local contact plane coordinates
    GlobalTo2DLocalCoords( cfx1_proj, cfy1_proj, cfz1_proj,
@@ -1655,10 +1654,10 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
    PolyReorder( cfx2_loc, cfy2_loc, numV[1] ); 
 
    // call intersection routine to get intersecting polygon
-   real pos_tol = parameters.len_collapse_ratio * 
+   RealT pos_tol = parameters.len_collapse_ratio * 
                   axom::utilities::max( mesh1.m_faceRadius[ m_pair.pairIndex1 ], 
                                         mesh2.m_faceRadius[ m_pair.pairIndex2 ] );
-   real len_tol = pos_tol;
+   RealT len_tol = pos_tol;
    FaceGeomError inter_err = Intersection2DPolygon( cfx1_loc, cfy1_loc, numV[0],
                                                     cfx2_loc, cfy2_loc, numV[1],
                                                     pos_tol, len_tol, &m_polyLocX,
@@ -1673,10 +1672,10 @@ FaceGeomError ContactPlane3D::computeLocalInterpenOverlap(bool& interpen)
 
    // store the local intersection polygons on the contact plane object, 
    // primarily for visualization
-   m_interpenPoly1X = new real[ numV[0] ];
-   m_interpenPoly1Y = new real[ numV[0] ];
-   m_interpenPoly2X = new real[ numV[1] ];
-   m_interpenPoly2Y = new real[ numV[1] ];
+   m_interpenPoly1X = new RealT[ numV[0] ];
+   m_interpenPoly1Y = new RealT[ numV[0] ];
+   m_interpenPoly2X = new RealT[ numV[1] ];
+   m_interpenPoly2Y = new RealT[ numV[1] ];
 
    m_numInterpenPoly1Vert = numV[0];
    m_numInterpenPoly2Vert = numV[1];
@@ -1768,13 +1767,13 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
    // allocate new memory for pointers and copy entries
    if (cp->m_polyLocX != nullptr && cp->m_polyLocY != nullptr)
    {
-     m_polyLocX = new real[ m_numPolyVert ];
-     m_polyLocY = new real[ m_numPolyVert ];
+     m_polyLocX = new RealT[ m_numPolyVert ];
+     m_polyLocY = new RealT[ m_numPolyVert ];
    }
 
-   if (cp->m_polyX != nullptr) m_polyX = new real[ m_numPolyVert ];
-   if (cp->m_polyY != nullptr) m_polyY = new real[ m_numPolyVert ];
-   if (cp->m_polyZ != nullptr) m_polyZ = new real[ m_numPolyVert ];
+   if (cp->m_polyX != nullptr) m_polyX = new RealT[ m_numPolyVert ];
+   if (cp->m_polyY != nullptr) m_polyY = new RealT[ m_numPolyVert ];
+   if (cp->m_polyZ != nullptr) m_polyZ = new RealT[ m_numPolyVert ];
 
    for (int i=0; i<m_numPolyVert; ++i)
    {
@@ -1788,8 +1787,8 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
 
    if (cp->m_interpenPoly1X != nullptr && cp->m_interpenPoly1Y != nullptr)
    {
-     m_interpenPoly1X = new real[ m_numInterpenPoly1Vert ];
-     m_interpenPoly1Y = new real[ m_numInterpenPoly1Vert ];
+     m_interpenPoly1X = new RealT[ m_numInterpenPoly1Vert ];
+     m_interpenPoly1Y = new RealT[ m_numInterpenPoly1Vert ];
 
      for (int i=0; i<m_numInterpenPoly1Vert; ++i)
      {
@@ -1800,8 +1799,8 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
 
    if (cp->m_interpenPoly2X != nullptr && cp->m_interpenPoly2Y != nullptr)
    {
-     m_interpenPoly2X = new real[ m_numInterpenPoly2Vert ];
-     m_interpenPoly2Y = new real[ m_numInterpenPoly2Vert ];
+     m_interpenPoly2X = new RealT[ m_numInterpenPoly2Vert ];
+     m_interpenPoly2Y = new RealT[ m_numInterpenPoly2Vert ];
 
      for (int i=0; i<m_numInterpenPoly2Vert; ++i)
      {
@@ -1813,9 +1812,9 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
    if (cp->m_interpenG1X != nullptr && cp->m_interpenG1Y != nullptr 
        && cp->m_interpenG1Z != nullptr)
    {
-     m_interpenG1X = new real[ m_numInterpenPoly1Vert ];
-     m_interpenG1Y = new real[ m_numInterpenPoly1Vert ];
-     m_interpenG1Z = new real[ m_numInterpenPoly1Vert ];
+     m_interpenG1X = new RealT[ m_numInterpenPoly1Vert ];
+     m_interpenG1Y = new RealT[ m_numInterpenPoly1Vert ];
+     m_interpenG1Z = new RealT[ m_numInterpenPoly1Vert ];
 
      for (int i=0; i<m_numInterpenPoly1Vert; ++i)
      {
@@ -1828,9 +1827,9 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
    if (cp->m_interpenG2X != nullptr && cp->m_interpenG2Y != nullptr 
        && cp->m_interpenG2Z != nullptr)
    {
-     m_interpenG2X = new real[ m_numInterpenPoly2Vert ];
-     m_interpenG2Y = new real[ m_numInterpenPoly2Vert ];
-     m_interpenG2Z = new real[ m_numInterpenPoly2Vert ];
+     m_interpenG2X = new RealT[ m_numInterpenPoly2Vert ];
+     m_interpenG2Y = new RealT[ m_numInterpenPoly2Vert ];
+     m_interpenG2Z = new RealT[ m_numInterpenPoly2Vert ];
 
      for (int i=0; i<m_numInterpenPoly2Vert; ++i)
      {
@@ -1847,7 +1846,7 @@ void ContactPlane3D::copyContactPlane( ContactPlane* RESTRICT cPlane )
 //-----------------------------------------------------------------------------
 // Contact Plane 2D routines
 //-----------------------------------------------------------------------------
-ContactPlane2D::ContactPlane2D( InterfacePair& pair, real lenFrac, 
+ContactPlane2D::ContactPlane2D( InterfacePair& pair, RealT lenFrac, 
                                 bool interpenOverlap, bool interPlane, 
                                 int dimension )
 {
@@ -1977,10 +1976,10 @@ FaceGeomError CheckEdgePair( InterfacePair& pair,
    parameters_t& params = parameters_t::getInstance();
 
    // alias variables off the InterfacePair
-   IndexType& meshId1 = pair.meshId1;
-   IndexType& meshId2 = pair.meshId2;
-   IndexType& edgeId1 = pair.pairIndex1;
-   IndexType& edgeId2 = pair.pairIndex2;
+   IndexT& meshId1 = pair.meshId1;
+   IndexT& meshId2 = pair.meshId2;
+   IndexT& edgeId1 = pair.pairIndex1;
+   IndexT& edgeId2 = pair.pairIndex2;
 
    // get instance of mesh manager
    MeshManager & meshManager = MeshManager::getInstance();
@@ -1999,7 +1998,7 @@ FaceGeomError CheckEdgePair( InterfacePair& pair,
    // (contact segment) and perform this check. Note, this tolerance is 
    // inclusive up to a separation of a fraction of the edge-radius.
    // This is done for the mortar method per 3D testing.
-   real separationTol = params.gap_separation_ratio * 
+   RealT separationTol = params.gap_separation_ratio * 
                         axom::utilities::max( mesh1.m_faceRadius[ edgeId1 ], 
                                               mesh2.m_faceRadius[ edgeId2 ] );
    bool all = false;
@@ -2027,10 +2026,10 @@ FaceGeomError CheckEdgePair( InterfacePair& pair,
    cp.computePlanePoint(); 
 
    // project each edge's nodes onto the contact segment.
-   real projX1[ mesh1.m_numNodesPerCell ];
-   real projY1[ mesh1.m_numNodesPerCell ];
-   real projX2[ mesh2.m_numNodesPerCell ];
-   real projY2[ mesh2.m_numNodesPerCell ];
+   RealT projX1[ mesh1.m_numNodesPerCell ];
+   RealT projY1[ mesh1.m_numNodesPerCell ];
+   RealT projX2[ mesh2.m_numNodesPerCell ];
+   RealT projY2[ mesh2.m_numNodesPerCell ];
 
    ProjectEdgeNodesToSegment( mesh1, edgeId1, cp.m_nX, cp.m_nY,
                               cp.m_cX, cp.m_cY, &projX1[0], &projY1[0] );
@@ -2122,17 +2121,17 @@ FaceGeomError CheckEdgePair( InterfacePair& pair,
       // Fix this later...
       cp.m_numInterpenPoly1Vert = 2;
       cp.m_numInterpenPoly2Vert = 2;
-      cp.m_interpenG1X = new real[ cp.m_numInterpenPoly1Vert ];
-      cp.m_interpenG1Y = new real[ cp.m_numInterpenPoly1Vert ];
-      cp.m_interpenG2X = new real[ cp.m_numInterpenPoly2Vert ];
-      cp.m_interpenG2Y = new real[ cp.m_numInterpenPoly2Vert ];
+      cp.m_interpenG1X = new RealT[ cp.m_numInterpenPoly1Vert ];
+      cp.m_interpenG1Y = new RealT[ cp.m_numInterpenPoly1Vert ];
+      cp.m_interpenG2X = new RealT[ cp.m_numInterpenPoly2Vert ];
+      cp.m_interpenG2Y = new RealT[ cp.m_numInterpenPoly2Vert ];
 
       cp.m_interpenG1Z = nullptr;
       cp.m_interpenG2Z = nullptr;
 
       for (int i=0; i<2; ++i)
       {
-         real xproj, yproj;
+         RealT xproj, yproj;
          ProjectPointToSegment( cp.m_segX[i], cp.m_segY[i], 
                                 cp.m_nX, cp.m_nY, 
                                 cp.m_cX, cp.m_cY, xproj, yproj );
@@ -2179,8 +2178,8 @@ void ContactPlane2D::computeNormal()
    }
 
    // normalize the cp normal
-   real mag;
-   real invMag;
+   RealT mag;
+   RealT invMag;
 
    mag = magnitude( m_nX, m_nY );
    invMag = 1.0 / mag;
@@ -2243,7 +2242,7 @@ void ContactPlane2D::computeAreaTol()
 } // ContactPlane2D::computeAreaTol()
 
 //------------------------------------------------------------------------------
-FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
+FaceGeomError ContactPlane2D::computeLocalInterpenOverlap( bool& interpen )
 {
    //
    // Note: the contact plane has to be properly located prior to calling 
@@ -2264,21 +2263,21 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
    int nodeA2 = mesh2.getFaceNodeId( edgeId2, 0 );
    int nodeB2 = mesh2.getFaceNodeId( edgeId2, 1 );
 
-   real xposA1 = mesh1.m_positionX[ nodeA1 ];
-   real yposA1 = mesh1.m_positionY[ nodeA1 ];
-   real xposB1 = mesh1.m_positionX[ nodeB1 ];
-   real yposB1 = mesh1.m_positionY[ nodeB1 ];
+   RealT xposA1 = mesh1.m_positionX[ nodeA1 ];
+   RealT yposA1 = mesh1.m_positionY[ nodeA1 ];
+   RealT xposB1 = mesh1.m_positionX[ nodeB1 ];
+   RealT yposB1 = mesh1.m_positionY[ nodeB1 ];
 
-   real xposA2 = mesh2.m_positionX[ nodeA2 ];
-   real yposA2 = mesh2.m_positionY[ nodeA2 ];
-   real xposB2 = mesh2.m_positionX[ nodeB2 ];
-   real yposB2 = mesh2.m_positionY[ nodeB2 ];
+   RealT xposA2 = mesh2.m_positionX[ nodeA2 ];
+   RealT yposA2 = mesh2.m_positionY[ nodeA2 ];
+   RealT xposB2 = mesh2.m_positionX[ nodeB2 ];
+   RealT yposB2 = mesh2.m_positionY[ nodeB2 ];
 
-   real xInter, yInter;
+   RealT xInter, yInter;
    bool duplicatePoint = false;
 
    // check if the segments intersect
-   real len_tol = parameters.len_collapse_ratio * 
+   RealT len_tol = parameters.len_collapse_ratio * 
                   axom::utilities::max( mesh1.m_faceRadius[ edgeId1 ], 
                                         mesh2.m_faceRadius[ edgeId2 ] );
 
@@ -2314,7 +2313,7 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
    // on the contact plane (segment). We can still do this projection 
    // to be safe and the routine will handle a point that is already 
    // on the plane
-   real xInterProj, yInterProj;
+   RealT xInterProj, yInterProj;
    ProjectPointToSegment( xInter, yInter, m_nX, m_nY, 
                           m_cX, m_cY, xInterProj, yInterProj );
 
@@ -2329,14 +2328,14 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
    {
       int nodeId1 = mesh1.getFaceNodeId( edgeId1, i );
       int nodeId2 = mesh2.getFaceNodeId( edgeId2, i );
-      real lvx1 = mesh1.m_positionX[ nodeId1 ] - m_cX;
-      real lvy1 = mesh1.m_positionY[ nodeId1 ] - m_cY;
-      real lvx2 = mesh2.m_positionX[ nodeId2 ] - m_cX;
-      real lvy2 = mesh2.m_positionY[ nodeId2 ] - m_cY;
+      RealT lvx1 = mesh1.m_positionX[ nodeId1 ] - m_cX;
+      RealT lvy1 = mesh1.m_positionY[ nodeId1 ] - m_cY;
+      RealT lvx2 = mesh2.m_positionX[ nodeId2 ] - m_cX;
+      RealT lvy2 = mesh2.m_positionY[ nodeId2 ] - m_cY;
 
       // dot each vector with the contact plane normal
-      real proj1 = lvx1 * m_nX + lvy1 * m_nY;
-      real proj2 = lvx2 * m_nX + lvy2 * m_nY;
+      RealT proj1 = lvx1 * m_nX + lvy1 * m_nY;
+      RealT proj2 = lvx2 * m_nX + lvy2 * m_nY;
 
       // check the projection to detect interpenetration and 
       // mark the node id if true
@@ -2368,14 +2367,14 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
    int nodeInter1 = mesh1.getFaceNodeId( edgeId1, interId1 );
    int nodeInter2 = mesh2.getFaceNodeId( edgeId2, interId2 ); 
 
-   real vix1 = mesh1.m_positionX[ nodeInter1 ] - xInterProj;
-   real viy1 = mesh1.m_positionY[ nodeInter1 ] - yInterProj;
-   real vix2 = mesh2.m_positionX[ nodeInter2 ] - xInterProj;
-   real viy2 = mesh2.m_positionY[ nodeInter2 ] - yInterProj;
+   RealT vix1 = mesh1.m_positionX[ nodeInter1 ] - xInterProj;
+   RealT viy1 = mesh1.m_positionY[ nodeInter1 ] - yInterProj;
+   RealT vix2 = mesh2.m_positionX[ nodeInter2 ] - xInterProj;
+   RealT viy2 = mesh2.m_positionY[ nodeInter2 ] - yInterProj;
 
    // determine magnitude of each vector
-   real mag1 = magnitude( vix1, viy1 );
-   real mag2 = magnitude( vix2, viy2 );
+   RealT mag1 = magnitude( vix1, viy1 );
+   RealT mag2 = magnitude( vix2, viy2 );
 
    // the interpenetration overlap length is the minimum of the above 
    // vectors
@@ -2385,23 +2384,23 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
    {
       // determine the edge vertex that forms the overlap segment along 
       // with the intersection point previously computed
-      real vx1 = (mag1 <= mag2) ? mesh1.m_positionX[ nodeInter1 ] 
+      RealT vx1 = (mag1 <= mag2) ? mesh1.m_positionX[ nodeInter1 ] 
                                 : mesh2.m_positionX[ nodeInter2 ];
 
-      real vy1 = (mag1 <= mag2) ? mesh1.m_positionY[ nodeInter1 ]
+      RealT vy1 = (mag1 <= mag2) ? mesh1.m_positionY[ nodeInter1 ]
                                 : mesh2.m_positionY[ nodeInter2 ];
      
-      real vx2 = xInterProj;
-      real vy2 = yInterProj;
+      RealT vx2 = xInterProj;
+      RealT vy2 = yInterProj;
 
       // allocate space to store the interpen vertices for visualization
       // (stored on contact plane base class)
       m_numInterpenPoly1Vert = 2;
       m_numInterpenPoly2Vert = 2;
-      m_interpenG1X = new real[2];
-      m_interpenG1Y = new real[2];
-      m_interpenG2X = new real[2];
-      m_interpenG2Y = new real[2];
+      m_interpenG1X = new RealT[2];
+      m_interpenG1Y = new RealT[2];
+      m_interpenG2X = new RealT[2];
+      m_interpenG2Y = new RealT[2];
      
       m_interpenG1Z = nullptr;
       m_interpenG2Z = nullptr;
@@ -2444,18 +2443,18 @@ FaceGeomError ContactPlane2D::computeLocalInterpenOverlap(bool& interpen)
 } // end ContactPlane2D::computeLocalInterpenOverlap()
 
 //------------------------------------------------------------------------------
-void ContactPlane2D::centroidGap( real scale )
+void ContactPlane2D::centroidGap( RealT scale )
 {
    // project the overlap centroid, which is taken to be the point data 
    // (i.e. centroid) of the contact plane, back to each edge using the 
    // line-plane intersection method where each edge is imagined to be 
    // within a plane defined by the edge's centroid and normal
-   real xc1 = 0.;
-   real yc1 = 0.;
-   real zc1 = 0.;
-   real xc2 = 0.;
-   real yc2 = 0.;
-   real zc2 = 0.;
+   RealT xc1 = 0.;
+   RealT yc1 = 0.;
+   RealT zc1 = 0.;
+   RealT xc2 = 0.;
+   RealT yc2 = 0.;
+   RealT zc2 = 0.;
 
    // find where the overlap centroid (plane point) intersects each face.
    // The following variables store the end vertices of 
@@ -2464,22 +2463,22 @@ void ContactPlane2D::centroidGap( real scale )
 
    // set the line segment's first vertex at the contact plane centroid, 
    // scaled in the direction opposite the contact plane normal
-   real xA = m_cX + m_nX * scale;
-   real yA = m_cY + m_nY * scale;
-   real zA = 0.0;
+   RealT xA = m_cX + m_nX * scale;
+   RealT yA = m_cY + m_nY * scale;
+   RealT zA = 0.0;
 
    // use the contact plane normal as the directional vector scale 
    // in the direction of the contact plane
-   real xB = m_cX - m_nX * scale;
-   real yB = m_cY - m_nY * scale;
-   real zB = 0.0;
+   RealT xB = m_cX - m_nX * scale;
+   RealT yB = m_cY - m_nY * scale;
+   RealT zB = 0.0;
 
    // get mesh data
    MeshData& m1 = getCpMeshData( m_pair.meshId1 );
    MeshData& m2 = getCpMeshData( m_pair.meshId2 ); 
    bool inPlane = false;
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
    bool intersect1 = LinePlaneIntersection( xA, yA, zA, xB, yB, zB,
                                             m1.m_cX[fId1], m1.m_cY[fId1], 0.0,
                                             m1.m_nX[fId1], m1.m_nY[fId1], 0.0,
@@ -2511,18 +2510,18 @@ void ContactPlane2D::centroidGap( real scale )
 } // end ContactPlane2D::centroidGap()
 
 //------------------------------------------------------------------------------
-void ContactPlane2D::planePointAndCentroidGap( real scale )
+void ContactPlane2D::planePointAndCentroidGap( RealT scale )
 {
    // project the overlap centroid, which is taken to be the point data 
    // (i.e. centroid) of the contact plane, back to each edge using the 
    // line-plane intersection method where each edge is imagined to be 
    // within a plane defined by the edge's centroid and normal
-   real xc1 = 0.;
-   real yc1 = 0.;
-   real zc1 = 0.;
-   real xc2 = 0.;
-   real yc2 = 0.;
-   real zc2 = 0.;
+   RealT xc1 = 0.;
+   RealT yc1 = 0.;
+   RealT zc1 = 0.;
+   RealT xc2 = 0.;
+   RealT yc2 = 0.;
+   RealT zc2 = 0.;
 
    // find where the overlap centroid (plane point) intersects each face.
    // The following variables store the end vertices of 
@@ -2531,22 +2530,22 @@ void ContactPlane2D::planePointAndCentroidGap( real scale )
 
    // set the line segment's first vertex at the contact plane centroid, 
    // scaled in the direction opposite the contact plane normal
-   real xA = m_cX + m_nX * scale;
-   real yA = m_cY + m_nY * scale;
-   real zA = 0.0;
+   RealT xA = m_cX + m_nX * scale;
+   RealT yA = m_cY + m_nY * scale;
+   RealT zA = 0.0;
 
    // use the contact plane normal as the directional vector scale 
    // in the direction of the contact plane
-   real xB = m_cX - m_nX * scale;
-   real yB = m_cY - m_nY * scale;
-   real zB = 0.0;
+   RealT xB = m_cX - m_nX * scale;
+   RealT yB = m_cY - m_nY * scale;
+   RealT zB = 0.0;
 
    // get mesh data
    MeshData& m1 = getCpMeshData( m_pair.meshId1 );
    MeshData& m2 = getCpMeshData( m_pair.meshId2 ); 
    bool inPlane = false;
-   IndexType fId1 = m_pair.pairIndex1;
-   IndexType fId2 = m_pair.pairIndex2;
+   IndexT fId1 = m_pair.pairIndex1;
+   IndexT fId2 = m_pair.pairIndex2;
    bool intersect1 = LinePlaneIntersection( xA, yA, zA, xB, yB, zB,
                                             m1.m_cX[fId1], m1.m_cY[fId1], 0.0,
                                             m1.m_nX[fId1], m1.m_nY[fId1], 0.0,
@@ -2648,9 +2647,9 @@ void ContactPlane2D::copyContactPlane( ContactPlane* RESTRICT cPlane )
    if (cp->m_interpenG1X != nullptr && cp->m_interpenG1Y != nullptr 
        && cp->m_interpenG1Z != nullptr)
    {
-     m_interpenG1X = new real[ m_numInterpenPoly1Vert ];
-     m_interpenG1Y = new real[ m_numInterpenPoly1Vert ];
-     m_interpenG1Z = new real[ m_numInterpenPoly1Vert ];
+     m_interpenG1X = new RealT[ m_numInterpenPoly1Vert ];
+     m_interpenG1Y = new RealT[ m_numInterpenPoly1Vert ];
+     m_interpenG1Z = new RealT[ m_numInterpenPoly1Vert ];
 
      for (int i=0; i<m_numInterpenPoly1Vert; ++i)
      {
@@ -2663,9 +2662,9 @@ void ContactPlane2D::copyContactPlane( ContactPlane* RESTRICT cPlane )
    if (cp->m_interpenG2X != nullptr && cp->m_interpenG2Y != nullptr 
        && cp->m_interpenG2Z != nullptr)
    {
-     m_interpenG2X = new real[ m_numInterpenPoly2Vert ];
-     m_interpenG2Y = new real[ m_numInterpenPoly2Vert ];
-     m_interpenG2Z = new real[ m_numInterpenPoly2Vert ];
+     m_interpenG2X = new RealT[ m_numInterpenPoly2Vert ];
+     m_interpenG2Y = new RealT[ m_numInterpenPoly2Vert ];
+     m_interpenG2Z = new RealT[ m_numInterpenPoly2Vert ];
 
      for (int i=0; i<m_numInterpenPoly2Vert; ++i)
      {
@@ -2680,8 +2679,8 @@ void ContactPlane2D::copyContactPlane( ContactPlane* RESTRICT cPlane )
 } // end ContactPlane2D::copyContactPlane()
 
 //------------------------------------------------------------------------------
-void ContactPlane2D::checkSegOverlap( const real* const RESTRICT pX1, const real* const RESTRICT pY1, 
-                                      const real* const RESTRICT pX2, const real* const RESTRICT pY2, 
+void ContactPlane2D::checkSegOverlap( const RealT* const RESTRICT pX1, const RealT* const RESTRICT pY1, 
+                                      const RealT* const RESTRICT pX2, const RealT* const RESTRICT pY2, 
                                       const int nV1, const int nV2 )
 {
    parameters_t & parameters = parameters_t::getInstance();
@@ -2707,30 +2706,30 @@ void ContactPlane2D::checkSegOverlap( const real* const RESTRICT pX1, const real
 
    // define the edge 1 non-unit directional vector between vertices 
    // 2 and 1
-   real lvx1 = pX1[1] - pX1[0];
-   real lvy1 = pY1[1] - pY1[0];
+   RealT lvx1 = pX1[1] - pX1[0];
+   RealT lvy1 = pY1[1] - pY1[0];
 
    // compute vector between each edge 2 vertex and vertex 1 on edge 1.
    // Then dot that vector with the directional vector of edge 1 to see 
    // if they are codirectional. If so, check, that this vector length is 
    // less than edge 1 length indicating that the vertex lies within edge 1
-   real projTol = parameters.projection_ratio * 
+   RealT projTol = parameters.projection_ratio * 
                   axom::utilities::max( mesh1.m_faceRadius[ e1Id ], 
                                         mesh2.m_faceRadius[ e2Id ] );
-   real vLenTol = projTol;
+   RealT vLenTol = projTol;
    int inter2 = 0;
    int twoInOneId = -1;
    for (int i=0; i<nV2; ++i)
    {
-      real vx = pX2[i] - pX1[0];
-      real vy = pY2[i] - pY1[0]; 
+      RealT vx = pX2[i] - pX1[0];
+      RealT vy = pY2[i] - pY1[0]; 
 
       // compute projection onto edge 1 directional vector
-      real proj = vx * lvx1 + vy * lvy1;
+      RealT proj = vx * lvx1 + vy * lvy1;
 
       // compute length of <vx,vy>; if vLen < some tolerance we have a 
       // coincident node
-      real vLen = magnitude( vx, vy );
+      RealT vLen = magnitude( vx, vy );
 
       if (vLen < vLenTol) // coincident vertex
       {
@@ -2771,8 +2770,8 @@ void ContactPlane2D::checkSegOverlap( const real* const RESTRICT pX1, const real
 
    // define the edge 2 non-unit directional vector between vertices 
    // 2 and 1
-   real lvx2 = pX2[1] - pX2[0];
-   real lvy2 = pY2[1] - pY2[0];
+   RealT lvx2 = pX2[1] - pX2[0];
+   RealT lvy2 = pY2[1] - pY2[0];
 
    // compute vector between each edge 1 vertex and vertex 1 on edge 2.
    // Then dot that vector with the directional vector of edge 2 to see 
@@ -2782,14 +2781,14 @@ void ContactPlane2D::checkSegOverlap( const real* const RESTRICT pX1, const real
    int oneInTwoId = -1;
    for (int i=0; i<nV1; ++i)
    {
-      real vx = pX1[i] - pX2[0];
-      real vy = pY1[i] - pY2[0]; 
+      RealT vx = pX1[i] - pX2[0];
+      RealT vy = pY1[i] - pY2[0]; 
 
       // compute projection onto edge 2 directional vector
-      real proj = vx * lvx2 + vy * lvy2;
+      RealT proj = vx * lvx2 + vy * lvy2;
 
       // compute length of <vx,vy>
-      real vLen = magnitude( vx, vy );
+      RealT vLen = magnitude( vx, vy );
 
       if (vLen < vLenTol) // coincident vertex
       {
@@ -2854,8 +2853,8 @@ void ContactPlane2D::checkSegOverlap( const real* const RESTRICT pX1, const real
    m_segY[1] = pY2[ twoInOneId ];
 
    // compute vector between "inter"-vertices
-   real vecX = m_segX[1] - m_segX[0];
-   real vecY = m_segY[1] - m_segY[0];
+   RealT vecX = m_segX[1] - m_segX[0];
+   RealT vecY = m_segY[1] - m_segY[0];
 
    // compute the length of the overlapping segment
    m_area = magnitude( vecX, vecY );

--- a/src/tribol/geom/ContactPlane.hpp
+++ b/src/tribol/geom/ContactPlane.hpp
@@ -65,10 +65,10 @@ FaceGeomError CheckInterfacePair( InterfacePair& pair,
  * \pre length(pX), length(pY), length(pZ) >= number of nodes on face
  */
 void ProjectFaceNodesToPlane( const MeshData& mesh, int faceId,
-                              real nrmlX, real nrmlY, real nrmlZ,
-                              real cX, real cY, real cZ,
-                              real* RESTRICT pX, real* RESTRICT pY, 
-                              real* RESTRICT pZ );
+                              RealT nrmlX, RealT nrmlY, RealT nrmlZ,
+                              RealT cX, RealT cY, RealT cZ,
+                              RealT* RESTRICT pX, RealT* RESTRICT pY, 
+                              RealT* RESTRICT pZ );
 
 /*!
  *
@@ -85,9 +85,9 @@ void ProjectFaceNodesToPlane( const MeshData& mesh, int faceId,
  *
  */
 void ProjectEdgeNodesToSegment( const MeshData& mesh, int edgeId, 
-                                real nrmlX, real nrmlY, real cX, 
-                                real cY, real* RESTRICT pX, 
-                                real* RESTRICT pY );
+                                RealT nrmlX, RealT nrmlY, RealT cX, 
+                                RealT cY, RealT* RESTRICT pX, 
+                                RealT* RESTRICT pY );
 
 /*!
  * \brief checks if the vertices on face2 have interpenetrated the level set 
@@ -110,7 +110,7 @@ void ProjectEdgeNodesToSegment( const MeshData& mesh, int edgeId,
  * 
  */
 bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2, 
-                     int fId1, int fId2, real tol, bool& allVerts );
+                     int fId1, int fId2, RealT tol, bool& allVerts );
 
 /*!
  *
@@ -128,7 +128,7 @@ bool FaceInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
  *
  */
 bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2, 
-                     int eId1, int eId2, real tol, bool& allVerts );
+                     int eId1, int eId2, RealT tol, bool& allVerts );
 
 /*!
  *
@@ -147,7 +147,7 @@ bool EdgeInterCheck( const MeshData& meshDat1, const MeshData& meshDat2,
  *
  */
 bool ExceedsMaxAutoInterpen( const MeshData& meshDat1, const MeshData& meshDat2,
-                             const int faceId1, const int faceId2, const real gap );
+                             const int faceId1, const int faceId2, const RealT gap );
 
 //-----------------------------------------------------------------------------
 // Contact Plane base class
@@ -168,40 +168,40 @@ public:
    bool m_inContact;         ///< True if face-pair is in contact
    bool m_interpenOverlap;   ///< True if using interpenetration overlap algorithm
 
-   real m_cX; ///< Contact plane point global x-coordinate 
-   real m_cY; ///< Contact plane point global y-coordinate 
-   real m_cZ; ///< Contact plane point global z-coordinate (zero out for 2D)
+   RealT m_cX; ///< Contact plane point global x-coordinate 
+   RealT m_cY; ///< Contact plane point global y-coordinate 
+   RealT m_cZ; ///< Contact plane point global z-coordinate (zero out for 2D)
 
-   real m_cXf1; ///< Global x-coordinate of contact plane centroid projected to face 1
-   real m_cYf1; ///< Global y-coordinate of contact plane centroid projected to face 1
-   real m_cZf1; ///< Global z-coordinate of contact plane centroid projected to face 1
+   RealT m_cXf1; ///< Global x-coordinate of contact plane centroid projected to face 1
+   RealT m_cYf1; ///< Global y-coordinate of contact plane centroid projected to face 1
+   RealT m_cZf1; ///< Global z-coordinate of contact plane centroid projected to face 1
   
-   real m_cXf2; ///< global x-coordinate of contact plane centroid projected to face 2
-   real m_cYf2; ///< global y-coordinate of contact plane centroid projected to face 2
-   real m_cZf2; ///< global z-coordinate of contact plane centroid projected to face 2
+   RealT m_cXf2; ///< global x-coordinate of contact plane centroid projected to face 2
+   RealT m_cYf2; ///< global y-coordinate of contact plane centroid projected to face 2
+   RealT m_cZf2; ///< global z-coordinate of contact plane centroid projected to face 2
 
    int m_numInterpenPoly1Vert; ///< Number of vertices on face 1 interpenetrating polygon
-   real* m_interpenG1X;        ///< Global x-coordinate of face 1 interpenetrating polygon
-   real* m_interpenG1Y;        ///< Global y-coordinate of face 1 interpenetrating polygon
-   real* m_interpenG1Z;        ///< Global z-coordinate of face 1 interpenetrating polygon
+   RealT* m_interpenG1X;   ///< Global x-coordinate of face 1 interpenetrating polygon
+   RealT* m_interpenG1Y;   ///< Global y-coordinate of face 1 interpenetrating polygon
+   RealT* m_interpenG1Z;   ///< Global z-coordinate of face 1 interpenetrating polygon
    
    int m_numInterpenPoly2Vert; ///< Number of vertices on face 2 interpenetrating polygon
-   real* m_interpenG2X;        ///< Global x-coordinate of face 2 interpenetrating polygon
-   real* m_interpenG2Y;        ///< Global y-coordinate of face 2 interpenetrating polygon
-   real* m_interpenG2Z;        ///< Global z-coordinate of face 2 interpenetrating polygon
+   RealT* m_interpenG2X;   ///< Global x-coordinate of face 2 interpenetrating polygon
+   RealT* m_interpenG2Y;   ///< Global y-coordinate of face 2 interpenetrating polygon
+   RealT* m_interpenG2Z;   ///< Global z-coordinate of face 2 interpenetrating polygon
 
-   real m_nX; ///< Global x-component of contact plane unit normal 
-   real m_nY; ///< Global y-component of contact plane unit normal
-   real m_nZ; ///< Global z-component of contact plane unit normal (zero out for 2D)
+   RealT m_nX; ///< Global x-component of contact plane unit normal 
+   RealT m_nY; ///< Global y-component of contact plane unit normal
+   RealT m_nZ; ///< Global z-component of contact plane unit normal (zero out for 2D)
 
-   real m_gap;    ///< Face-pair gap
-   real m_gapTol; ///< Face-pair gap tolerance
+   RealT m_gap;    ///< Face-pair gap
+   RealT m_gapTol; ///< Face-pair gap tolerance
 
    // cp area
-   real m_areaFrac;     ///< Face area fraction used to determine overlap area cutoff
-   real m_areaMin;      ///< Minimum overlap area for inclusion into the active set
-   real m_area;         ///< Overlap area
-   real m_interpenArea; ///< Interpenetrating overlap area
+   RealT m_areaFrac;     ///< Face area fraction used to determine overlap area cutoff
+   RealT m_areaMin;      ///< Minimum overlap area for inclusion into the active set
+   RealT m_area;         ///< Overlap area
+   RealT m_interpenArea; ///< Interpenetrating overlap area
 
 public:
 
@@ -211,7 +211,7 @@ public:
    /*!
     * \brief Compute the contact plane normal
     */
-   virtual void computeNormal( ) = 0 ; 
+   virtual void computeNormal() = 0 ; 
 
    /*!
     * \brief Compute the contact plane point
@@ -233,14 +233,14 @@ public:
     *
     * \param [in] scale Scale to help find centroid-to-face projections
     */
-   virtual void centroidGap(real scale) = 0 ;
+   virtual void centroidGap( RealT scale ) = 0 ;
 
    /*!
     * \brief Compute the contact plane centroid gap and relocate contact plane point
     *
     * \param [in] scale Scale to help find the centroid-to-face projections
     */
-   virtual void planePointAndCentroidGap( real scale ) = 0 ;
+   virtual void planePointAndCentroidGap( RealT scale ) = 0 ;
 
    /*!
     * \brief Compute the contact plane integral gap expression
@@ -249,7 +249,7 @@ public:
     *
     * \return 0 if no error, non-zero (via FaceGeomError enum) otherwise
     */
-   virtual FaceGeomError computeLocalInterpenOverlap(bool& interpen) = 0 ;
+   virtual FaceGeomError computeLocalInterpenOverlap( bool& interpen ) = 0 ;
    
    /*!
     * \brief Copy the contact plane object
@@ -374,7 +374,7 @@ public:
     * \param [in] i Face number 
     * \param [in] pairType Face type 
     */
-   void setCpPairType( int id, integer pairType )
+   void setCpPairType( int id, int pairType )
    {
       if (id != 1 && id != 2)
      {
@@ -412,31 +412,31 @@ class ContactPlane3D : public ContactPlane
 {
 public:
 
-   real m_e1X; ///< Global x-component of first in-plane basis vector
-   real m_e1Y; ///< Global y-component of first in-plane basis vector
-   real m_e1Z; ///< Global z-component of first in-plane basis vector
+   RealT m_e1X; ///< Global x-component of first in-plane basis vector
+   RealT m_e1Y; ///< Global y-component of first in-plane basis vector
+   RealT m_e1Z; ///< Global z-component of first in-plane basis vector
 
-   real m_e2X; ///< Global x-component of second in-plane basis vector
-   real m_e2Y; ///< Global y-component of second in-plane basis vector
-   real m_e2Z; ///< Global z-component of second in-plane basis vector
+   RealT m_e2X; ///< Global x-component of second in-plane basis vector
+   RealT m_e2Y; ///< Global y-component of second in-plane basis vector
+   RealT m_e2Z; ///< Global z-component of second in-plane basis vector
 
-   real* m_polyLocX; ///< Pointer to local x-components of overlap polygon's vertices
-   real* m_polyLocY; ///< Pointer to local y-components of overlap polygon's vertices 
+   RealT* m_polyLocX; ///< Pointer to local x-components of overlap polygon's vertices
+   RealT* m_polyLocY; ///< Pointer to local y-components of overlap polygon's vertices 
 
-   real* m_polyX; ///< Pointer to global x-components of overlap polygon's vertices
-   real* m_polyY; ///< Pointer to global y-components of overlap polygon's vertices
-   real* m_polyZ; ///< Pointer to global z-components of overlap polygon's vertices
+   RealT* m_polyX; ///< Global x-components of overlap polygon's vertices
+   RealT* m_polyY; ///< Global y-components of overlap polygon's vertices
+   RealT* m_polyZ; ///< Global z-components of overlap polygon's vertices
 
    int m_numPolyVert; ///< Number of vertices in overlapping polygon
 
-   real m_overlapCX; ///< Local x-coordinate of overlap centroid
-   real m_overlapCY; ///< Local y-coordinate of overlap centroid
+   RealT m_overlapCX; ///< Local x-coordinate of overlap centroid
+   RealT m_overlapCY; ///< Local y-coordinate of overlap centroid
 
-   real* m_interpenPoly1X; ///< Local x-coordinates of face 1 interpenetrating overlap
-   real* m_interpenPoly1Y; ///< Local y-coordinates of face 1 interpenetrating overlap
+   RealT* m_interpenPoly1X; ///< Local x-coordinates of face 1 interpenetrating overlap
+   RealT* m_interpenPoly1Y; ///< Local y-coordinates of face 1 interpenetrating overlap
 
-   real* m_interpenPoly2X; ///< Local x-coordinates of face 2 interpenetrating overlap
-   real* m_interpenPoly2Y; ///< Local y-coordinates of face 2 interpenetrating overlap
+   RealT* m_interpenPoly2X; ///< Local x-coordinates of face 2 interpenetrating overlap
+   RealT* m_interpenPoly2Y; ///< Local y-coordinates of face 2 interpenetrating overlap
 
 public:
 
@@ -449,9 +449,9 @@ public:
     * \param [in] interPlane True if intermediate (i.e. common) plane is used
     * \param [in] dimension Dimension of the problem
     */
-   ContactPlane3D( InterfacePair& pair, real areaFrac, 
-                   bool interpenOverlap, bool interPlane, 
-                   int dimension );
+   ContactPlane3D( InterfacePair& pair, RealT areaFrac, 
+                                      bool interpenOverlap, bool interPlane, 
+                                      int dimension );
 
    /*!
     * Overload constructor with no argument list
@@ -483,11 +483,15 @@ public:
 
    /*!
     * \brief Compute the unit normal that defines the contact plane
+    * \param [in] m1 data associated with mesh 1
+    * \param [in] m2 data associated with mesh 2
     */
-   virtual void computeNormal( );
+   virtual void computeNormal();
    
    /*!
     * \brief Computes a reference point on the plane locating it in 3-space
+    * \param [in] m1 data associated with mesh 1
+    * \param [in] m2 data associated with mesh 2
     *
     * \note This is taken as the average of the vertex averaged centroids of 
     *  the two faces that are used to define a local contact plane
@@ -518,9 +522,9 @@ public:
     * \pre length(pX), length(pY), length(pZ) >= size
     * \pre length(pLX), length(pLY) >= size
     */
-   void globalTo2DLocalCoords( real* RESTRICT pX, real* RESTRICT pY, 
-                               real* RESTRICT pZ, real* RESTRICT pLX, 
-                               real* RESTRICT pLY, int size );
+   void globalTo2DLocalCoords( RealT* RESTRICT pX, RealT* RESTRICT pY, 
+                               RealT* RESTRICT pZ, RealT* RESTRICT pLX, 
+                               RealT* RESTRICT pLY, int size );
    
    /*!
     * \brief Compute the local 2D coordinates of a point on the contact plane
@@ -534,8 +538,8 @@ public:
     * \note Overloaded member function to compute local coordinates of 
     *  a single point on the contact plane
     */
-   void globalTo2DLocalCoords( real pX, real pY, real pZ,
-                               real& pLX, real& pLY, int size );
+   void globalTo2DLocalCoords( RealT pX, RealT pY, RealT pZ,
+                               RealT& pLX, RealT& pLY, int size );
    
    /*!
     * \brief Computes the area tolerance for accepting a face pair
@@ -547,9 +551,9 @@ public:
     *
     * \note Wrapper routine that calls the ALE3D polygon intersection routine
     */
-   void checkPolyOverlap( real* RESTRICT projLocX1, real* RESTRICT projLocY1, 
-                          real* RESTRICT projLocX2, real* RESTRICT projLocY2, 
-                          const int isym );
+   void checkPolyOverlap( RealT* RESTRICT projLocX1, RealT* RESTRICT projLocY1, 
+                          RealT* RESTRICT projLocX2, RealT* RESTRICT projLocY2, 
+                          const int isym);
 
    /*!
     * \brief Transform a local 2D point on the contact plane to global 3D 
@@ -562,7 +566,7 @@ public:
     * \param [in,out] zg global z coordinate of point
     *
     */
-   void local2DToGlobalCoords( real xloc, real yloc, real& xg, real& yg, real& zg );
+   void local2DToGlobalCoords( RealT xloc, RealT yloc, RealT& xg, RealT& yg, RealT& zg );
    
    /*!
     * \brief Recomputes the reference point that locates the plane in 3-space
@@ -572,7 +576,7 @@ public:
     *  polygon intersection routine) back to each face that are used to form 
     *  the contact plane and then averages these projected points.
     */
-   virtual void planePointAndCentroidGap( real scale );
+   virtual void planePointAndCentroidGap( RealT scale );
    
    /*!
     * \brief Computes the gap between the two projections of the contact 
@@ -580,7 +584,7 @@ public:
     *
     * \param [in] scale
     */
-   virtual void centroidGap( real scale );
+   virtual void centroidGap( RealT scale );
    
    /*!
     * \brief Computes the polygonal overlap between the portion of two  
@@ -591,7 +595,7 @@ public:
     *
     * \return 0 if no error, non-zero (via FaceGeomError enum) otherwise
     */
-   virtual FaceGeomError computeLocalInterpenOverlap(bool& interpen);
+   virtual FaceGeomError computeLocalInterpenOverlap( bool& interpen );
    
    /*!
     * \brief Copies one contact plane object's data to another
@@ -611,8 +615,8 @@ class ContactPlane2D : public ContactPlane
 {
 public:
 
-   real m_segX[2]; ///< Global x-components of overlap segment vertices
-   real m_segY[2]; ///< Global y-components of overlap segment vertices
+   RealT m_segX[2]; ///< Global x-components of overlap segment vertices
+   RealT m_segY[2]; ///< Global y-components of overlap segment vertices
 
 public:
 
@@ -625,9 +629,9 @@ public:
     * \param [in] interPlane True if intermediate (i.e. common) plane is used
     * \param [in] dimension Dimension of problem
     */
-   ContactPlane2D( InterfacePair& pair, real lenFrac, 
-                  bool interpenOverlap, bool interPlane, 
-                  int dimension ) ;
+   ContactPlane2D( InterfacePair& pair, RealT lenFrac, 
+                   bool interpenOverlap, bool interPlane, 
+                   int dimension ) ;
 
    /*!
     * \brief Overloaded constructor with no arguments
@@ -648,11 +652,15 @@ public:
 
    /*!
     * \brief Compute the unit normal that defines the contact plane
+    * \param [in] m1 data associated with mesh 1
+    * \param [in] m2 data associated with mesh 2
     */
-   virtual void computeNormal( );
+   virtual void computeNormal();
 
    /*!
     * \brief Computes a reference point on the plane locating it in 3-space
+    * \param [in] m1 data associated with mesh 1
+    * \param [in] m2 data associated with mesh 2
     *
     * \note This is taken as the average of the vertex averaged centroids of 
     *  the two faces that are used to define a local contact plane
@@ -675,7 +683,7 @@ public:
     *
     * \param [in] scale
     */
-   virtual void centroidGap( real scale );
+   virtual void centroidGap( RealT scale );
 
    /*!
     * \brief Recomputes the reference point that locates the plane in 3-space
@@ -685,7 +693,7 @@ public:
     *  polygon intersection routine) back to each face that are used to form 
     *  the contact plane and then averages these projected points.
     */
-   virtual void planePointAndCentroidGap( real scale );
+   virtual void planePointAndCentroidGap( RealT scale );
  
    /*!
     * \brief Computes the polygonal overlap between the portion of two  
@@ -696,7 +704,7 @@ public:
     *
     * \return 0 if no error, non-zero (via FaceGeomError enum) otherwise
     */
-   virtual FaceGeomError computeLocalInterpenOverlap(bool& interpen);
+   virtual FaceGeomError computeLocalInterpenOverlap( bool& interpen );
    
    /*!
     * \brief Copies one contact plane object's data to another
@@ -709,8 +717,8 @@ public:
     * \brief Check whether two segments have a positive length of overlap 
     *
     */
-   void checkSegOverlap( const real* const RESTRICT pX1, const real* const RESTRICT pY1, 
-                         const real* const RESTRICT pX2, const real* const RESTRICT pY2, 
+   void checkSegOverlap( const RealT* const RESTRICT pX1, const RealT* const RESTRICT pY1, 
+                         const RealT* const RESTRICT pX2, const RealT* const RESTRICT pY2, 
                          const int nV1, const int nV2 );
 
 };

--- a/src/tribol/geom/ContactPlaneManager.cpp
+++ b/src/tribol/geom/ContactPlaneManager.cpp
@@ -31,13 +31,13 @@ ContactPlaneManager & ContactPlaneManager::getInstance()
 }
 
 //------------------------------------------------------------------------------
-void ContactPlaneManager::resize( IndexType const newSize )
+void ContactPlaneManager::resize( IndexT const newSize )
 {
   m_numContactPlanes = newSize;
 
   if( m_numContactPlanes > m_allocatedNumContactPlanes )
   {
-    reserve( static_cast<IndexType>( m_numContactPlanes * 1.1 ) );
+    reserve( static_cast<IndexT>( m_numContactPlanes * 1.1 ) );
   }
 
   switch(m_spaceDim)
@@ -194,7 +194,7 @@ void ContactPlaneManager::resize2D( )
 }
 
 //------------------------------------------------------------------------------
-void ContactPlaneManager::reserve( IndexType const newSize )
+void ContactPlaneManager::reserve( IndexT const newSize )
 {
   if (m_spaceDim == 3)
   {
@@ -213,7 +213,7 @@ void ContactPlaneManager::reserve( IndexType const newSize )
 }
 
 //------------------------------------------------------------------------------
-void ContactPlaneManager::reserve3D( IndexType const newSize )
+void ContactPlaneManager::reserve3D( IndexT const newSize )
 {
   m_allocatedNumContactPlanes = newSize;
 
@@ -297,7 +297,7 @@ void ContactPlaneManager::reserve3D( IndexType const newSize )
 }
 
 //------------------------------------------------------------------------------
-void ContactPlaneManager::reserve2D( IndexType const newSize )
+void ContactPlaneManager::reserve2D( IndexT const newSize )
 {
   m_allocatedNumContactPlanes = newSize;
 
@@ -739,7 +739,7 @@ void ContactPlaneManager::clearCPManager()
 //------------------------------------------------------------------------------
 void ContactPlaneManager::getContactPlaneOverlapVerts( int const id,
                                                      int const numVerts,
-                                                     real * coords )
+                                                     RealT * coords )
 {
    if (numVerts != m_numPolyVert[id])
    {
@@ -749,9 +749,9 @@ void ContactPlaneManager::getContactPlaneOverlapVerts( int const id,
 
    // point to the appropriate overlap vertex coordinate
    // data structure
-   real const * vertCoordsX = nullptr;
-   real const * vertCoordsY = nullptr;
-   real const * vertCoordsZ = nullptr;
+   RealT const * vertCoordsX = nullptr;
+   RealT const * vertCoordsY = nullptr;
+   RealT const * vertCoordsZ = nullptr;
    if (m_spaceDim == 3)
    {
       vertCoordsX = m_polyX[id];
@@ -764,7 +764,7 @@ void ContactPlaneManager::getContactPlaneOverlapVerts( int const id,
       vertCoordsY = m_segY[id];
    }
 
-   for (IndexType ivert=0; ivert<numVerts; ++ivert)
+   for (IndexT ivert=0; ivert<numVerts; ++ivert)
    {
       coords[m_spaceDim * ivert]     = vertCoordsX[ivert];
       coords[m_spaceDim * ivert + 1] = vertCoordsY[ivert];
@@ -781,7 +781,7 @@ void ContactPlaneManager::getContactPlaneOverlapVerts( int const id,
 //------------------------------------------------------------------------------
 void ContactPlaneManager::getContactPlaneNormal( int const id,
                                                  int const dim,
-                                                 real * nrml )
+                                                 RealT * nrml )
 {
    nrml[0] = this->m_nX[ id ];
    nrml[1] = this->m_nY[ id ];
@@ -795,13 +795,13 @@ void ContactPlaneManager::getContactPlaneNormal( int const id,
 //------------------------------------------------------------------------------
 void ContactPlaneManager::getProjectedFaceCoords( int const id,
                                                   int const faceId,
-                                                  real * coords )
+                                                  RealT * coords )
 {
    // Note: at the moment there is no bounds check for coords.
    // Doxygen comments in the function prototype have been added
    // to note the expected length of the coords array.
-   IndexType const numNodesPerFace = (m_spaceDim == 3) ? 4 : 2;
-   IndexType meshId, fId;
+   IndexT const numNodesPerFace = (m_spaceDim == 3) ? 4 : 2;
+   IndexT meshId, fId;
 
    if ( faceId == 0 )
    {
@@ -824,9 +824,9 @@ void ContactPlaneManager::getProjectedFaceCoords( int const id,
       fId = m_fId2[ id ];
    }
 
-   real projX[ numNodesPerFace ];
-   real projY[ numNodesPerFace ];
-   real projZ[ numNodesPerFace ];
+   RealT projX[ numNodesPerFace ];
+   RealT projY[ numNodesPerFace ];
+   RealT projZ[ numNodesPerFace ];
 
    for (int i=0; i<numNodesPerFace; ++i)
    {

--- a/src/tribol/geom/ContactPlaneManager.hpp
+++ b/src/tribol/geom/ContactPlaneManager.hpp
@@ -18,91 +18,91 @@ protected:
 
   int m_spaceDim; ///< Space dimension
 
-  IndexType m_numContactPlanes; ///< Total number of contact planes
-  IndexType m_allocatedNumContactPlanes; ///< Total number of allocated contact planes
+  IndexT m_numContactPlanes; ///< Total number of contact planes
+  IndexT m_allocatedNumContactPlanes; ///< Total number of allocated contact planes
 
   bool m_resized;
 
 public:
 
-  containerArray<IndexType> m_numFaces; ///< Number of constituent faces
+  ArrayT<IndexT> m_numFaces; ///< Number of constituent faces
 
-  containerArray<IndexType> m_meshId1; ///< Mesh id for first face
-  containerArray<IndexType> m_meshId2; ///< Mesh id for second face
+  ArrayT<IndexT> m_meshId1; ///< Mesh id for first face
+  ArrayT<IndexT> m_meshId2; ///< Mesh id for second face
 
-  containerArray<IndexType> m_fId1; ///< First face id
-  containerArray<IndexType> m_fId2; ///< Second face id
+  ArrayT<IndexT> m_fId1; ///< First face id
+  ArrayT<IndexT> m_fId2; ///< Second face id
 
-  containerArray<real> m_pressure; ///< Contact pressure
-  containerArray<real> m_ratePressure; ///< Velocity gap pressure
+  ArrayT<RealT> m_pressure; ///< Contact pressure
+  ArrayT<RealT> m_ratePressure; ///< Velocity gap pressure
 
-  containerArray<bool> m_inContact; ///< True if faces are in contact
+  ArrayT<bool> m_inContact; ///< True if faces are in contact
 
-  containerArray<bool> m_interpenOverlap; ///< True if interpenetration overlap calculation
+  ArrayT<bool> m_interpenOverlap; ///< True if interpenetration overlap calculation
 
-  containerArray<real> m_cX; ///< Global x-coordinates of contact plane point
-  containerArray<real> m_cY; ///< Global y-coordinates of contact plane point
-  containerArray<real> m_cZ; ///< Global z-coordinates of contact plane point
+  ArrayT<RealT> m_cX; ///< Global x-coordinates of contact plane point
+  ArrayT<RealT> m_cY; ///< Global y-coordinates of contact plane point
+  ArrayT<RealT> m_cZ; ///< Global z-coordinates of contact plane point
 
-  containerArray<real> m_e1X; ///< Global x-component of first in-plane basis vector
-  containerArray<real> m_e1Y; ///< Global y-component of first in-plane basis vector
-  containerArray<real> m_e1Z; ///< Global z-component of first in-plane basis vector
+  ArrayT<RealT> m_e1X; ///< Global x-component of first in-plane basis vector
+  ArrayT<RealT> m_e1Y; ///< Global y-component of first in-plane basis vector
+  ArrayT<RealT> m_e1Z; ///< Global z-component of first in-plane basis vector
 
-  containerArray<real> m_e2X; ///< Global x-component of second in-plane basis vector
-  containerArray<real> m_e2Y; ///< Global y-component of second in-plane basis vector
-  containerArray<real> m_e2Z; ///< Global z-component of second in-plane basis vector
+  ArrayT<RealT> m_e2X; ///< Global x-component of second in-plane basis vector
+  ArrayT<RealT> m_e2Y; ///< Global y-component of second in-plane basis vector
+  ArrayT<RealT> m_e2Z; ///< Global z-component of second in-plane basis vector
 
-  containerArray<real> m_nX; ///< Global x-component of contact plane unit normal
-  containerArray<real> m_nY; ///< Global y-component of contact plane unit normal
-  containerArray<real> m_nZ; ///< Global z-component of contact plane unit normal
+  ArrayT<RealT> m_nX; ///< Global x-component of contact plane unit normal
+  ArrayT<RealT> m_nY; ///< Global y-component of contact plane unit normal
+  ArrayT<RealT> m_nZ; ///< Global z-component of contact plane unit normal
 
-  containerArray<IndexType> m_numPolyVert; ///< Number of overlap polygon vertices
+  ArrayT<IndexT> m_numPolyVert; ///< Number of overlap polygon vertices
 
-  containerArray<real*> m_polyLocX; ///< Local x-coordinates of overlap polygon's vertices
-  containerArray<real*> m_polyLocY; ///< Local y-coordinates of overlap polygon's vertices
+  ArrayT<RealT*> m_polyLocX; ///< Local x-coordinates of overlap polygon's vertices
+  ArrayT<RealT*> m_polyLocY; ///< Local y-coordinates of overlap polygon's vertices
 
-  containerArray<real*> m_polyX; ///< Global x-coordinates of overlap polygon's vertices
-  containerArray<real*> m_polyY; ///< Global y-coordinates of overlap polygon's vertices
-  containerArray<real*> m_polyZ; ///< Global z-coordinates of overlap polygon's vertices
+  ArrayT<RealT*> m_polyX; ///< Global x-coordinates of overlap polygon's vertices
+  ArrayT<RealT*> m_polyY; ///< Global y-coordinates of overlap polygon's vertices
+  ArrayT<RealT*> m_polyZ; ///< Global z-coordinates of overlap polygon's vertices
 
-  containerArray<real> m_overlapCX; ///< Local x-coordinates of overlap centroid
-  containerArray<real> m_overlapCY; ///< Local y-coordinates of overlap centroid
+  ArrayT<RealT> m_overlapCX; ///< Local x-coordinates of overlap centroid
+  ArrayT<RealT> m_overlapCY; ///< Local y-coordinates of overlap centroid
 
-  containerArray<real> m_gap; ///< Contact plane kinematic gap
-  containerArray<real> m_velGap; ///< Velocity (rate) gap
-  containerArray<real> m_gapTol; ///< Gap tolerance
+  ArrayT<RealT> m_gap; ///< Contact plane kinematic gap
+  ArrayT<RealT> m_velGap; ///< Velocity (rate) gap
+  ArrayT<RealT> m_gapTol; ///< Gap tolerance
 
-  containerArray<IndexType> m_numInterpenPoly1Vert; ///< Number of vertices in face 1 interpen. polygon
-  containerArray<real*> m_interpenPoly1X; ///< Local x-coordinates of face 1 interpenetrating polygon 
-  containerArray<real*> m_interpenPoly1Y; ///< Local y-coordinates of face 1 interpenetrating polygon 
+  ArrayT<IndexT> m_numInterpenPoly1Vert; ///< Number of vertices in face 1 interpen. polygon
+  ArrayT<RealT*> m_interpenPoly1X; ///< Local x-coordinates of face 1 interpenetrating polygon 
+  ArrayT<RealT*> m_interpenPoly1Y; ///< Local y-coordinates of face 1 interpenetrating polygon 
 
-  containerArray<IndexType> m_numInterpenPoly2Vert; ///< Number of vertices in face 2 interpen. polygon
-  containerArray<real*> m_interpenPoly2X; ///< Local x-coordinates of face 2 interpenetrating polygon
-  containerArray<real*> m_interpenPoly2Y; ///< Local y-coordinates of face 2 interpenetrating polygon
+  ArrayT<IndexT> m_numInterpenPoly2Vert; ///< Number of vertices in face 2 interpen. polygon
+  ArrayT<RealT*> m_interpenPoly2X; ///< Local x-coordinates of face 2 interpenetrating polygon
+  ArrayT<RealT*> m_interpenPoly2Y; ///< Local y-coordinates of face 2 interpenetrating polygon
 
-  containerArray<real*> m_interpenG1X; ///< Global x-coordinate of face 1 interpenetrating polygon
-  containerArray<real*> m_interpenG1Y; ///< Global y-coordinate of face 1 interpenetrating polygon
-  containerArray<real*> m_interpenG1Z; ///< Global z-coordinate of face 1 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG1X; ///< Global x-coordinate of face 1 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG1Y; ///< Global y-coordinate of face 1 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG1Z; ///< Global z-coordinate of face 1 interpenetrating polygon
 
-  containerArray<real*> m_interpenG2X; ///< Global x-coordinate of face 2 interpenetrating polygon
-  containerArray<real*> m_interpenG2Y; ///< Global y-coordinate of face 2 interpenetrating polygon
-  containerArray<real*> m_interpenG2Z; ///< Global z-coordiante of face 2 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG2X; ///< Global x-coordinate of face 2 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG2Y; ///< Global y-coordinate of face 2 interpenetrating polygon
+  ArrayT<RealT*> m_interpenG2Z; ///< Global z-coordiante of face 2 interpenetrating polygon
 
-  containerArray<real> m_areaFrac; ///< Area fraction for polygon overlap inclusion
-  containerArray<real> m_areaMin; ///< Minimum overlap area to include in the active set
-  containerArray<real> m_area; ///< Overlap area
-  containerArray<real> m_interpenArea; ///< Area of the interpenetrating overlap
+  ArrayT<RealT> m_areaFrac; ///< Area fraction for polygon overlap inclusion
+  ArrayT<RealT> m_areaMin; ///< Minimum overlap area to include in the active set
+  ArrayT<RealT> m_area; ///< Overlap area
+  ArrayT<RealT> m_interpenArea; ///< Area of the interpenetrating overlap
 
-  containerArray<real> m_cXf1; ///< Global x-coord of the contact plane centroid projected to face 1
-  containerArray<real> m_cYf1; ///< Global y-coord of the contact plane centroid projected to face 1
-  containerArray<real> m_cZf1; ///< Global z-coord of the contact plane centroid projected to face 1
+  ArrayT<RealT> m_cXf1; ///< Global x-coord of the contact plane centroid projected to face 1
+  ArrayT<RealT> m_cYf1; ///< Global y-coord of the contact plane centroid projected to face 1
+  ArrayT<RealT> m_cZf1; ///< Global z-coord of the contact plane centroid projected to face 1
 
-  containerArray<real> m_cXf2; ///< Global x-coord of the contact plane centroid projected to face 2
-  containerArray<real> m_cYf2; ///< Global y-coord of the contact plane centroid projected to face 2
-  containerArray<real> m_cZf2; ///< Global z-coord of the contact plane centroid projected to face 2
+  ArrayT<RealT> m_cXf2; ///< Global x-coord of the contact plane centroid projected to face 2
+  ArrayT<RealT> m_cYf2; ///< Global y-coord of the contact plane centroid projected to face 2
+  ArrayT<RealT> m_cZf2; ///< Global z-coord of the contact plane centroid projected to face 2
 
-  containerArray<real*> m_segX; ///< Global x-coordinate of the overlap vertices (2D)
-  containerArray<real*> m_segY; ///< Global y_coordinate of the overlap vertices (2D)
+  ArrayT<RealT*> m_segX; ///< Global x-coordinate of the overlap vertices (2D)
+  ArrayT<RealT*> m_segY; ///< Global y_coordinate of the overlap vertices (2D)
 
 public:
   /*!
@@ -123,14 +123,14 @@ public:
   *
   * \return Number of contact planes 
   */
-  integer size() const { return m_numContactPlanes; }
+  int size() const { return m_numContactPlanes; }
 
   /*!
    * \brief Wrapper routine for adding 2D and 3D contact planes to the list.
    *
    * \param [in] newSize New size of the container
    */
-  void resize( IndexType const newSize );
+  void resize( IndexT const newSize );
 
   /*!
    * \brief Wrapper routine to allocate space for newSize 2D or 
@@ -138,21 +138,21 @@ public:
    *
    * \param [in] newSize New size of the container
    */
-  void reserve( IndexType const newSize );
+  void reserve( IndexT const newSize );
 
   /*!
   * \brief 3D routine to allocate space for newSize contact planes
   *
   * \param [in] newSize New size of the container
   */
-  void reserve3D( IndexType const newSize );
+  void reserve3D( IndexT const newSize );
 
   /*!
   * \brief 2D routine to allocate space for newSize contact planes
   *
   * \param [in] newSize New size of the container
   */
-  void reserve2D( IndexType const newSize );
+  void reserve2D( IndexT const newSize );
 
   /*!
   * \brief Set the space dimension
@@ -206,7 +206,7 @@ public:
   *
   * \pre coords points to a 1D array of size (problem dimension) x numVerts.
   */
-  void getContactPlaneOverlapVerts( int const id, int const numVerts, real * coords );
+  void getContactPlaneOverlapVerts( int const id, int const numVerts, RealT * coords );
 
   /*!
   * \brief returns pointer to array of stacked components of the contact 
@@ -217,7 +217,7 @@ public:
   * \param [in/out] coords pointer to array of stacked normal components 
   *
   */
-  void getContactPlaneNormal( int const id, int const dim, real * nrml );
+  void getContactPlaneNormal( int const id, int const dim, RealT * nrml );
 
   /*!
   * \brief populates pointer to array of stacked (x,y,z) coordinates of 
@@ -231,7 +231,7 @@ public:
   * \pre faceId is 0 or 1 for first or second face, respectively
   */
   void getProjectedFaceCoords( int const id, int const faceId,
-                               real * coords );
+                               RealT * coords );
 
   /*!
   * \brief clear contact plane manager 

--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -17,19 +17,19 @@
 namespace tribol
 {
 
-void ProjectPointToPlane( const real x, const real y, const real z, 
-                          const real nx, const real ny, const real nz,
-                          const real ox, const real oy, const real oz, 
-                          real& px, real& py, real& pz )
+void ProjectPointToPlane( const RealT x, const RealT y, const RealT z, 
+                          const RealT nx, const RealT ny, const RealT nz,
+                          const RealT ox, const RealT oy, const RealT oz, 
+                          RealT& px, RealT& py, RealT& pz )
 {
    // compute the vector from input point to be projected to 
    // the origin point on the plane
-   real vx = x - ox;
-   real vy = y - oy;
-   real vz = z - oz;
+   RealT vx = x - ox;
+   RealT vy = y - oy;
+   RealT vz = z - oz;
 
    // compute the projection onto the plane normal
-   real dist = vx * nx + vy * ny + vz * nz;
+   RealT dist = vx * nx + vy * ny + vz * nz;
 
    // compute the projected coordinates of the input point
    px = x - dist*nx;
@@ -41,18 +41,18 @@ void ProjectPointToPlane( const real x, const real y, const real z,
 } // end ProjectPointToPlane()
 
 //------------------------------------------------------------------------------
-void ProjectPointToSegment( const real x, const real y,
-                            const real nx, const real ny,
-                            const real ox, const real oy,
-                            real& px, real& py )
+void ProjectPointToSegment( const RealT x, const RealT y,
+                            const RealT nx, const RealT ny,
+                            const RealT ox, const RealT oy,
+                            RealT& px, RealT& py )
 {
    // compute the vector from input point to be projected to 
    // the origin point on the plane
-   real vx = x - ox;
-   real vy = y - oy;
+   RealT vx = x - ox;
+   RealT vy = y - oy;
 
    // compute the projection onto the plane normal
-   real dist = vx * nx + vy * ny;
+   RealT dist = vx * nx + vy * ny;
 
    // compute the projected coordinates of the input point
    px = x - dist * nx;
@@ -64,31 +64,31 @@ void ProjectPointToSegment( const real x, const real y,
 
 //------------------------------------------------------------------------------
 void PolyInterYCentroid( const int namax,
-                         const real* const RESTRICT xa,
-                         const real* const RESTRICT ya,
+                         const RealT* const RESTRICT xa,
+                         const RealT* const RESTRICT ya,
                          const int nbmax,
-                         const real* const RESTRICT xb,
-                         const real* const RESTRICT yb,
+                         const RealT* const RESTRICT xb,
+                         const RealT* const RESTRICT yb,
                          const int isym,
-                         real & area,
-                         real & ycent )
+                         RealT & area,
+                         RealT & ycent )
 {
 
-   real vol;
+   RealT vol;
 
    // calculate origin shift to avoid roundoff errors
-   real xorg = FLT_MAX;
-   real yorg = FLT_MAX;
-   real xa_min = FLT_MAX;
-   real xa_max = -FLT_MAX;
-   real ya_min = FLT_MAX;
-   real ya_max = -FLT_MAX;
-   real xb_min = FLT_MAX;
-   real xb_max = -FLT_MAX;
-   real yb_min = FLT_MAX;
-   real yb_max = -FLT_MAX;
+   RealT xorg = FLT_MAX;
+   RealT yorg = FLT_MAX;
+   RealT xa_min = FLT_MAX;
+   RealT xa_max = -FLT_MAX;
+   RealT ya_min = FLT_MAX;
+   RealT ya_max = -FLT_MAX;
+   RealT xb_min = FLT_MAX;
+   RealT xb_max = -FLT_MAX;
+   RealT yb_min = FLT_MAX;
+   RealT yb_max = -FLT_MAX;
 
-   real qy = 0.0;
+   RealT qy = 0.0;
 
    if (nbmax < 1 || namax < 1) {
       area = 0.0;
@@ -152,10 +152,10 @@ void PolyInterYCentroid( const int namax,
    // loop over faces of polygon a
    for (int na = 0 ; na < namax ; ++na) {
       int nap = (na+1)%namax;
-      real xa1 = xa[na]  - xorg;
-      real ya1 = ya[na]  - yorg;
-      real xa2 = xa[nap] - xorg;
-      real ya2 = ya[nap] - yorg;
+      RealT xa1 = xa[na]  - xorg;
+      RealT ya1 = ya[na]  - yorg;
+      RealT xa2 = xa[nap] - xorg;
+      RealT ya2 = ya[nap] - yorg;
       if (isym==1) {
          if (ya[na]<0.0 && ya[nap]<0.0) {
             continue;
@@ -173,20 +173,20 @@ void PolyInterYCentroid( const int namax,
             ya2 = -yorg;
          }
       }
-      real dxa = xa2 - xa1;
+      RealT dxa = xa2 - xa1;
       if (dxa==0.0) {
          continue;
       }
-      real dya = ya2 - ya1;
-      real slopea = dya/dxa;
+      RealT dya = ya2 - ya1;
+      RealT slopea = dya/dxa;
 
       // loop over faces of polygon b
       for (int nb = 0 ; nb < nbmax ; ++nb) {
          int nbp = (nb+1)%nbmax;
-         real xb1 = xb[nb]  - xorg;
-         real yb1 = yb[nb]  - yorg;
-         real xb2 = xb[nbp] - xorg;
-         real yb2 = yb[nbp] - yorg;
+         RealT xb1 = xb[nb]  - xorg;
+         RealT yb1 = yb[nb]  - yorg;
+         RealT xb2 = xb[nbp] - xorg;
+         RealT yb2 = yb[nbp] - yorg;
          if (isym==1) {
             if (yb[nb]<0.0 && yb[nbp]<0.0) {
                continue;
@@ -204,42 +204,42 @@ void PolyInterYCentroid( const int namax,
                yb2 = -yorg;
             }
          }
-         real dxb = xb2 - xb1;
+         RealT dxb = xb2 - xb1;
          if (dxb==0.0) {
             continue;
          }
-         real dyb = yb2 - yb1;
-         real slopeb = dyb/dxb;
+         RealT dyb = yb2 - yb1;
+         RealT slopeb = dyb/dxb;
 
          // determine sign of volume of intersection
-         real s = dxa * dxb;
+         RealT s = dxa * dxb;
 
          // calculate left and right coordinates of overlap
-         real xl = axom::utilities::max(axom::utilities::min(xa1, xa2), axom::utilities::min(xb1, xb2) );
-         real xr = axom::utilities::min(axom::utilities::max(xa1, xa2), axom::utilities::max(xb1, xb2) );
+         RealT xl = axom::utilities::max(axom::utilities::min(xa1, xa2), axom::utilities::min(xb1, xb2) );
+         RealT xr = axom::utilities::min(axom::utilities::max(xa1, xa2), axom::utilities::max(xb1, xb2) );
          if (xl>=xr) {
             continue;
          }
-         real yla = ya1 + (xl-xa1)*slopea;
-         real ylb = yb1 + (xl-xb1)*slopeb;
-         real yra = ya1 + (xr-xa1)*slopea;
-         real yrb = yb1 + (xr-xb1)*slopeb;
-         real yl = axom::utilities::min(yla, ylb);
-         real yr = axom::utilities::min(yra, yrb);
+         RealT yla = ya1 + (xl-xa1)*slopea;
+         RealT ylb = yb1 + (xl-xb1)*slopeb;
+         RealT yra = ya1 + (xr-xa1)*slopea;
+         RealT yrb = yb1 + (xr-xb1)*slopeb;
+         RealT yl = axom::utilities::min(yla, ylb);
+         RealT yr = axom::utilities::min(yra, yrb);
 
-         real area1;
-         real qy1;
-         real ym;
+         RealT area1;
+         RealT qy1;
+         RealT ym;
 
          // check if lines intersect
-         real dslope = slopea - slopeb;
+         RealT dslope = slopea - slopeb;
          if (dslope!=0.0) {
-            real xm = (yb1 - ya1 + slopea*xa1 - slopeb*xb1)/dslope;
+            RealT xm = (yb1 - ya1 + slopea*xa1 - slopeb*xb1)/dslope;
             ym = ya1 + slopea*(xm-xa1);
             if (xm>xl && xm<xr) {
                // lines intersect, case ii
                area1 = 0.5 * copysign((yl+ym)*(xm-xl), s);
-               real area2 = 0.5 * copysign((ym+yr)*(xr-xm), s);
+               RealT area2 = 0.5 * copysign((ym+yr)*(xr-xm), s);
                area  = area + area1 + area2;
 
                if (yl+ym>0) {
@@ -247,7 +247,7 @@ void PolyInterYCentroid( const int namax,
                   qy  = qy + qy1;
                }
                if (ym+yr>0) {
-                  real qy2 = 1.0/3.0*(yr+ym*ym/(ym+yr))*area2;
+                  RealT qy2 = 1.0/3.0*(yr+ym*ym/(ym+yr))*area2;
                   qy  = qy + qy2;
                }
 
@@ -292,19 +292,19 @@ void PolyInterYCentroid( const int namax,
 } // end PolyInterYCentroid()
 
 //------------------------------------------------------------------------------
-void Local2DToGlobalCoords( real xloc, real yloc, 
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real& xg, real& yg, real& zg )
+void Local2DToGlobalCoords( RealT xloc, RealT yloc, 
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT& xg, RealT& yg, RealT& zg )
 {
 
    // This projection takes the two input local vector components and uses 
    // them as coefficients in a linear combination of local basis vectors. 
    // This gives a 3-vector with origin at the common plane centroid.
-   real vx = xloc * e1X + yloc * e2X;
-   real vy = xloc * e1Y + yloc * e2Y;
-   real vz = xloc * e1Z + yloc * e2Z;
+   RealT vx = xloc * e1X + yloc * e2X;
+   RealT vy = xloc * e1Y + yloc * e2Y;
+   RealT vz = xloc * e1Z + yloc * e2Z;
    
    // the vector in the global coordinate system requires the addition of the 
    // plane point vector (global Cartesian coordinate basis) to the previously 
@@ -318,14 +318,14 @@ void Local2DToGlobalCoords( real xloc, real yloc,
 } // end Local2DToGlobalCoords()
 
 //------------------------------------------------------------------------------
-void GlobalTo2DLocalCoords( const real* const RESTRICT pX, 
-                            const real* const RESTRICT pY, 
-                            const real* const RESTRICT pZ,
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real* const RESTRICT pLX, 
-                            real* const RESTRICT pLY, int size )
+void GlobalTo2DLocalCoords( const RealT* const RESTRICT pX, 
+                            const RealT* const RESTRICT pY, 
+                            const RealT* const RESTRICT pZ,
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT* const RESTRICT pLX, 
+                            RealT* const RESTRICT pLY, int size )
 {
 
    SLIC_ERROR_IF(size > 0 && (pLX == nullptr || pLY == nullptr),
@@ -335,9 +335,9 @@ void GlobalTo2DLocalCoords( const real* const RESTRICT pX,
    for (int i=0; i<size; ++i) {
 
       // compute the vector between the point on the plane and the input plane point
-      real vX = pX[i] - cX;
-      real vY = pY[i] - cY;
-      real vZ = pZ[i] - cZ;
+      RealT vX = pX[i] - cX;
+      RealT vY = pY[i] - cY;
+      RealT vZ = pZ[i] - cZ;
 
       // project this vector onto the {e1,e2} local basis. This vector is 
       // in the plane so the out-of-plane component should be zero.
@@ -351,16 +351,16 @@ void GlobalTo2DLocalCoords( const real* const RESTRICT pX,
 } // end GlobalTo2DLocalCoords()
 
 //------------------------------------------------------------------------------
-void GlobalTo2DLocalCoords( real pX, real pY, real pZ,
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real& pLX, real& pLY )
+void GlobalTo2DLocalCoords( RealT pX, RealT pY, RealT pZ,
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT& pLX, RealT& pLY )
 {
    // compute the vector between the point on the plane and the input plane point
-   real vX = pX - cX;
-   real vY = pY - cY;
-   real vZ = pZ - cZ;
+   RealT vX = pX - cX;
+   RealT vY = pY - cY;
+   RealT vZ = pZ - cZ;
 
    // project this vector onto the {e1,e2} local basis. This vector is 
    // in the plane so the out-of-plane component should be zero.
@@ -372,11 +372,11 @@ void GlobalTo2DLocalCoords( real pX, real pY, real pZ,
 } // end GlobalTo2DLocalCoords()
 
 //------------------------------------------------------------------------------
-void VertexAvgCentroid( const real* const RESTRICT x, 
-                        const real* const RESTRICT y, 
-                        const real* const RESTRICT z, 
+void VertexAvgCentroid( const RealT* const RESTRICT x, 
+                        const RealT* const RESTRICT y, 
+                        const RealT* const RESTRICT z, 
                         const int numVert,
-                        real& cX, real& cY, real& cZ )
+                        RealT& cX, RealT& cY, RealT& cZ )
 {
    SLIC_ERROR_IF (numVert==0, "VertexAvgCentroid: numVert = 0.");
 
@@ -386,7 +386,7 @@ void VertexAvgCentroid( const real* const RESTRICT x,
    cZ = 0.0;
 
    // loop over nodes adding the position components
-   real fac = 1.0 / numVert;
+   RealT fac = 1.0 / numVert;
    for (int i=0; i<numVert; ++i) {
       cX += x[i];
       cY += y[i];
@@ -406,10 +406,10 @@ void VertexAvgCentroid( const real* const RESTRICT x,
 } // end VertexAvgCentroid()
 
 //------------------------------------------------------------------------------
-void VertexAvgCentroid( const real* const RESTRICT x, 
+void VertexAvgCentroid( const RealT* const RESTRICT x, 
                         const int dim,
                         const int numVert,
-                        real& cX, real& cY, real& cZ )
+                        RealT& cX, RealT& cY, RealT& cZ )
 {
    SLIC_ERROR_IF(numVert==0, "VertexAvgCentroid: numVert = 0.");
 
@@ -419,7 +419,7 @@ void VertexAvgCentroid( const real* const RESTRICT x,
    cZ = 0.0;
 
    // loop over nodes adding the position components
-   real fac = 1.0 / numVert;
+   RealT fac = 1.0 / numVert;
    for (int i=0; i<numVert; ++i) {
       cX += x[dim*i];
       cY += x[dim*i+1];
@@ -439,10 +439,10 @@ void VertexAvgCentroid( const real* const RESTRICT x,
 } // end VertexAvgCentroid()
 
 //------------------------------------------------------------------------------
-void PolyAreaCentroid( const real* const RESTRICT x, 
+void PolyAreaCentroid( const RealT* const RESTRICT x, 
                        const int dim,
                        const int numVert,
-                       real& cX, real& cY, real& cZ )
+                       RealT& cX, RealT& cY, RealT& cZ )
 {
    SLIC_ERROR_IF(numVert==0, "PolyAreaCentroid: numVert = 0.");
 
@@ -453,21 +453,21 @@ void PolyAreaCentroid( const real* const RESTRICT x,
 
    // compute the vertex average centroid of the polygon in 
    // order to break it up into triangles
-   real cX_poly, cY_poly, cZ_poly;
+   RealT cX_poly, cY_poly, cZ_poly;
    VertexAvgCentroid( x, dim, numVert, cX_poly, cY_poly, cZ_poly);
 
    // loop over triangles formed from adjacent polygon vertices 
    // and the vertex averaged centroid
-   real xTri[3] = { 0., 0., 0. };
-   real yTri[3] = { 0., 0., 0. };
-   real zTri[3] = { 0., 0., 0. };
+   RealT xTri[3] = { 0., 0., 0. };
+   RealT yTri[3] = { 0., 0., 0. };
+   RealT zTri[3] = { 0., 0., 0. };
    
    // assign all of the last triangle coordinates to the 
    // polygon's vertex average centroid
    xTri[2] = cX_poly;
    yTri[2] = cY_poly;
    zTri[2] = cZ_poly;
-   real area_sum = 0.;
+   RealT area_sum = 0.;
    for (int i=0; i<numVert; ++i) // loop over triangles
    {
       // group triangle coordinates
@@ -481,11 +481,11 @@ void PolyAreaCentroid( const real* const RESTRICT x,
       zTri[1] = x[ dim * triIdPlusOne + 2 ];
 
       // compute the area of the triangle
-      real area_tri = Area3DTri( xTri, yTri, zTri );
+      RealT area_tri = Area3DTri( xTri, yTri, zTri );
       area_sum += area_tri;
 
       // compute the vertex average centroid of the triangle 
-      real cX_tri, cY_tri, cZ_tri;
+      RealT cX_tri, cY_tri, cZ_tri;
       VertexAvgCentroid( &xTri[0], &yTri[0], &zTri[0],
                          3, cX_tri, cY_tri, cZ_tri );
 
@@ -504,10 +504,10 @@ void PolyAreaCentroid( const real* const RESTRICT x,
 } // end PolyAreaCentroid()
 
 //------------------------------------------------------------------------------
-void PolyCentroid( const real* const RESTRICT x, 
-                   const real* const RESTRICT y,
+void PolyCentroid( const RealT* const RESTRICT x, 
+                   const RealT* const RESTRICT y,
                    const int numVert,
-                   real& cX, real& cY )
+                   RealT& cX, RealT& cY )
 {
    SLIC_ERROR_IF(numVert==0, "PolyAreaCentroid: numVert = 0.");
 
@@ -515,7 +515,7 @@ void PolyCentroid( const real* const RESTRICT x,
    cX = 0.0;
    cY = 0.0;
 
-   real area = 0.;
+   RealT area = 0.;
 
    for (int i=0; i<numVert; ++i)
    {
@@ -527,23 +527,23 @@ void PolyCentroid( const real* const RESTRICT x,
 
    area *= 1./2.;
 
-   real fac = 1./(6.*area);
+   RealT fac = 1./(6.*area);
    cX *= fac;
    cY *= fac; 
  
 } // end PolyCentroid()
 
 //------------------------------------------------------------------------------
-FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA, 
-                                     const real* const RESTRICT yA, 
+FaceGeomError Intersection2DPolygon( const RealT* const RESTRICT xA, 
+                                     const RealT* const RESTRICT yA, 
                                      const int numVertexA, 
-                                     const real* const RESTRICT xB, 
-                                     const real* const RESTRICT yB, 
+                                     const RealT* const RESTRICT xB, 
+                                     const RealT* const RESTRICT yB, 
                                      const int numVertexB,
-                                     real posTol, real lenTol, 
-                                     real* RESTRICT * RESTRICT polyX, 
-                                     real* RESTRICT * RESTRICT polyY, 
-                                     int& numPolyVert, real& area, bool orientCheck )
+                                     RealT posTol, RealT lenTol, 
+                                     RealT* RESTRICT * RESTRICT polyX, 
+                                     RealT* RESTRICT * RESTRICT polyY, 
+                                     int& numPolyVert, RealT& area, bool orientCheck )
 {
    // for tribol, if you have called this routine it is because a positive area of 
    // overlap between two polygons (faces) exists. This routine does not perform a 
@@ -591,11 +591,11 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
    initIntArray( &interiorVBId[0], numVertexB, -1 );
 
    // precompute the vertex averaged centroids for both polygons. 
-   real xCA = 0.0;
-   real yCA = 0.0;
-   real xCB = 0.0;
-   real yCB = 0.0;
-   real zC = 0.0; // not required, only used as dummy argument in centroid routine
+   RealT xCA = 0.0;
+   RealT yCA = 0.0;
+   RealT xCB = 0.0;
+   RealT yCB = 0.0;
+   RealT zC = 0.0; // not required, only used as dummy argument in centroid routine
 
    VertexAvgCentroid( xA, yA, nullptr, numVertexA, xCA, yCA, zC );
    VertexAvgCentroid( xB, yB, nullptr, numVertexB, xCB, yCB, zC );
@@ -620,16 +620,16 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
    // check to see if ALL of A is in B; then A is the overlapping polygon.
    if (numVAI == numVertexA)
    {
-      *polyX = new real[ numVertexA ];
-      *polyY = new real[ numVertexA ];
+      *polyX = new RealT[ numVertexA ];
+      *polyY = new RealT[ numVertexA ];
       numPolyVert = numVertexA;
       for (int i=0; i<numVertexA; ++i)
       {
          (*polyX)[i] = xA[i];
          (*polyY)[i] = yA[i];
       }
-      real* xVert = *polyX;
-      real* yVert = *polyY;
+      RealT* xVert = *polyX;
+      RealT* yVert = *polyY;
       area = Area2DPolygon( xVert, yVert, numVertexA );
       return NO_FACE_GEOM_ERROR;
    }
@@ -648,16 +648,16 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
    // check to see if ALL of B is in A; then B is the overlapping polygon.
    if (numVBI == numVertexB)
    {
-      *polyX = new real[ numVertexB ];
-      *polyY = new real[ numVertexB ];
+      *polyX = new RealT[ numVertexB ];
+      *polyY = new RealT[ numVertexB ];
       numPolyVert = numVertexB;
       for (int i=0; i<numVertexB; ++i)
       {
          (*polyX)[i] = xB[i];
          (*polyY)[i] = yB[i];
       }
-      real* xVert = *polyX;
-      real* yVert = *polyY;
+      RealT* xVert = *polyX;
+      RealT* yVert = *polyY;
       area = Area2DPolygon( xVert, yVert, numVertexB );
       return NO_FACE_GEOM_ERROR;
    }
@@ -675,9 +675,9 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
             if (interiorVBId[j] != -1)
             {
               // compute the distance between interior vertices
-              real distX = xA[i] - xB[j];
-              real distY = yA[i] - yB[j];
-              real distMag = magnitude( distX, distY );
+              RealT distX = xA[i] - xB[j];
+              RealT distY = yA[i] - yB[j];
+              RealT distMag = magnitude( distX, distY );
               if (distMag < 1.E-15)
               {
                  // remove the interior designation for the vertex in polygon B
@@ -697,8 +697,8 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
 
    // allocate space to store the segment-segment intersection vertex coords. 
    // and a boolean array to indicate intersecting pairs
-   real interX[ maxSegInter ];
-   real interY[ maxSegInter ];
+   RealT interX[ maxSegInter ];
+   RealT interY[ maxSegInter ];
    bool intersect[ maxSegInter ];
    bool dupl; // boolean to indicate a segment-segment intersection that 
               // duplicates an existing interior vertex.
@@ -775,8 +775,8 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
    // allocate temp intersection polygon vertex coordinate arrays to consist 
    // of segment-segment intersections and number of interior points in A and B
    numPolyVert = numSegInter + numVAI + numVBI;
-   real polyXTemp[ numPolyVert ];
-   real polyYTemp[ numPolyVert ];
+   RealT polyXTemp[ numPolyVert ];
+   RealT polyYTemp[ numPolyVert ];
 
    // fill polyXTemp and polyYTemp with the intersection points
    int k = 0;
@@ -852,8 +852,8 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
    }
 
    // compute the area of the polygon
-   real* xVert = *polyX;
-   real* yVert = *polyY;
+   RealT* xVert = *polyX;
+   RealT* yVert = *polyY;
    area = 0.0;
    area = Area2DPolygon( xVert, yVert, numPolyVert );
 
@@ -862,8 +862,8 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
 } // end Intersection2DPolygon()
 
 //------------------------------------------------------------------------------
-bool CheckPolyOrientation( const real* const RESTRICT x, 
-                           const real* const RESTRICT y, 
+bool CheckPolyOrientation( const RealT* const RESTRICT x, 
+                           const RealT* const RESTRICT y, 
                            const int numVertex )
 {
    bool check = true;
@@ -874,25 +874,25 @@ bool CheckPolyOrientation( const real* const RESTRICT x,
       int ib = (i == (numVertex-1)) ? 0 : (i+1);
 
       // compute segment vector
-      real lambdaX = x[ib] - x[ia];
-      real lambdaY = y[ib] - y[ia];
+      RealT lambdaX = x[ib] - x[ia];
+      RealT lambdaY = y[ib] - y[ia];
     
       // determine segment normal 
-      real nrmlx = -lambdaY;
-      real nrmly = lambdaX;
+      RealT nrmlx = -lambdaY;
+      RealT nrmly = lambdaX;
 
       // compute vertex-averaged centroid
-      real* z = nullptr;
-      real xc, yc, zc;
+      RealT* z = nullptr;
+      RealT xc, yc, zc;
       VertexAvgCentroid( x, y, z, numVertex, xc, yc, zc );
 
       // compute vector between centroid and first vertex of current segment
-      real vx = xc - x[ia];
-      real vy = yc - y[ia];
+      RealT vx = xc - x[ia];
+      RealT vy = yc - y[ia];
 
       // compute dot product between segment normal and centroid-to-vertex vector.
       // the normal points inward toward the centroid
-      real prod = vx * nrmlx + vy * nrmly;
+      RealT prod = vx * nrmlx + vy * nrmly;
 
       if (prod < 0.) // don't keep checking
       {
@@ -905,10 +905,10 @@ bool CheckPolyOrientation( const real* const RESTRICT x,
 } // end CheckPolyOrientation()
 
 //------------------------------------------------------------------------------
-bool Point2DInFace( const real xPoint, const real yPoint, 
-                    const real* const RESTRICT xPoly, 
-                    const real* const RESTRICT yPoly,
-                    const real xC, const real yC, 
+bool Point2DInFace( const RealT xPoint, const RealT yPoint, 
+                    const RealT* const RESTRICT xPoly, 
+                    const RealT* const RESTRICT yPoly,
+                    const RealT xC, const RealT yC, 
                     const int numPolyVert )
 {
    SLIC_ERROR_IF(numPolyVert<3, "Point2DInFace: number of face vertices is less than 3");
@@ -926,8 +926,8 @@ bool Point2DInFace( const real xPoint, const real yPoint,
    for (int i=0; i<numPolyVert; ++i)
    {
 
-      real xTri[3];
-      real yTri[3];
+      RealT xTri[3];
+      RealT yTri[3];
 
       // construct polygon using i^th segment vertices and face centroid
       xTri[0] = xPoly[i];
@@ -953,36 +953,36 @@ bool Point2DInFace( const real xPoint, const real yPoint,
 } // end Point2DInFace()
 
 //------------------------------------------------------------------------------
-bool Point2DInTri( const real xp, const real yp, 
-                   const real* const RESTRICT xTri, 
-                   const real* const RESTRICT yTri )
+bool Point2DInTri( const RealT xp, const RealT yp, 
+                   const RealT* const RESTRICT xTri, 
+                   const RealT* const RESTRICT yTri )
 {
    bool inside = false;
 
    // compute coordinate basis between the 1-2 and 1-3 vertices
-   real e1x = xTri[1] - xTri[0];
-   real e1y = yTri[1] - yTri[0];
+   RealT e1x = xTri[1] - xTri[0];
+   RealT e1y = yTri[1] - yTri[0];
 
-   real e2x = xTri[2] - xTri[0];
-   real e2y = yTri[2] - yTri[0];
+   RealT e2x = xTri[2] - xTri[0];
+   RealT e2y = yTri[2] - yTri[0];
 
    // compute vector components of vector between point and first vertex
-   real p1x = xp - xTri[0];
-   real p1y = yp - yTri[0];
+   RealT p1x = xp - xTri[0];
+   RealT p1y = yp - yTri[0];
 
    // compute dot products (e1,e1), (e1,e2), (e2,e2), (p1,e1), and (p1,e2)
-   real e11 =  e1x * e1x + e1y * e1y;
-   real e12 =  e1x * e2x + e1y * e2y;
-   real e22 =  e2x * e2x + e2y * e2y;
-   real p1e1 = p1x * e1x + p1y * e1y;
-   real p1e2 = p1x * e2x + p1y * e2y;
+   RealT e11 =  e1x * e1x + e1y * e1y;
+   RealT e12 =  e1x * e2x + e1y * e2y;
+   RealT e22 =  e2x * e2x + e2y * e2y;
+   RealT p1e1 = p1x * e1x + p1y * e1y;
+   RealT p1e2 = p1x * e2x + p1y * e2y;
 
    // compute the inverse determinant
-   real invDet = 1.0 / (e11 * e22 - e12 * e12);
+   RealT invDet = 1.0 / (e11 * e22 - e12 * e12);
 
    // compute 2 local barycentric coordinates
-   real u = invDet * (e22 * p1e1 - e12 * p1e2);
-   real v = invDet * (e11 * p1e2 - e12 * p1e1); 
+   RealT u = invDet * (e22 * p1e1 - e12 * p1e2);
+   RealT v = invDet * (e11 * p1e2 - e12 * p1e1); 
    
    // u or v may be negative, but numerically zero. Address this
    u = (std::abs(u) < 1.e-12) ? 0.0 : u;
@@ -998,17 +998,17 @@ bool Point2DInTri( const real xp, const real yp,
 } // end Point2DInTri()
 
 //------------------------------------------------------------------------------
-real Area2DPolygon( const real* const RESTRICT x, 
-                    const real* const RESTRICT y, 
+RealT Area2DPolygon( const RealT* const RESTRICT x, 
+                    const RealT* const RESTRICT y, 
                     const int numPolyVert )
 {
 
-   real area = 0.;
+   RealT area = 0.;
 
    // compute vertex-averaged centroid to construct a triangle between segment 
    // vertices and centroid
-   real* z = nullptr;
-   real xc, yc, zc;
+   RealT* z = nullptr;
+   RealT xc, yc, zc;
    VertexAvgCentroid(x, y, z, numPolyVert, xc, yc, zc);
 
    for (int i=0; i<numPolyVert; ++i)
@@ -1026,22 +1026,22 @@ real Area2DPolygon( const real* const RESTRICT x,
 } // end Area2DPolygon()
 
 //------------------------------------------------------------------------------
-real Area3DTri( const real* const RESTRICT x,
-                const real* const RESTRICT y,
-                const real* const RESTRICT z )
+RealT Area3DTri( const RealT* const RESTRICT x,
+                const RealT* const RESTRICT y,
+                const RealT* const RESTRICT z )
 {
-   real u[3] = { x[1] - x[0], y[1] - y[0], z[1] - z[0] };
-   real v[3] = { x[2] - x[0], y[2] - y[0], z[2] - z[0] };
+   RealT u[3] = { x[1] - x[0], y[1] - y[0], z[1] - z[0] };
+   RealT v[3] = { x[2] - x[0], y[2] - y[0], z[2] - z[0] };
 
    return std::abs( 1./2. * magCrossProd( u, v ));
 
 } // end Area3DTri()
 
 //------------------------------------------------------------------------------
-bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, const real yB1,
-                            const real xA2, const real yA2, const real xB2, const real yB2,
-                            const bool* const RESTRICT interior, real& x, real& y, 
-                            bool& duplicate, const real tol )
+bool SegmentIntersection2D( const RealT xA1, const RealT yA1, const RealT xB1, const RealT yB1,
+                            const RealT xA2, const RealT yA2, const RealT xB2, const RealT yB2,
+                            const bool* const RESTRICT interior, RealT& x, RealT& y, 
+                            bool& duplicate, const RealT tol )
 {
    // note 1: this routine computes a unique segment-segment intersection, where two 
    // segments are assumed to intersect at a single point. A segment-segment overlap 
@@ -1059,20 +1059,20 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
    // be in the list of overlapping polygon vertices prior to calling this routine.
 
    // compute segment vectors
-   real lambdaX1 = xB1 - xA1;
-   real lambdaY1 = yB1 - yA1;
+   RealT lambdaX1 = xB1 - xA1;
+   RealT lambdaY1 = yB1 - yA1;
 
-   real lambdaX2 = xB2 - xA2;
-   real lambdaY2 = yB2 - yA2;
+   RealT lambdaX2 = xB2 - xA2;
+   RealT lambdaY2 = yB2 - yA2;
 
-   real seg1Mag = magnitude( lambdaX1, lambdaY1 );
-   real seg2Mag = magnitude( lambdaX2, lambdaY2 );
+   RealT seg1Mag = magnitude( lambdaX1, lambdaY1 );
+   RealT seg2Mag = magnitude( lambdaX2, lambdaY2 );
 
    // compute determinant of the lambda matrix, [ -lx1 -ly1, lx2 ly2 ]
-   real det = -lambdaX1 * lambdaY2 + lambdaX2 * lambdaY1;
+   RealT det = -lambdaX1 * lambdaY2 + lambdaX2 * lambdaY1;
 
    // return false if det = 0. Check for numerically zero determinant
-   real detTol = 1.E-12;
+   RealT detTol = 1.E-12;
    if (det > -detTol && det < detTol)
    {
       x = 0.;
@@ -1082,11 +1082,11 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
    }
 
    // compute intersection
-   real invDet = 1.0 / det;
-   real rX = xA1 - xA2;
-   real rY = yA1 - yA2;
-   real tA = invDet * (rX * lambdaY2 - rY * lambdaX2);
-   real tB = invDet * (rX * lambdaY1 - rY * lambdaX1);
+   RealT invDet = 1.0 / det;
+   RealT rX = xA1 - xA2;
+   RealT rY = yA1 - yA2;
+   RealT tA = invDet * (rX * lambdaY2 - rY * lambdaX2);
+   RealT tB = invDet * (rX * lambdaY1 - rY * lambdaX1);
 
    // if tA and tB don't lie between [0,1] then return false.
    if ((tA < 0. || tA > 1.) || (tB < 0. || tB > 1.))
@@ -1103,19 +1103,19 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
      // debug check to make sure the intersection coordinates derived from 
      // each segment equation (scaled with tA and tB) are the same to some 
      // tolerance
-     real xTest1 = xA1 + lambdaX1 * tA;
-     real yTest1 = yA1 + lambdaY1 * tA;
-     real xTest2 = xA2 + lambdaX2 * tB; 
-     real yTest2 = yA2 + lambdaY2 * tB; 
+     RealT xTest1 = xA1 + lambdaX1 * tA;
+     RealT yTest1 = yA1 + lambdaY1 * tA;
+     RealT xTest2 = xA2 + lambdaX2 * tB; 
+     RealT yTest2 = yA2 + lambdaY2 * tB; 
      
-     real xDiff = xTest1 - xTest2;
-     real yDiff = yTest1 - yTest2;
+     RealT xDiff = xTest1 - xTest2;
+     RealT yDiff = yTest1 - yTest2;
 
      // make sure the differences are positive
      xDiff = (xDiff < 0.) ? -1.0 * xDiff : xDiff;
      yDiff = (yDiff < 0.) ? -1.0 * yDiff : yDiff;
 
-     real diffTol = 1.0E-3;
+     RealT diffTol = 1.0E-3;
      SLIC_DEBUG_IF( xDiff > diffTol || yDiff > diffTol, 
                    "SegmentIntersection2D(): Intersection coordinates are not equally derived." );
    }
@@ -1128,8 +1128,8 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
 
    // for convenience, define an array of pointers that point to the 
    // input coordinates
-   real xVert[4];
-   real yVert[4];
+   RealT xVert[4];
+   RealT yVert[4];
    
    xVert[0] = xA1;
    xVert[1] = xB1;
@@ -1141,9 +1141,9 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
    yVert[2] = yA2;
    yVert[3] = yB2;
 
-   real distX[4];
-   real distY[4];
-   real distMag[4];
+   RealT distX[4];
+   RealT distY[4];
+   RealT distMag[4];
 
    for (int i=0; i<4; ++i)
    {
@@ -1152,10 +1152,10 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
       distMag[i] = magnitude( distX[i], distY[i] );
    }
 
-   real distMin = (seg1Mag > seg2Mag) ? seg1Mag: seg2Mag;
+   RealT distMin = (seg1Mag > seg2Mag) ? seg1Mag: seg2Mag;
    int idMin;
-   real xMinVert;
-   real yMinVert;
+   RealT xMinVert;
+   RealT yMinVert;
 
    for (int i=0; i<4; ++i)
    {
@@ -1170,7 +1170,7 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
 
    // check to see if the minimum distance is less than the position tolerance for 
    // the segments
-   real distRatio = (idMin == 0 || idMin == 1) ? (distMin / seg1Mag) : (distMin / seg2Mag);
+   RealT distRatio = (idMin == 0 || idMin == 1) ? (distMin / seg1Mag) : (distMin / seg2Mag);
 
    // if the distRatio is less than the tolerance, or percentage cutoff of the original 
    // segment that we would like to keep, then check to see if the segment vertex closest 
@@ -1195,12 +1195,12 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
 } // end SegmentIntersection2D()
 
 //------------------------------------------------------------------------------
-FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RESTRICT y, 
-                             const int numPoints, const real tol, 
-                             real* RESTRICT * RESTRICT xnew, real* RESTRICT * RESTRICT ynew, 
+FaceGeomError CheckPolySegs( const RealT* const RESTRICT x, const RealT* const RESTRICT y, 
+                             const int numPoints, const RealT tol, 
+                             RealT* RESTRICT * RESTRICT xnew, RealT* RESTRICT * RESTRICT ynew, 
                              int& numNewPoints )
 {
-   real newIDs[ numPoints ];
+   RealT newIDs[ numPoints ];
 
    // set newIDs[i] to original local ordering
    for (int i=0; i<numPoints; ++i)
@@ -1215,9 +1215,9 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
       int ib = (i == (numPoints-1)) ? 0 : (i+1);
 
       // compute segment vector magnitude
-      real lambdaX = x[ib] - x[ia];
-      real lambdaY = y[ib] - y[ia];
-      real lambdaMag = magnitude( lambdaX, lambdaY );
+      RealT lambdaX = x[ib] - x[ia];
+      RealT lambdaY = y[ib] - y[ia];
+      RealT lambdaMag = magnitude( lambdaX, lambdaY );
      
       // check segment length against tolerance
       if (lambdaMag < tol)
@@ -1240,8 +1240,8 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
    // allocate space for xnew and ynew. These are the input/output pointers 
    // to the overlapping polygon's vertex coordinates in the main polygon intersection 
    // routine
-   *xnew = new real[ numNewPoints ];
-   *ynew = new real[ numNewPoints ];
+   *xnew = new RealT[ numNewPoints ];
+   *ynew = new RealT[ numNewPoints ];
    
    // set the coordinates in xnew and ynew 
    int k = 0;
@@ -1266,14 +1266,14 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
 } // end CheckPolySegs()
 
 //------------------------------------------------------------------------------
-void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numPoints )
+void PolyReorder( RealT* const RESTRICT x, RealT* const RESTRICT y, const int numPoints )
 {
 
    SLIC_ERROR_IF(numPoints<3, "PolyReorder: numPoints < 3.");
 
-   real xC, yC, zC;
-   real * z = nullptr;
-   real proj [numPoints - 2];
+   RealT xC, yC, zC;
+   RealT * z = nullptr;
+   RealT proj [numPoints - 2];
 
    int newIDs[ numPoints ];
 
@@ -1297,10 +1297,10 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
    for (int j=1; j<numPoints; ++j)
    {
       // determine segment vector and normal
-      real lambdaX = x[j] - x[id0];
-      real lambdaY = y[j] - y[id0];
-      real nrmlx = -lambdaY;
-      real nrmly = lambdaX;
+      RealT lambdaX = x[j] - x[id0];
+      RealT lambdaY = y[j] - y[id0];
+      RealT nrmlx = -lambdaY;
+      RealT nrmly = lambdaX;
 
       // project vectors that span from each point, except j,k, to first vertex (id0), onto the 
       // segment normal. There will always be numPoints-2 projections
@@ -1352,10 +1352,10 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
          // one of two segments that will pass the previous test.
          // Check the dot product between the normal and the vector
          // between the centroid and first (0th) vertex
-         real vx = xC - x[id0];
-         real vy = yC - y[id0];
+         RealT vx = xC - x[id0];
+         RealT vy = yC - y[id0];
 
-         real prod = nrmlx * vx + nrmly * vy;
+         RealT prod = nrmlx * vx + nrmly * vy;
 
          // check if the two vertices are a segment on the convex hull and oriented CCW.
          // CCW orientation has prod > 0
@@ -1384,12 +1384,12 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
    for (int i=0; i<(numPoints-3); ++i) // increment to (numPoints - 3) or (numPoints - 2)?
    {
       int jID;
-      real cosThetaMax = -1.; // this handles angles up to 180 degrees. Not possible for convex polygons
-      real cosTheta;
-      real refMag, linkMag;
+      RealT cosThetaMax = -1.; // this handles angles up to 180 degrees. Not possible for convex polygons
+      RealT cosTheta;
+      RealT refMag, linkMag;
 
       // compute reference vector;
-      real refx, refy;
+      RealT refx, refy;
       refx = x[newIDs[i+1]] - x[newIDs[i]];
       refy = y[newIDs[i+1]] - y[newIDs[i]];
       refMag = magnitude( refx, refy );
@@ -1400,7 +1400,7 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
       int nextVertexID = 2+i;
       for (int j=nextVertexID; j<numPoints; ++j)
       {
-         real lx, ly;
+         RealT lx, ly;
 
          lx = x[newIDs[j]] - x[newIDs[i]];
          ly = y[newIDs[j]] - y[newIDs[i]];
@@ -1424,8 +1424,8 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
    } // end loop over i
 
    // reorder x and y coordinate arrays based on newIDs id-array
-   real xtemp[ numPoints ];
-   real ytemp[ numPoints ];
+   RealT xtemp[ numPoints ];
+   RealT ytemp[ numPoints ];
    for (int i=0; i<numPoints; ++i)
    {
       xtemp[i] = x[i];
@@ -1443,10 +1443,10 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
 } // end PolyReorder()
 
 //------------------------------------------------------------------------------
-void PolyReverse( real* const RESTRICT x, real* const RESTRICT y, const int numPoints )
+void PolyReverse( RealT* const RESTRICT x, RealT* const RESTRICT y, const int numPoints )
 {
-   real xtemp[ numPoints ];
-   real ytemp[ numPoints ];
+   RealT xtemp[ numPoints ];
+   RealT ytemp[ numPoints ];
    for (int i=0; i<numPoints; ++i)
    {
       xtemp[i] = x[i];
@@ -1463,40 +1463,40 @@ void PolyReverse( real* const RESTRICT x, real* const RESTRICT y, const int numP
 }
 
 //------------------------------------------------------------------------------
-void PolyReorderWithNormal( real* const RESTRICT x,
-                            real* const RESTRICT y,
-                            real* const RESTRICT z,
+void PolyReorderWithNormal( RealT* const RESTRICT x,
+                            RealT* const RESTRICT y,
+                            RealT* const RESTRICT z,
                             const int numPoints,
-                            const real nX,
-                            const real nY,
-                            const real nZ )
+                            const RealT nX,
+                            const RealT nY,
+                            const RealT nZ )
 {
    // form link vectors between second and first vertex and third and first
    // vertex
-   real lv10X = x[1] - x[0];
-   real lv10Y = y[1] - y[0];
-   real lv10Z = z[1] - z[0];
+   RealT lv10X = x[1] - x[0];
+   RealT lv10Y = y[1] - y[0];
+   RealT lv10Z = z[1] - z[0];
 
-   real lv20X = x[2] - x[0];
-   real lv20Y = y[2] - y[0];
-   real lv20Z = z[2] - z[0];
+   RealT lv20X = x[2] - x[0];
+   RealT lv20Y = y[2] - y[0];
+   RealT lv20Z = z[2] - z[0];
 
    // take the cross product of the vectors to get the normal
-   real pNrmlX, pNrmlY, pNrmlZ;
+   RealT pNrmlX, pNrmlY, pNrmlZ;
    crossProd( lv10X, lv10Y, lv10Z,
               lv20X, lv20Y, lv20Z,
               pNrmlX, pNrmlY, pNrmlZ );
 
    // dot the computed plane normal based on vertex ordering with the 
    // input normal
-   real v = dotProd( pNrmlX, pNrmlY, pNrmlZ, nX, nY, nZ ); 
+   RealT v = dotProd( pNrmlX, pNrmlY, pNrmlZ, nX, nY, nZ ); 
 
    // check to see if v is negative. If so, reorient the vertices
    if (v < 0)
    {
-      real xTemp[ numPoints ];
-      real yTemp[ numPoints ];
-      real zTemp[ numPoints ];
+      RealT xTemp[ numPoints ];
+      RealT yTemp[ numPoints ];
+      RealT zTemp[ numPoints ];
 
       xTemp[0] = x[0];
       yTemp[0] = y[0];
@@ -1522,20 +1522,20 @@ void PolyReorderWithNormal( real* const RESTRICT x,
 } // end PolyReorderWithNormal()
 
 //------------------------------------------------------------------------------
-bool LinePlaneIntersection( const real xA, const real yA, const real zA,
-                            const real xB, const real yB, const real zB,
-                            const real xP, const real yP, const real zP,
-                            const real nX, const real nY, const real nZ,
-                            real& x, real& y, real& z, bool& inPlane )
+bool LinePlaneIntersection( const RealT xA, const RealT yA, const RealT zA,
+                            const RealT xB, const RealT yB, const RealT zB,
+                            const RealT xP, const RealT yP, const RealT zP,
+                            const RealT nX, const RealT nY, const RealT nZ,
+                            RealT& x, RealT& y, RealT& z, bool& inPlane )
 {
 
    // compute segment vector
-   real lambdaX = xB - xA;
-   real lambdaY = yB - yA;
-   real lambdaZ = zB - zA;
+   RealT lambdaX = xB - xA;
+   RealT lambdaY = yB - yA;
+   RealT lambdaZ = zB - zA;
 
    // check dot product with plane normal
-   real prod = lambdaX*nX + lambdaY*nY + lambdaZ*nZ;
+   RealT prod = lambdaX*nX + lambdaY*nY + lambdaZ*nZ;
 
    if (prod == 0.) // line lies in plane
    {
@@ -1548,16 +1548,16 @@ bool LinePlaneIntersection( const real xA, const real yA, const real zA,
 
    // compute vector difference between point on plane 
    // and first vertex on segment
-   real vX = xP - xA;
-   real vY = yP - yA;
-   real vZ = zP - zA;
+   RealT vX = xP - xA;
+   RealT vY = yP - yA;
+   RealT vZ = zP - zA;
 
    // compute dot product between <vX, vY, vZ> and the plane normal
-   real prodV = vX * nX + vY * nY + vZ * nZ;
+   RealT prodV = vX * nX + vY * nY + vZ * nZ;
 
    // compute the line segment parameter, t, and check to see if it is 
    // between 0 and 1, inclusive
-   real t = prodV / prod;
+   RealT t = prodV / prod;
 
    if (t >= 0 && t <= 1)
    {
@@ -1579,17 +1579,17 @@ bool LinePlaneIntersection( const real xA, const real yA, const real zA,
 } // end LinePlaneIntersection()
 
 //------------------------------------------------------------------------------
-bool PlanePlaneIntersection( const real x1, const real y1, const real z1,
-                             const real x2, const real y2, const real z2,
-                             const real nX1, const real nY1, const real nZ1,
-                             const real nX2, const real nY2, const real nZ2,
-                             real& x, real& y, real& z )
+bool PlanePlaneIntersection( const RealT x1, const RealT y1, const RealT z1,
+                             const RealT x2, const RealT y2, const RealT z2,
+                             const RealT nX1, const RealT nY1, const RealT nZ1,
+                             const RealT nX2, const RealT nY2, const RealT nZ2,
+                             RealT& x, RealT& y, RealT& z )
 {
 
    // note: this routine has not been tested
 
    // check dot product between two normals for coplanarity
-   real coProd = nX1 * nX2 + nY1 * nY2 + nZ1 * nZ2;
+   RealT coProd = nX1 * nX2 + nY1 * nY2 + nZ1 * nZ2;
 
    if (axom::utilities::isNearlyEqual(coProd, 1.0, 1.e-8)) 
    {
@@ -1600,26 +1600,26 @@ bool PlanePlaneIntersection( const real x1, const real y1, const real z1,
    }
 
    // compute dot products between each plane's reference point and the normal
-   real prod1 = nX1 * x1 + nY1 * y1 + nZ1 * z1;
-   real prod2 = nX2 * x2 + nY2 * y2 + nZ2 * z2; 
+   RealT prod1 = nX1 * x1 + nY1 * y1 + nZ1 * z1;
+   RealT prod2 = nX2 * x2 + nY2 * y2 + nZ2 * z2; 
 
    // form matrix of dot products between normals
-   real A11 = nX1 * nX1 + nY1 * nY1 + nZ1 * nZ1;
-   real A12 = nX1 * nX2 + nY1 * nY2 + nZ1 * nZ2;
-   real A22 = nX2 * nX2 + nY2 * nY2 + nZ2 * nZ2;
+   RealT A11 = nX1 * nX1 + nY1 * nY1 + nZ1 * nZ1;
+   RealT A12 = nX1 * nX2 + nY1 * nY2 + nZ1 * nZ2;
+   RealT A22 = nX2 * nX2 + nY2 * nY2 + nZ2 * nZ2;
 
    // form determinant and inverse determinant of 2x2 matrix
-   real detA = A11 * A22 - A12 * A12;
-   real invDetA = 1.0 / detA;
+   RealT detA = A11 * A22 - A12 * A12;
+   RealT invDetA = 1.0 / detA;
 
    // form inverse matrix components
-   real invA11 =  A22;
-   real invA12 = -A12;
-   real invA22 =  A11;
+   RealT invA11 =  A22;
+   RealT invA12 = -A12;
+   RealT invA22 =  A11;
 
    // compute two parameters for point on line of intersection
-   real s1 = invDetA * (prod1 * invA11 + prod2 * invA12);
-   real s2 = invDetA * (prod1 * invA12 + prod2 * invA22);
+   RealT s1 = invDetA * (prod1 * invA11 + prod2 * invA12);
+   RealT s2 = invDetA * (prod1 * invA12 + prod2 * invA22);
 
    // compute the point on the line of intersection
    x = s1 * nX1 + s2 * nX2;
@@ -1631,8 +1631,8 @@ bool PlanePlaneIntersection( const real x1, const real y1, const real z1,
 } // end PlanePlaneIntersection()
 
 //------------------------------------------------------------------------------
-void Vertex2DOrderToCCW( const real* const RESTRICT x, const real* const RESTRICT y,
-                         real* RESTRICT xTemp, real* RESTRICT yTemp,
+void Vertex2DOrderToCCW( const RealT* const RESTRICT x, const RealT* const RESTRICT y,
+                         RealT* RESTRICT xTemp, RealT* RESTRICT yTemp,
                          const int numVert )
 {
    if (numVert <= 0)

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -34,10 +34,10 @@ namespace tribol
  * \param [in,out] pz z coordinate of projected point
  *
  */
-void ProjectPointToPlane( const real x, const real y, const real z, 
-                          const real nx, const real ny, const real nz,
-                          const real ox, const real oy, const real oz, 
-                          real& px, real& py, real& pz );
+void ProjectPointToPlane( const RealT x, const RealT y, const RealT z, 
+                          const RealT nx, const RealT ny, const RealT nz,
+                          const RealT ox, const RealT oy, const RealT oz, 
+                          RealT& px, RealT& py, RealT& pz );
 
 /*!
  *
@@ -54,10 +54,10 @@ void ProjectPointToPlane( const real x, const real y, const real z,
  * \param [in,out] py y coordinate of projected point
  *
  */
-void ProjectPointToSegment( const real x, const real y,
-                            const real nx, const real ny,
-                            const real ox, const real oy,
-                            real& px, real& py );
+void ProjectPointToSegment( const RealT x, const RealT y,
+                            const RealT nx, const RealT ny,
+                            const RealT ox, const RealT oy,
+                            RealT& px, RealT& py );
 
 /*!
  *
@@ -83,14 +83,14 @@ void ProjectPointToSegment( const real x, const real y,
  *  to get centroid x-coordinate.
  */
 void PolyInterYCentroid( const int namax,
-                         const real* const RESTRICT xa,
-                         const real* const RESTRICT ya,
+                         const RealT* const RESTRICT xa,
+                         const RealT* const RESTRICT ya,
                          const int nbmax,
-                         const real* const RESTRICT xb,
-                         const real* const RESTRICT yb,
+                         const RealT* const RESTRICT xb,
+                         const RealT* const RESTRICT yb,
                          const int isym,
-                         real & area,
-                         real & ycent );
+                         RealT & area,
+                         RealT & ycent );
 
 /*!
  *
@@ -116,11 +116,11 @@ void PolyInterYCentroid( const int namax,
  *  2D coordinate basis to a point in the 3D global coordinate system
  *
  */
-void Local2DToGlobalCoords( real xloc, real yloc, 
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real& xg, real& yg, real& zg );
+void Local2DToGlobalCoords( RealT xloc, RealT yloc, 
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT& xg, RealT& yg, RealT& zg );
 
 /*!
  *
@@ -151,14 +151,14 @@ void Local2DToGlobalCoords( real xloc, real yloc,
  * \note this assumes that the point lies in the plane defined by the 
  *  2D local basis vectors. 
  */
-void GlobalTo2DLocalCoords( const real* const RESTRICT pX, 
-                            const real* const RESTRICT pY, 
-                            const real* const RESTRICT pZ,
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real* const RESTRICT pLX, 
-                            real* const RESTRICT pLY, 
+void GlobalTo2DLocalCoords( const RealT* const RESTRICT pX, 
+                            const RealT* const RESTRICT pY, 
+                            const RealT* const RESTRICT pZ,
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT* const RESTRICT pLX, 
+                            RealT* const RESTRICT pLY, 
                             int size );
 
 /*!
@@ -184,11 +184,11 @@ void GlobalTo2DLocalCoords( const real* const RESTRICT pX,
  * \note this assumes that the point lies in the plane defined by the 
  *  2D local basis vectors. 
  */
-void GlobalTo2DLocalCoords( real pX, real pY, real pZ,
-                            real e1X, real e1Y, real e1Z,
-                            real e2X, real e2Y, real e2Z,
-                            real cX, real cY, real cZ,
-                            real& pLX, real& pLY );
+void GlobalTo2DLocalCoords( RealT pX, RealT pY, RealT pZ,
+                            RealT e1X, RealT e1Y, RealT e1Z,
+                            RealT e2X, RealT e2Y, RealT e2Z,
+                            RealT cX, RealT cY, RealT cZ,
+                            RealT& pLX, RealT& pLY );
 /*!
  *
  * \brief computes the vertex averaged centroid of a point set
@@ -206,11 +206,11 @@ void GlobalTo2DLocalCoords( real pX, real pY, real pZ,
  * \pre length(z) >= numVert
  *
  */
-void VertexAvgCentroid( const real* const RESTRICT x, 
-                        const real* const RESTRICT y, 
-                        const real* const RESTRICT z, 
+void VertexAvgCentroid( const RealT* const RESTRICT x, 
+                        const RealT* const RESTRICT y, 
+                        const RealT* const RESTRICT z, 
                         const int numVert,
-                        real& cX, real& cY, real& cZ );
+                        RealT& cX, RealT& cY, RealT& cZ );
 
 /*!
  *
@@ -226,10 +226,10 @@ void VertexAvgCentroid( const real* const RESTRICT x,
  * \pre length(x) >= numVert
  *
  */
-void VertexAvgCentroid( const real* const RESTRICT x, 
+void VertexAvgCentroid( const RealT* const RESTRICT x, 
                         const int dim,
                         const int numVert,
-                        real& cX, real& cY, real& cZ );
+                        RealT& cX, RealT& cY, RealT& cZ );
 
 /*!
  *
@@ -245,10 +245,10 @@ void VertexAvgCentroid( const real* const RESTRICT x,
  * \pre length(x) >= numVert
  *
  */
-void PolyAreaCentroid( const real* const RESTRICT x, 
+void PolyAreaCentroid( const RealT* const RESTRICT x, 
                        const int dim,
                        const int numVert,
-                       real& cX, real& cY, real& cZ );
+                       RealT& cX, RealT& cY, RealT& cZ );
 
 /*!
  *
@@ -263,10 +263,10 @@ void PolyAreaCentroid( const real* const RESTRICT x,
  * \pre length(x) >= numVert
  *
  */
-void PolyCentroid( const real* const RESTRICT x, 
-                   const real* const RESTRICT y,
+void PolyCentroid( const RealT* const RESTRICT x, 
+                   const RealT* const RESTRICT y,
                    const int numVert,
-                   real& cX, real& cY );
+                   RealT& cX, RealT& cY );
 
 /*!
  *
@@ -295,16 +295,16 @@ void PolyCentroid( const real* const RESTRICT x,
  *  this memory when necessary.
  *
  */
-FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA, 
-                                     const real* const RESTRICT yA, 
+FaceGeomError Intersection2DPolygon( const RealT* const RESTRICT xA, 
+                                     const RealT* const RESTRICT yA, 
                                      const int numVertexA, 
-                                     const real* const RESTRICT xB, 
-                                     const real* const RESTRICT yB, 
+                                     const RealT* const RESTRICT xB, 
+                                     const RealT* const RESTRICT yB, 
                                      const int numVertexB,
-                                     real posTol, real lenTol, 
-                                     real* RESTRICT * RESTRICT polyX, 
-                                     real* RESTRICT * RESTRICT polyY, 
-                                     int& numPolyVert, real& area,
+                                     RealT posTol, RealT lenTol, 
+                                     RealT* RESTRICT * RESTRICT polyX, 
+                                     RealT* RESTRICT * RESTRICT polyY, 
+                                     int& numPolyVert, RealT& area,
                                      bool orientCheck=true );
                            
 /*!
@@ -318,8 +318,8 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
  * \return true if CCW orientation, false otherwise
  *
  */
-bool CheckPolyOrientation( const real* const RESTRICT x, 
-                           const real* const RESTRICT y, 
+bool CheckPolyOrientation( const RealT* const RESTRICT x, 
+                           const RealT* const RESTRICT y, 
                            const int numVertex );
 
 /*!
@@ -346,10 +346,10 @@ bool CheckPolyOrientation( const real* const RESTRICT x,
  *  vertex averaged centroid. This routine then calls a routine to check if the 
  *  point lies in either of those two triangles.
  */
-bool Point2DInFace( const real xPoint, const real yPoint, 
-                    const real* const RESTRICT xPoly, 
-                    const real* const RESTRICT yPoly,
-                    const real xC, const real yC, 
+bool Point2DInFace( const RealT xPoint, const RealT yPoint, 
+                    const RealT* const RESTRICT xPoly, 
+                    const RealT* const RESTRICT yPoly,
+                    const RealT xC, const RealT yC, 
                     const int numPolyVert );
 
 /*!
@@ -369,9 +369,9 @@ bool Point2DInFace( const real xPoint, const real yPoint,
  *  determines if those coordinates are inside or out 
  *  (http://blackpawn.com/texts/pointinpoly/default.html);
  */
-bool Point2DInTri( const real xp, const real yp, 
-                   const real* const RESTRICT xTri, 
-                   const real* const RESTRICT yTri );
+bool Point2DInTri( const RealT xp, const RealT yp, 
+                   const RealT* const RESTRICT xTri, 
+                   const RealT* const RESTRICT yTri );
 
 /*!
  * \brief computes the area of a polygon
@@ -384,8 +384,8 @@ bool Point2DInTri( const real xp, const real yp,
  *
  * \note breaks the polygon into triangles and sums the areas of the triangles
  */
-real Area2DPolygon( const real* const RESTRICT x, 
-                    const real* const RESTRICT y, 
+RealT Area2DPolygon( const RealT* const RESTRICT x, 
+                    const RealT* const RESTRICT y, 
                     const int numPolyVert );
 
 /*!
@@ -398,9 +398,9 @@ real Area2DPolygon( const real* const RESTRICT x,
  * \return area of triangle
  *
  */
-real Area3DTri( const real* const RESTRICT x,
-                const real* const RESTRICT y,
-                const real* const RESTRICT z );
+RealT Area3DTri( const RealT* const RESTRICT x,
+                const RealT* const RESTRICT y,
+                const RealT* const RESTRICT z );
 
 /*!
  *
@@ -438,10 +438,10 @@ real Area3DTri( const real* const RESTRICT x,
  *  vertices tagged as interior to one of the polygons may render a degenerate overlap 
  *  polygon and must be checked.
  */
-bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, const real yB1,
-                            const real xA2, const real yA2, const real xB2, const real yB2,
-                            const bool* const RESTRICT interior, real& x, real& y, 
-                            bool& duplicate, const real tol );
+bool SegmentIntersection2D( const RealT xA1, const RealT yA1, const RealT xB1, const RealT yB1,
+                            const RealT xA2, const RealT yA2, const RealT xB2, const RealT yB2,
+                            const bool* const RESTRICT interior, RealT& x, RealT& y, 
+                            bool& duplicate, const RealT tol );
 
 /*!
  *
@@ -467,9 +467,9 @@ bool SegmentIntersection2D( const real xA1, const real yA1, const real xB1, cons
  *  xnew and ynew values are set to x and y, respectively, and numNewPoints 
  *  equals numPoints.
  */
-FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RESTRICT y, 
-                             const int numPoints, const real tol, 
-                             real* RESTRICT * RESTRICT xnew, real* RESTRICT * RESTRICT ynew, 
+FaceGeomError CheckPolySegs( const RealT* const RESTRICT x, const RealT* const RESTRICT y, 
+                             const int numPoints, const RealT tol, 
+                             RealT* RESTRICT * RESTRICT xnew, RealT* RESTRICT * RESTRICT ynew, 
                              int& numNewPoints );
 
 /*!
@@ -486,7 +486,7 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
  * \note This routine takes the unordered set of vertex coordinates of a star convex 
  *  polygon and orders the vertices in counter-clockwise orientation.
  */
-void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numPoints );
+void PolyReorder( RealT* const RESTRICT x, RealT* const RESTRICT y, const int numPoints );
 
 /*!
  *
@@ -499,7 +499,7 @@ void PolyReorder( real* const RESTRICT x, real* const RESTRICT y, const int numP
  * \pre length(x), length(y) >= numPoints
  *
  */
-void PolyReverse( real* const RESTRICT x, real* const RESTRICT y, const int numPoints );
+void PolyReverse( RealT* const RESTRICT x, RealT* const RESTRICT y, const int numPoints );
 
 /*!
  *
@@ -517,13 +517,13 @@ void PolyReverse( real* const RESTRICT x, real* const RESTRICT y, const int numP
  * \pre length(x), length(y), length(z) >= numPoints
  *
  */
-void PolyReorderWithNormal( real* const RESTRICT x,
-                            real* const RESTRICT y,
-                            real* const RESTRICT z,
+void PolyReorderWithNormal( RealT* const RESTRICT x,
+                            RealT* const RESTRICT y,
+                            RealT* const RESTRICT z,
                             const int numPoints,
-                            const real nX,
-                            const real nY,
-                            const real nZ );
+                            const RealT nX,
+                            const RealT nY,
+                            const RealT nZ );
 
 /*!
  * \brief computes the intersection point between a line and plane
@@ -546,11 +546,11 @@ void PolyReorderWithNormal( real* const RESTRICT x,
  * \param[in,out] inPlane true if segment lies in the plane
  *
  */
-bool LinePlaneIntersection( const real xA, const real yA, const real zA,
-                            const real xB, const real yB, const real zB,
-                            const real xP, const real yP, const real zP,
-                            const real nX, const real nY, const real nZ,
-                            real& x, real& y, real& z, bool& inPlane );
+bool LinePlaneIntersection( const RealT xA, const RealT yA, const RealT zA,
+                            const RealT xB, const RealT yB, const RealT zB,
+                            const RealT xP, const RealT yP, const RealT zP,
+                            const RealT nX, const RealT nY, const RealT nZ,
+                            RealT& x, RealT& y, RealT& z, bool& inPlane );
 
 /*!
  * \brief computes the line segment that is the intersection between two 
@@ -586,11 +586,11 @@ bool LinePlaneIntersection( const real xA, const real yA, const real zA,
  * segment is controlled by each plane's input reference points.
  *
  */
-bool PlanePlaneIntersection( const real x1, const real y1, const real z1,
-                             const real x2, const real y2, const real z2,
-                             const real nX1, const real nY1, const real nZ1,
-                             const real nX2, const real nY2, const real nZ2,
-                             real& x, real& y, real& z );
+bool PlanePlaneIntersection( const RealT x1, const RealT y1, const RealT z1,
+                             const RealT x2, const RealT y2, const RealT z2,
+                             const RealT nX1, const RealT nY1, const RealT nZ1,
+                             const RealT nX2, const RealT nY2, const RealT nZ2,
+                             RealT& x, RealT& y, RealT& z );
 
 /*!
  *
@@ -605,8 +605,8 @@ bool PlanePlaneIntersection( const real x1, const real y1, const real z1,
  * \pre this routine assumes that the original coordinates are in clockwise ordering
  *
  */
-void Vertex2DOrderToCCW( const real* const RESTRICT x, const real* const RESTRICT y,
-                         real* RESTRICT xTemp, real* RESTRICT yTemp,
+void Vertex2DOrderToCCW( const RealT* const RESTRICT x, const RealT* const RESTRICT y,
+                         RealT* RESTRICT xTemp, RealT* RESTRICT yTemp,
                          const int numVert );
 
 }

--- a/src/tribol/integ/FE.cpp
+++ b/src/tribol/integ/FE.cpp
@@ -32,10 +32,10 @@ int GetNumFaceNodes( int dim, FaceOrderType order_type )
    return numNodes;
 }
 
-void GalerkinEval( const real* const RESTRICT x, 
-                   const real pX, const real pY, const real pZ, 
+void GalerkinEval( const RealT* const RESTRICT x, 
+                   const RealT pX, const RealT pY, const RealT pZ, 
                    FaceOrderType order_type, BasisEvalType basis_type, 
-                   int dim, int galerkinDim, real* nodeVals, real* galerkinVal )
+                   int dim, int galerkinDim, RealT* nodeVals, RealT* galerkinVal )
 {
    SLIC_ERROR_IF(x==nullptr, "GalerkinEval(): input pointer, x, is NULL.");
    SLIC_ERROR_IF(nodeVals==nullptr, "GalerkinEval(): input pointer, nodeVals, is NULL.");
@@ -48,7 +48,7 @@ void GalerkinEval( const real* const RESTRICT x,
       case PHYSICAL :
          for (int nd=0; nd<numNodes; ++nd)
          {
-            real phi = 0.;
+            RealT phi = 0.;
             EvalBasis( x, pX, pY, pZ, numNodes, nd, phi );
             for (int i=0; i<galerkinDim; ++i)
             {
@@ -61,10 +61,10 @@ void GalerkinEval( const real* const RESTRICT x,
    }
 }
 
-void EvalBasis( const real* const RESTRICT x, 
-                const real pX, const real pY, const real pZ, 
+void EvalBasis( const RealT* const RESTRICT x, 
+                const RealT pX, const RealT pY, const RealT pZ, 
                 const int numPoints, const int vertexId, 
-                real& phi )
+                RealT& phi )
 {
    if (numPoints > 2)
    {
@@ -82,10 +82,10 @@ void EvalBasis( const real* const RESTRICT x,
 }
 
 //------------------------------------------------------------------------------
-void SegmentBasis( const real* const RESTRICT x, 
-                   const real pX, const real pY,
+void SegmentBasis( const RealT* const RESTRICT x, 
+                   const RealT pX, const RealT pY,
                    const int numPoints, const int vertexId, 
-                   real& phi )
+                   RealT& phi )
 {
    SLIC_ERROR_IF(numPoints != 2, "SegmentBasis: numPoints is " << numPoints <<
                  " but should be 2.");
@@ -95,15 +95,15 @@ void SegmentBasis( const real* const RESTRICT x,
                  " but should be 0 or 1.");
 
    // compute length of segment
-   real vx = x[numPoints*1] - x[numPoints*0];
-   real vy = x[numPoints*1+1] - x[numPoints*0+1];
-   real lambda = magnitude( vx, vy );
+   RealT vx = x[numPoints*1] - x[numPoints*0];
+   RealT vy = x[numPoints*1+1] - x[numPoints*0+1];
+   RealT lambda = magnitude( vx, vy );
 
    // compute the magnitude of the vector <pX,pY> - <x[vertexId],y[vertexId]>
-   real wx = pX - x[ numPoints*vertexId ];
-   real wy = pY - x[ numPoints*vertexId+1 ];
+   RealT wx = pX - x[ numPoints*vertexId ];
+   RealT wy = pY - x[ numPoints*vertexId+1 ];
 
-   real magW = magnitude( wx, wy );
+   RealT magW = magnitude( wx, wy );
 
    phi = 1.0 / lambda * (lambda - magW); // this calculation is inverted, (phi_a is actually phi_b and vice versa)
 
@@ -135,15 +135,15 @@ void SegmentBasis( const real* const RESTRICT x,
 }
 
 //------------------------------------------------------------------------------
-void WachspressBasis( const real* const RESTRICT x, 
-                      const real pX, const real pY, const real pZ, 
-                      const int numPoints, const int vertexId, real& phi )
+void WachspressBasis( const RealT* const RESTRICT x, 
+                      const RealT pX, const RealT pY, const RealT pZ, 
+                      const int numPoints, const int vertexId, RealT& phi )
 {
    SLIC_ERROR_IF(numPoints<3, "WachspressBasis: numPoints < 3.");
 
    // first compute the areas of all the triangles formed by the i-1,i,i+1 vertices.
    // These consist of all the numerators in the Wachspress formulation
-   real triVertArea[ numPoints ];
+   RealT triVertArea[ numPoints ];
    for (int i=0; i<numPoints; ++i)
    {
       // determine the i-1, i, i+1 vertices
@@ -152,19 +152,19 @@ void WachspressBasis( const real* const RESTRICT x,
       int vIdPlus = (vId == (numPoints-1)) ? 0 : (vId+1);
 
       // construct segment between i-1,i and i-1,i+1
-      real vx = x[ 3*vId ]   - x[ 3*vIdMinus ];
-      real vy = x[ 3*vId+1 ] - x[ 3*vIdMinus+1 ];
-      real vz = x[ 3*vId+2 ] - x[ 3*vIdMinus+2 ];
+      RealT vx = x[ 3*vId ]   - x[ 3*vIdMinus ];
+      RealT vy = x[ 3*vId+1 ] - x[ 3*vIdMinus+1 ];
+      RealT vz = x[ 3*vId+2 ] - x[ 3*vIdMinus+2 ];
 
-      real wx = x[ 3*vIdPlus ] -   x[ 3*vIdMinus ];
-      real wy = x[ 3*vIdPlus+1 ] - x[ 3*vIdMinus+1 ];
-      real wz = x[ 3*vIdPlus+2 ] - x[ 3*vIdMinus+2 ];
+      RealT wx = x[ 3*vIdPlus ] -   x[ 3*vIdMinus ];
+      RealT wy = x[ 3*vIdPlus+1 ] - x[ 3*vIdMinus+1 ];
+      RealT wz = x[ 3*vIdPlus+2 ] - x[ 3*vIdMinus+2 ];
 
       // take the cross product between v and w to get the normal, and then obtain the 
       // area from the normal's magnitude
-      real nX = (vy * wz) - (vz * wy);
-      real nY = (vz * wx) - (vx * wz);
-      real nZ = (vx * wy) - (vy * wx);
+      RealT nX = (vy * wz) - (vz * wy);
+      RealT nY = (vz * wx) - (vx * wz);
+      RealT nZ = (vx * wy) - (vy * wx);
   
       triVertArea[i] = 0.5 * magnitude( nX, nY, nZ );
 
@@ -172,7 +172,7 @@ void WachspressBasis( const real* const RESTRICT x,
 
    // second, compute the areas of all triangles formed using edge segment vertices
    // and the specified interior point (pX,pY,pZ)
-   real triPointArea[ numPoints ];
+   RealT triPointArea[ numPoints ];
    for (int i=0; i<numPoints; ++i)
    {
       // determine the i,i+1 edge segment 
@@ -180,28 +180,28 @@ void WachspressBasis( const real* const RESTRICT x,
       int vIdPlus = (vId == (numPoints-1)) ? 0 : (vId+1);
 
       // construct segments between i+1,i and p,i 
-      real vx = x[ 3*vIdPlus ]   - x[ 3*vId ];
-      real vy = x[ 3*vIdPlus+1 ] - x[ 3*vId+1 ];
-      real vz = x[ 3*vIdPlus+2 ] - x[ 3*vId+2 ];
+      RealT vx = x[ 3*vIdPlus ]   - x[ 3*vId ];
+      RealT vy = x[ 3*vIdPlus+1 ] - x[ 3*vId+1 ];
+      RealT vz = x[ 3*vIdPlus+2 ] - x[ 3*vId+2 ];
 
-      real wx = pX - x[ 3*vId ];
-      real wy = pY - x[ 3*vId+1 ];
-      real wz = pZ - x[ 3*vId+2 ];
+      RealT wx = pX - x[ 3*vId ];
+      RealT wy = pY - x[ 3*vId+1 ];
+      RealT wz = pZ - x[ 3*vId+2 ];
 
       // take the cross product between v and w to get the normal, and then obtain the 
       // area from the normal's magnitude
-      real nX = (vy * wz) - (vz * wy);
-      real nY = (vz * wx) - (vx * wz);
-      real nZ = (vx * wy) - (vy * wx);
+      RealT nX = (vy * wz) - (vz * wy);
+      RealT nY = (vz * wx) - (vx * wz);
+      RealT nZ = (vx * wy) - (vy * wx);
   
       triPointArea[i] = 0.5 * magnitude( nX, nY, nZ );
 
    }
 
    // third, compute all of the weights per Wachspress formulation
-   real weight[ numPoints ];
-   real myWeight;
-   real weightSum = 0.;
+   RealT weight[ numPoints ];
+   RealT myWeight;
+   RealT weightSum = 0.;
    for (int i=0; i<numPoints; ++i)
    {
       int vId = i; 
@@ -229,88 +229,88 @@ void WachspressBasis( const real* const RESTRICT x,
 }
 
 //------------------------------------------------------------------------------
-void InvIso( const real  x[3], 
-             const real* xA,
-             const real* yA,
-             const real* zA,
+void InvIso( const RealT  x[3], 
+             const RealT* xA,
+             const RealT* yA,
+             const RealT* zA,
              const int numNodes,
-             real  xi[2] )
+             RealT  xi[2] )
 {
 
    SLIC_ERROR_IF(numNodes!=4, "InvIso: routine only for 4 node quads.");
 
    bool convrg = false;
    int kmax = 15;
-   real xtol = 1.E-12;
+   RealT xtol = 1.E-12;
 
-   real x_sol[2] = {0., 0.};
+   RealT x_sol[2] = {0., 0.};
 
    // derivatives of the Jacobian wrt (xi,eta)
-   real djde_11   = 0.;
-   real djde_x_12 = 0.25 * (xA[0] - xA[1] + xA[2] - xA[3]);
-   real djde_y_12 = 0.25 * (yA[0] - yA[1] + yA[2] - yA[3]);
-   real djde_z_12 = 0.25 * (zA[0] - zA[1] + zA[2] - zA[3]);
-   real djde_22   = 0.;
+   RealT djde_11   = 0.;
+   RealT djde_x_12 = 0.25 * (xA[0] - xA[1] + xA[2] - xA[3]);
+   RealT djde_y_12 = 0.25 * (yA[0] - yA[1] + yA[2] - yA[3]);
+   RealT djde_z_12 = 0.25 * (zA[0] - zA[1] + zA[2] - zA[3]);
+   RealT djde_22   = 0.;
 
    // loop over newton iterations
    for (int k = 0; k < kmax; ++k)
    {
       // evaluate Jacobian
-      real j_x_1 = 0.25 * (xA[0] * (1. + x_sol[1]) - xA[1] * 
+      RealT j_x_1 = 0.25 * (xA[0] * (1. + x_sol[1]) - xA[1] * 
                    (1. + x_sol[1]) - xA[2] * (1. - x_sol[1]) + 
                    xA[3] * (1. - x_sol[1]));
 
-      real j_y_1 = 0.25 * (yA[0] * (1. + x_sol[1]) - yA[1] * 
+      RealT j_y_1 = 0.25 * (yA[0] * (1. + x_sol[1]) - yA[1] * 
                    (1. + x_sol[1]) - yA[2] * (1. - x_sol[1]) + 
                    yA[3] * (1. - x_sol[1]));
 
-      real j_z_1 = 0.25 * (zA[0] * (1. + x_sol[1]) - zA[1] * 
+      RealT j_z_1 = 0.25 * (zA[0] * (1. + x_sol[1]) - zA[1] * 
                    (1. + x_sol[1]) - zA[2] * (1. - x_sol[1]) + 
                    zA[3] * (1. - x_sol[1]));
 
-      real j_x_2 = 0.25 * (xA[0] * (1. + x_sol[0]) + xA[1] * 
+      RealT j_x_2 = 0.25 * (xA[0] * (1. + x_sol[0]) + xA[1] * 
                    (1. - x_sol[0]) - xA[2] * (1. - x_sol[0]) - 
                    xA[3] * (1. + x_sol[0]));
 
-      real j_y_2 = 0.25 * (yA[0] * (1. + x_sol[0]) + yA[1] * 
+      RealT j_y_2 = 0.25 * (yA[0] * (1. + x_sol[0]) + yA[1] * 
                    (1. - x_sol[0]) - yA[2] * (1. - x_sol[0]) - 
                    yA[3] * (1. + x_sol[0]));
 
-      real j_z_2 = 0.25 * (zA[0] * (1. + x_sol[0]) + zA[1] * 
+      RealT j_z_2 = 0.25 * (zA[0] * (1. + x_sol[0]) + zA[1] * 
                    (1. - x_sol[0]) - zA[2] * (1. - x_sol[0]) - 
                    zA[3] * (1. + x_sol[0]));
 
       // evaluate the residual
-      real f_x = x[0] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * xA[0]
+      RealT f_x = x[0] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * xA[0]
                  + (1. - x_sol[0]) * (1. + x_sol[1]) * xA[1]
                  + (1. - x_sol[0]) * (1. - x_sol[1]) * xA[2]
                  + (1. + x_sol[0]) * (1. - x_sol[1]) * xA[3]);
 
-      real f_y = x[1] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * yA[0]
+      RealT f_y = x[1] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * yA[0]
                  + (1. - x_sol[0]) * (1. + x_sol[1]) * yA[1]
                  + (1. - x_sol[0]) * (1. - x_sol[1]) * yA[2]
                  + (1. + x_sol[0]) * (1. - x_sol[1]) * yA[3]);
 
-      real f_z = x[2] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * zA[0]
+      RealT f_z = x[2] - 0.25 * ((1. + x_sol[0]) * (1. + x_sol[1]) * zA[0]
                  + (1. - x_sol[0]) * (1. + x_sol[1]) * zA[1]
                  + (1. - x_sol[0]) * (1. - x_sol[1]) * zA[2]
                  + (1. + x_sol[0]) * (1. - x_sol[1]) * zA[3]);
 
       // compute J' * J
-      real JTJ_11 = j_x_1 * j_x_1 + j_y_1 * j_y_1 + j_z_1 * j_z_1;
-      real JTJ_12 = j_x_1 * j_x_2 + j_y_1 * j_y_2 + j_z_1 * j_z_2;
-      //real JTJ_21 = JTJ_12;
-      real JTJ_22 = j_x_2 * j_x_2 + j_y_2 * j_y_2 + j_z_2 * j_z_2;;
+      RealT JTJ_11 = j_x_1 * j_x_1 + j_y_1 * j_y_1 + j_z_1 * j_z_1;
+      RealT JTJ_12 = j_x_1 * j_x_2 + j_y_1 * j_y_2 + j_z_1 * j_z_2;
+      //RealT JTJ_21 = JTJ_12;
+      RealT JTJ_22 = j_x_2 * j_x_2 + j_y_2 * j_y_2 + j_z_2 * j_z_2;;
 
       // compute J' * F
-      real JTF_1 = j_x_1 * f_x + j_y_1 * f_y + j_z_1 * f_z;
-      real JTF_2 = j_x_2 * f_x + j_y_2 * f_y + j_z_2 * f_z;
+      RealT JTF_1 = j_x_1 * f_x + j_y_1 * f_y + j_z_1 * f_z;
+      RealT JTF_2 = j_x_2 * f_x + j_y_2 * f_y + j_z_2 * f_z;
 
       // for first few steps don't do exact Newton.
-      real cm_11 = JTJ_11; //- (djde_11 * f_x + djde_11 * f_y + djde_11 * f_z);
-      real cm_12 = JTJ_12; //- (djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z);
-      real cm_21 = cm_12;
-      real cm_22 = JTJ_22; //- (djde_22 * f_x + djde_22 * f_y + djde_22 * f_z);
+      RealT cm_11 = JTJ_11; //- (djde_11 * f_x + djde_11 * f_y + djde_11 * f_z);
+      RealT cm_12 = JTJ_12; //- (djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z);
+      RealT cm_21 = cm_12;
+      RealT cm_22 = JTJ_22; //- (djde_22 * f_x + djde_22 * f_y + djde_22 * f_z);
 
       // do exact Newton for steps beyond first few
       if (k > 2)  // set to 2 per mortar method testing 
@@ -321,21 +321,21 @@ void InvIso( const real  x[3],
        cm_22 += - (djde_22 * f_x + djde_22 * f_y + djde_22 * f_z);
       }
 
-      real detI = 1. / (cm_11 * cm_22 - cm_12 * cm_21);
+      RealT detI = 1. / (cm_11 * cm_22 - cm_12 * cm_21);
 
-      real cmi_11 = cm_22 * detI;
-      real cmi_22 = cm_11 * detI;
-      real cmi_12 = -cm_12 * detI;
-      real cmi_21 = -cm_21 * detI;
+      RealT cmi_11 = cm_22 * detI;
+      RealT cmi_22 = cm_11 * detI;
+      RealT cmi_12 = -cm_12 * detI;
+      RealT cmi_21 = -cm_21 * detI;
 
-      real dxi_1 = cmi_11 * JTF_1 + cmi_12 * JTF_2;
-      real dxi_2 = cmi_21 * JTF_1 + cmi_22 * JTF_2;
+      RealT dxi_1 = cmi_11 * JTF_1 + cmi_12 * JTF_2;
+      RealT dxi_2 = cmi_21 * JTF_1 + cmi_22 * JTF_2;
 
       x_sol[0] += dxi_1;
       x_sol[1] += dxi_2;
 
-      real abs_dxi_1 = std::abs(dxi_1);
-      real abs_dxi_2 = std::abs(dxi_2);
+      RealT abs_dxi_1 = std::abs(dxi_1);
+      RealT abs_dxi_2 = std::abs(dxi_2);
 
       if (abs_dxi_1 <= xtol && abs_dxi_2 <= xtol)
       {
@@ -374,17 +374,17 @@ void InvIso( const real  x[3],
 }
 
 //------------------------------------------------------------------------------
-void FwdMapLinQuad( const real xi[2],
-                    real xa[4],
-                    real ya[4],
-                    real za[4],
-                    real x[3] )
+void FwdMapLinQuad( const RealT xi[2],
+                    RealT xa[4],
+                    RealT ya[4],
+                    RealT za[4],
+                    RealT x[3] )
 {
    // initialize output array
    initRealArray( &x[0], 3, 0. );
 
    // obtain shape function evaluations at (xi,eta)
-   real phi[4] = { 0., 0., 0., 0. };
+   RealT phi[4] = { 0., 0., 0., 0. };
    LinIsoQuadShapeFunc( xi[0], xi[1], 0, phi[0] );
    LinIsoQuadShapeFunc( xi[0], xi[1], 1, phi[1] );
    LinIsoQuadShapeFunc( xi[0], xi[1], 2, phi[2] );
@@ -400,17 +400,17 @@ void FwdMapLinQuad( const real xi[2],
 }
 
 //------------------------------------------------------------------------------
-void FwdMapLinTri( const real xi[2],
-                   real xa[3],
-                   real ya[3],
-                   real za[3],
-                   real x[3] )
+void FwdMapLinTri( const RealT xi[2],
+                   RealT xa[3],
+                   RealT ya[3],
+                   RealT za[3],
+                   RealT x[3] )
 {
    // initialize output array
    initRealArray( &x[0], 3, 0. );
 
    // obtain shape function evaluations at (xi,eta)
-   real phi[3] = { 0., 0., 0. };
+   RealT phi[3] = { 0., 0., 0. };
    LinIsoTriShapeFunc( xi[0], xi[1], 0, phi[0] );
    LinIsoTriShapeFunc( xi[0], xi[1], 1, phi[1] );
    LinIsoTriShapeFunc( xi[0], xi[1], 2, phi[2] );
@@ -425,10 +425,10 @@ void FwdMapLinTri( const real xi[2],
 }
 
 //------------------------------------------------------------------------------
-void LinIsoTriShapeFunc( const real xi, 
-                         const real eta,
+void LinIsoTriShapeFunc( const RealT xi, 
+                         const RealT eta,
                          const int a,
-                         real& phi )
+                         RealT& phi )
 {
    switch (a)
    {
@@ -450,12 +450,12 @@ void LinIsoTriShapeFunc( const real xi,
 }
 
 //------------------------------------------------------------------------------
-void LinIsoQuadShapeFunc( const real xi, 
-                          const real eta,
+void LinIsoQuadShapeFunc( const RealT xi, 
+                          const RealT eta,
                           const int a,
-                          real& phi )
+                          RealT& phi )
 {
-   real xi_node, eta_node;
+   RealT xi_node, eta_node;
    switch (a)
    {
       case 0:
@@ -487,20 +487,20 @@ void LinIsoQuadShapeFunc( const real xi,
 }
 
 //------------------------------------------------------------------------------
-void DetJQuad( const real xi,
-               const real eta,
-               const real* x,
+void DetJQuad( const RealT xi,
+               const RealT eta,
+               const RealT* x,
                const int dim,
-               real& detJ )
+               RealT& detJ )
 {
    
-   real J[4] = { 0., 0., 0., 0. }; // column major ordering
+   RealT J[4] = { 0., 0., 0., 0. }; // column major ordering
 
    // loop over nodes
    for (int a=0; a<4; ++a)
    {
       // determine (xi,eta) coord of node a
-      real xi_node, eta_node;
+      RealT xi_node, eta_node;
       switch (a)
       {
          case 0:

--- a/src/tribol/integ/FE.hpp
+++ b/src/tribol/integ/FE.hpp
@@ -31,10 +31,10 @@ namespace tribol
  * \pre z is nullptr for 2D
  *
  */
-void GalerkinEval( const real* const RESTRICT x, 
-                   const real pX, const real pY, const real pZ, 
+void GalerkinEval( const RealT* const RESTRICT x, 
+                   const RealT pX, const RealT pY, const RealT pZ, 
                    FaceOrderType order_type, BasisEvalType basis_type, 
-                   int dim, int galerkinDim, real* nodeVals, real* galerkinVal );
+                   int dim, int galerkinDim, RealT* nodeVals, RealT* galerkinVal );
 
 /*!
  *
@@ -52,10 +52,10 @@ void GalerkinEval( const real* const RESTRICT x,
  * \pre z is nullptr for 2D
  *
  */
-void EvalBasis( const real* const RESTRICT x, 
-                const real pX, const real pY, const real pZ, 
+void EvalBasis( const RealT* const RESTRICT x, 
+                const RealT pX, const RealT pY, const RealT pZ, 
                 const int numPoints, const int vertexId, 
-                real& phi );
+                RealT& phi );
 
 /*!
  *
@@ -74,9 +74,9 @@ void EvalBasis( const real* const RESTRICT x,
  * \note This is implicitly a 3D routine
  *
  */
-void WachspressBasis( const real* const RESTRICT x, 
-                      const real pX, const real pY, const real pZ, 
-                      const int numPoints, const int vertexId, real& phi );
+void WachspressBasis( const RealT* const RESTRICT x, 
+                      const RealT pX, const RealT pY, const RealT pZ, 
+                      const int numPoints, const int vertexId, RealT& phi );
 
 /*!
  *
@@ -92,10 +92,10 @@ void WachspressBasis( const real* const RESTRICT x,
  * \note This is implicitly a 2D routine
  *
  */
-void SegmentBasis( const real* const RESTRICT x, 
-                   const real pX, const real pY,
+void SegmentBasis( const RealT* const RESTRICT x, 
+                   const RealT pX, const RealT pY,
                    const int numPoints, const int vertexId, 
-                   real& phi );
+                   RealT& phi );
 
 /*!
  *
@@ -115,12 +115,12 @@ void SegmentBasis( const real* const RESTRICT x,
  *       x[2] is equal to 0.
  *
  */
-void InvIso( const real  x[3], 
-             const real* xA,
-             const real* yA,
-             const real* zA,
+void InvIso( const RealT  x[3], 
+             const RealT* xA,
+             const RealT* yA,
+             const RealT* zA,
              const int numNodes,
-             real  xi[2] );
+             RealT  xi[2] );
 
 /*!
  *
@@ -134,11 +134,11 @@ void InvIso( const real  x[3],
  *
  *
  */
-void FwdMapLinQuad( const real xi[2],
-                    real xa[4],
-                    real ya[4],
-                    real za[4],
-                    real x[3] );
+void FwdMapLinQuad( const RealT xi[2],
+                    RealT xa[4],
+                    RealT ya[4],
+                    RealT za[4],
+                    RealT x[3] );
 
 /*!
  *
@@ -152,11 +152,11 @@ void FwdMapLinQuad( const real xi[2],
  *
  *
  */
-void FwdMapLinTri( const real xi[2],
-                   real xa[3],
-                   real ya[3],
-                   real za[3],
-                   real x[3] );
+void FwdMapLinTri( const RealT xi[2],
+                   RealT xa[3],
+                   RealT ya[3],
+                   RealT za[3],
+                   RealT x[3] );
 
 /*!
  *
@@ -172,10 +172,10 @@ void FwdMapLinTri( const real xi[2],
  *
  *
  */
-void LinIsoQuadShapeFunc( const real xi, 
-                          const real eta,
+void LinIsoQuadShapeFunc( const RealT xi, 
+                          const RealT eta,
                           const int a,
-                          real& phi );
+                          RealT& phi );
 
 /*!
  *
@@ -194,10 +194,10 @@ void LinIsoQuadShapeFunc( const real xi,
  *       of each node are as follows (-1,-1), (1,-1), (0,1).
  *
  */
-void LinIsoTriShapeFunc( const real xi, 
-                         const real eta,
+void LinIsoTriShapeFunc( const RealT xi, 
+                         const RealT eta,
                          const int a,
-                         real& phi );
+                         RealT& phi );
 
 /*!
  *
@@ -217,11 +217,11 @@ void LinIsoTriShapeFunc( const real xi,
  *       integrals
  *
  */
-void DetJQuad( const real xi,
-               const real eta,
-               const real* x,
+void DetJQuad( const RealT xi,
+               const RealT eta,
+               const RealT* x,
                const int dim,
-               real& detJ );
+               RealT& detJ );
 
 } // end of namespace "tribol"
 

--- a/src/tribol/integ/Integration.cpp
+++ b/src/tribol/integ/Integration.cpp
@@ -23,12 +23,12 @@ namespace tribol
 template< >
 void EvalWeakFormIntegral< COMMON_PLANE, SINGLE_POINT >
                          ( SurfaceContactElem const & elem,
-                           real * const integ1,
-                           real * const integ2 )
+                           RealT * const integ1,
+                           RealT * const integ2 )
 {
    // compute the area centroid of the overlap polygon,
    // which serves as the single integration point
-   real cx[3] = {0., 0., 0.};
+   RealT cx[3] = {0., 0., 0.};
    PolyAreaCentroid( elem.overlapCoords, elem.dim, elem.numPolyVert,
                      cx[0], cx[1], cx[2] );
 
@@ -37,10 +37,10 @@ void EvalWeakFormIntegral< COMMON_PLANE, SINGLE_POINT >
    //project overlap polygon centroid to each face
    //
    ///////////////////////////////////////////////
-   real cxProj1[3]  = { 0., 0., 0. }; // overlap centroid projected to face 1
-   real cxProj2[3]  = { 0., 0., 0. }; // overlap centroid projected to face 2
-   real cxf1[3] = { 0., 0., 0. }; // vertex avg. centroid of face 1
-   real cxf2[3] = { 0., 0., 0. }; // vertex avg. centroid of face 2
+   RealT cxProj1[3]  = { 0., 0., 0. }; // overlap centroid projected to face 1
+   RealT cxProj2[3]  = { 0., 0., 0. }; // overlap centroid projected to face 2
+   RealT cxf1[3] = { 0., 0., 0. }; // vertex avg. centroid of face 1
+   RealT cxf2[3] = { 0., 0., 0. }; // vertex avg. centroid of face 2
 
    // compute vertex averaged centroid of each face for the point-normal data
    VertexAvgCentroid( elem.faceCoords1, elem.dim, elem.numFaceVert,
@@ -100,7 +100,7 @@ void EvalWeakFormIntegral< COMMON_PLANE, SINGLE_POINT >
 //------------------------------------------------------------------------------
 void TWBPolyInt( SurfaceContactElem const & elem,
                  IntegPts & integ,
-                 integer k )
+                 int k )
 {
    // check that the order, k, is either 2 or 3
    if (k != 2 && k !=3)
@@ -118,7 +118,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
 
    // declare local array to hold barycentric coordinates for each 
    // triangle
-   real bary[ elem.dim * numTriPoints ];
+   RealT bary[ elem.dim * numTriPoints ];
 
    switch (k) 
    {
@@ -196,7 +196,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
    // compute the vertex averaged centroid of the overlap polygon. Note 
    // that the coordinates of the overlap polygon are always assumed to be 
    // 3D
-   real xc[elem.dim];
+   RealT xc[elem.dim];
    for (int i=0; i<elem.dim; ++i)
    {
       xc[i] = 0.;
@@ -217,7 +217,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
    // integration points based on the TWB barycenter data for the 
    // given integration order
 
-   real vx, vy, vz, a, b, c, p, area;
+   RealT vx, vy, vz, a, b, c, p, area;
    int kmax = elem.numPolyVert - 1;
    for (int k=0; k<kmax; ++k)
    {
@@ -237,7 +237,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
       vz = xc[2] - elem.overlapCoords[ elem.dim * (k+1) + 2 ];
       c = magnitude( vx, vy, vz );
       p = 0.5 * (a + b + c);
-      real area = sqrt(p * (p - a) * (p - b) * (p - c));
+      RealT area = sqrt(p * (p - a) * (p - b) * (p - c));
 
       for (int m=0; m<numTriPoints; ++m)
       {
@@ -297,7 +297,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
 
 //------------------------------------------------------------------------------
 int NumTWBPointsPoly( SurfaceContactElem const & elem,
-                      integer k )
+                      int k )
 {
 
    // get the number of integration points per triangle per integration rule 
@@ -311,7 +311,7 @@ int NumTWBPointsPoly( SurfaceContactElem const & elem,
 }
 
 //------------------------------------------------------------------------------
-int NumTWBPointsPerTri( integer order )
+int NumTWBPointsPerTri( int order )
 {
    switch (order)
    {
@@ -330,7 +330,7 @@ int NumTWBPointsPerTri( integer order )
 //------------------------------------------------------------------------------
 void GaussPolyIntTri( SurfaceContactElem const & elem,
                       IntegPts & integ,
-                      integer k )
+                      int k )
 {
    // determine the number of integration points per triangle in the decomposed 
    // polygon and the total number of integration points on the polygon
@@ -358,7 +358,7 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
 
    // populate wts array and set parent space coordinates of 
    // integration points on triangle
-   real* coords;
+   RealT* coords;
    switch (k)
    {
       case 2:
@@ -366,7 +366,7 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
          {
             integ.wts[i] = 0.3333333333;
          }
-         coords = new real[6];
+         coords = new RealT[6];
          coords[0] = 0.1666666667;
          coords[1] = 0.1666666667;
          coords[2] = 0.6666666667;
@@ -376,8 +376,8 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
          break;
       case 3:
       case 4:
-         real wt1 = 0.109951743655322;
-         real wt2 = 0.223381589678011;
+         RealT wt1 = 0.109951743655322;
+         RealT wt2 = 0.223381589678011;
          for (int i=0; i<elem.numPolyVert; ++i)
          {
             integ.wts[numTriPoints * i] = wt1;
@@ -387,11 +387,11 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
             integ.wts[numTriPoints * i + 4] = wt2;
             integ.wts[numTriPoints * i + 5] = wt2; 
          }
-         real x1 = 0.091576213509771;
-         real x2 = 0.816847572980459;
-         real x3 = 0.108103018168070;
-         real x4 = 0.445948490915965;
-         coords = new real[12];
+         RealT x1 = 0.091576213509771;
+         RealT x2 = 0.816847572980459;
+         RealT x3 = 0.108103018168070;
+         RealT x4 = 0.445948490915965;
+         coords = new RealT[12];
          coords[0]  = x1;
          coords[1]  = x1;
          coords[2]  = x2;
@@ -408,9 +408,9 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
    }
  
    // compute area centroid of polygon
-   real xTri[3] = { 0., 0., 0. };
-   real yTri[3] = { 0., 0., 0. };
-   real zTri[3] = { 0., 0., 0. };
+   RealT xTri[3] = { 0., 0., 0. };
+   RealT yTri[3] = { 0., 0., 0. };
+   RealT zTri[3] = { 0., 0., 0. };
    PolyAreaCentroid(elem.overlapCoords, elem.dim, elem.numPolyVert, 
                     xTri[2], yTri[2], zTri[2] );
 
@@ -428,7 +428,7 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
       zTri[1] = elem.overlapCoords[ elem.dim * triIdPlusOne + 2 ];
 
       // compute area of triangle
-      real area = Area3DTri( xTri, yTri, zTri );
+      RealT area = Area3DTri( xTri, yTri, zTri );
 
       for (int k=0; k<numTriPoints; ++k)
       {
@@ -441,12 +441,12 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
          integ.wts[ numTriPoints * j + k ] *= area;
 
          // group parent space ip coordinates
-         real xi[2];
+         RealT xi[2];
          xi[0] = coords[parentDim * k];
          xi[1] = coords[parentDim * k + 1];
 
          // forward map parent space ip coords to physical space
-         real x[3];
+         RealT x[3];
          FwdMapLinTri( xi, xTri, yTri, zTri, x );
 
          integ.xy[ ((integ.ipDim) * numTriPoints) * j + (integ.ipDim * k) ] = 
@@ -465,7 +465,7 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
 //------------------------------------------------------------------------------
 void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
                        IntegPts & integ,
-                       integer k )
+                       int k )
 {
    // determine the number of integration points per quad 
    int numQuadPoints;
@@ -509,8 +509,8 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
          {
             integ.wts[i] = 1.;
          }
-//         real inv_root_3 = 1./std::sqrt(3.);
-         real inv_root_3 = 1./std::sqrt(3.);
+//         RealT inv_root_3 = 1./std::sqrt(3.);
+         RealT inv_root_3 = 1./std::sqrt(3.);
 
          // integration points ordered counter-clockwise 
          integ.xy[0] = -inv_root_3;
@@ -525,8 +525,8 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
       }
       case 3:
       {
-         real five_nine = 5./9.;
-         real eight_nine = 8./9.;
+         RealT five_nine = 5./9.;
+         RealT eight_nine = 8./9.;
 
          // integration points ordered left to right, bottom to top
          integ.wts[0] = five_nine * five_nine;
@@ -539,8 +539,8 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
          integ.wts[7] = five_nine * eight_nine;
          integ.wts[8] = five_nine * five_nine;
 
-         real x1 = std::sqrt(3./5.);
-         real x2 = 0.;
+         RealT x1 = std::sqrt(3./5.);
+         RealT x2 = 0.;
          integ.xy[0]  = -x1; 
          integ.xy[1]  = -x1; 
          integ.xy[2]  =  x2; 
@@ -565,8 +565,8 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
       }
       case 4:
       {
-         real wt1 = (18. - std::sqrt(30.)) / 36.;
-         real wt2 = (18. + std::sqrt(30.)) / 36.;
+         RealT wt1 = (18. - std::sqrt(30.)) / 36.;
+         RealT wt2 = (18. + std::sqrt(30.)) / 36.;
 
          // integration points ordered bottom to top, left to right.
          // Note, this is different that the third order rule
@@ -587,10 +587,10 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
          integ.wts[14] = wt1 * wt2;
          integ.wts[15] = wt1 * wt1;
 
-//         real x1 = std::sqrt((15. + 2. * std::sqrt(30.)) / 35.);
-//         real x2 = std::sqrt((15. - 2. * std::sqrt(30.)) / 35.);
-         real x1 = std::sqrt(3./7. + 2./7. * std::sqrt(6./5.));
-         real x2 = std::sqrt(3./7. - 2./7. * std::sqrt(6./5.));
+//         RealT x1 = std::sqrt((15. + 2. * std::sqrt(30.)) / 35.);
+//         RealT x2 = std::sqrt((15. - 2. * std::sqrt(30.)) / 35.);
+         RealT x1 = std::sqrt(3./7. + 2./7. * std::sqrt(6./5.));
+         RealT x2 = std::sqrt(3./7. - 2./7. * std::sqrt(6./5.));
 
          integ.xy[0]  = -x1;
          integ.xy[1]  = -x1;
@@ -631,9 +631,9 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
       }
       case 5:
       {
-         real wt1 = 1. / 900. * (322. - 13. * std::sqrt(70.));
-         real wt2 = 1. / 900. * (322. + 13. * std::sqrt(70.));
-         real wt3 = 128. / 225.;
+         RealT wt1 = 1. / 900. * (322. - 13. * std::sqrt(70.));
+         RealT wt2 = 1. / 900. * (322. + 13. * std::sqrt(70.));
+         RealT wt3 = 128. / 225.;
      
          // points are ordered bottom to top, left to right
          integ.wts[0] = wt1 * wt1;
@@ -662,9 +662,9 @@ void GaussPolyIntQuad( SurfaceContactElem const & TRIBOL_UNUSED_PARAM(elem),
          integ.wts[23] = wt1 * wt2;
          integ.wts[24] = wt1 * wt1;
 
-         real x1 = 1./3. * std::sqrt(5. + 2. * std::sqrt(10./7.)) ;
-         real x2 = 1./3. * std::sqrt(5. - 2. * std::sqrt(10./7.)) ;
-         real x3 = 0.;
+         RealT x1 = 1./3. * std::sqrt(5. + 2. * std::sqrt(10./7.)) ;
+         RealT x2 = 1./3. * std::sqrt(5. - 2. * std::sqrt(10./7.)) ;
+         RealT x3 = 0.;
 
          integ.xy[0] = -x1;
          integ.xy[1] = -x1;

--- a/src/tribol/integ/Integration.hpp
+++ b/src/tribol/integ/Integration.hpp
@@ -21,14 +21,14 @@ struct SurfaceContactElem;
 struct IntegPts
 {
    /// IntegPts constructor
-   IntegPts( integer numPoints, ///< [in] Number of integration points
-             integer IPDim      ///< [in] dimension of integration point coordinates
+   IntegPts( int numPoints, ///< [in] Number of integration points
+             int IPDim      ///< [in] dimension of integration point coordinates
            ) 
       : numIPs( numPoints )
       , ipDim(IPDim)
    { 
-      xy =  new real[ IPDim * numPoints ];
-      wts = new real[ numPoints ]; 
+      xy =  new RealT[ IPDim * numPoints ];
+      wts = new RealT[ numPoints ]; 
    }
 
    /// IntegPts overloaded constructor
@@ -55,29 +55,29 @@ struct IntegPts
       this->numIPs = numTotalIPs;
       if (this->xy == nullptr)
       {
-         this->xy = new real [dim * numTotalIPs];
+         this->xy = new RealT [dim * numTotalIPs];
       }
       else
       {
          delete [] this->xy;
-         this->xy = new real [dim * numTotalIPs];
+         this->xy = new RealT [dim * numTotalIPs];
       }
       if (this->wts == nullptr)
       {
-         this->wts = new real [numTotalIPs];
+         this->wts = new RealT [numTotalIPs];
       }
       else
       {
          delete [] this->wts;
-         this->wts = new real [numTotalIPs];
+         this->wts = new RealT [numTotalIPs];
       }
    }
 
    // member variables
-   integer numIPs; ///< number of integration points on entire overlap
-   integer ipDim;  ///< coordinate dimension of the integration points 
-   real* xy;       ///< coordinates of ALL integration points
-   real* wts;      ///< integration point weights
+   int numIPs; ///< number of integration points on entire overlap
+   int ipDim;  ///< coordinate dimension of the integration points 
+   RealT* xy;       ///< coordinates of ALL integration points
+   RealT* wts;      ///< integration point weights
 };
 
 /*!
@@ -96,8 +96,8 @@ struct IntegPts
  */
 template< ContactMethod M, PolyInteg I > 
 void EvalWeakFormIntegral( SurfaceContactElem const & elem,
-                           real * const integ1,
-                           real * const integ2 );
+                           RealT * const integ1,
+                           RealT * const integ2 );
                         
 /*!
  *
@@ -120,7 +120,7 @@ void EvalWeakFormIntegral( SurfaceContactElem const & elem,
  */
 void TWBPolyInt( SurfaceContactElem const & elem,
                  IntegPts & integ,
-                 integer k );
+                 int k );
 
 /*!
  *
@@ -139,7 +139,7 @@ void TWBPolyInt( SurfaceContactElem const & elem,
  */
 void GaussPolyIntTri( SurfaceContactElem const & elem,
                       IntegPts & integ,
-                      integer k );
+                      int k );
 
 /*!
  *
@@ -159,7 +159,7 @@ void GaussPolyIntTri( SurfaceContactElem const & elem,
 
 void GaussPolyIntQuad( SurfaceContactElem const & elem,
                        IntegPts & integ,
-                       integer k );
+                       int k );
 /*!
  *
  * \brief returns the number of TWB integration points for polygonal overlap 
@@ -172,7 +172,7 @@ void GaussPolyIntQuad( SurfaceContactElem const & elem,
  *
  */
 int NumTWBPointsPoly( SurfaceContactElem const & elem,
-                      integer k );
+                      int k );
 
 /*!
  *
@@ -184,7 +184,7 @@ int NumTWBPointsPoly( SurfaceContactElem const & elem,
  * \pre order 2 <= k <= 3
  *
  */
-int NumTWBPointsPerTri( integer order );
+int NumTWBPointsPerTri( int order );
 
 } // end namespace tribol
 #endif /* SRC_INTEG_INTEGRATION_HPP_ */

--- a/src/tribol/interface/mfem_tribol.cpp
+++ b/src/tribol/interface/mfem_tribol.cpp
@@ -15,13 +15,13 @@
 namespace tribol
 {
 
-void registerMfemCouplingScheme( integer cs_id,
-                                 integer mesh_id_1,
-                                 integer mesh_id_2,
+void registerMfemCouplingScheme( int cs_id,
+                                 int mesh_id_1,
+                                 int mesh_id_2,
                                  const mfem::ParMesh& mesh,
                                  const mfem::ParGridFunction& current_coords,
-                                 std::set<integer> b_attributes_1,
-                                 std::set<integer> b_attributes_2,
+                                 std::set<int> b_attributes_1,
+                                 std::set<int> b_attributes_2,
                                  ContactMode contact_mode,
                                  ContactCase contact_case,
                                  ContactMethod contact_method,
@@ -62,7 +62,7 @@ void registerMfemCouplingScheme( integer cs_id,
             current_coords.FESpace()->FEColl()->GetOrder(),
             mesh.SpaceDimension()
          );
-      integer pressure_vdim = 0;
+      int pressure_vdim = 0;
       if (contact_model == FRICTIONLESS)
       {
          pressure_vdim = 1;
@@ -109,7 +109,7 @@ void registerMfemCouplingScheme( integer cs_id,
 
 }
 
-void setMfemLORFactor( integer cs_id, integer lor_factor )
+void setMfemLORFactor( int cs_id, int lor_factor )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -120,9 +120,9 @@ void setMfemLORFactor( integer cs_id, integer lor_factor )
    coupling_scheme->getMfemMeshData()->SetLORFactor(lor_factor);
 }
 
-void setMfemKinematicConstantPenalty( integer cs_id, 
-                                      real mesh1_penalty,
-                                      real mesh2_penalty )
+void setMfemKinematicConstantPenalty( int cs_id, 
+                                      RealT mesh1_penalty,
+                                      RealT mesh2_penalty )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -136,7 +136,7 @@ void setMfemKinematicConstantPenalty( integer cs_id,
    coupling_scheme->getMfemMeshData()->SetMesh2KinematicConstantPenalty(mesh2_penalty);
 }
 
-void setMfemKinematicElementPenalty( integer cs_id, 
+void setMfemKinematicElementPenalty( int cs_id, 
                                      mfem::Coefficient& modulus_coefficient )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
@@ -151,9 +151,9 @@ void setMfemKinematicElementPenalty( integer cs_id,
    coupling_scheme->getMfemMeshData()->SetMaterialModulus(modulus_coefficient);
 }
 
-void setMfemRateConstantPenalty( integer cs_id, 
-                                 real mesh1_penalty, 
-                                 real mesh2_penalty )
+void setMfemRateConstantPenalty( int cs_id, 
+                                 RealT mesh1_penalty, 
+                                 RealT mesh2_penalty )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -174,9 +174,9 @@ void setMfemRateConstantPenalty( integer cs_id,
    coupling_scheme->getMfemMeshData()->SetMesh2RateConstantPenalty(mesh2_penalty);
 }
 
-void setMfemRatePercentPenalty( integer cs_id, 
-                                 real mesh1_ratio, 
-                                 real mesh2_ratio )
+void setMfemRatePercentPenalty( int cs_id, 
+                                 RealT mesh1_ratio, 
+                                 RealT mesh2_ratio )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -197,7 +197,7 @@ void setMfemRatePercentPenalty( integer cs_id,
    coupling_scheme->getMfemMeshData()->SetMesh2RatePercentPenalty(mesh2_ratio);
 }
 
-void setMfemKinematicPenaltyScale( integer cs_id, real mesh1_scale, real mesh2_scale )
+void setMfemKinematicPenaltyScale( int cs_id, RealT mesh1_scale, RealT mesh2_scale )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -215,7 +215,7 @@ void setMfemKinematicPenaltyScale( integer cs_id, real mesh1_scale, real mesh2_s
    coupling_scheme->getMfemMeshData()->SetMesh2KinematicPenaltyScale(mesh2_scale);
 }
 
-void updateMfemElemThickness(integer cs_id)
+void updateMfemElemThickness(int cs_id)
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -231,7 +231,7 @@ void updateMfemElemThickness(integer cs_id)
    coupling_scheme->getMfemMeshData()->ComputeElementThicknesses();
 }
 
-void updateMfemMaterialModulus(integer cs_id, mfem::Coefficient& modulus_coefficient)
+void updateMfemMaterialModulus(int cs_id, mfem::Coefficient& modulus_coefficient)
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -247,7 +247,7 @@ void updateMfemMaterialModulus(integer cs_id, mfem::Coefficient& modulus_coeffic
    coupling_scheme->getMfemMeshData()->SetMaterialModulus(modulus_coefficient);
 }
 
-void registerMfemVelocity( integer cs_id, const mfem::ParGridFunction& v )
+void registerMfemVelocity( int cs_id, const mfem::ParGridFunction& v )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -258,7 +258,7 @@ void registerMfemVelocity( integer cs_id, const mfem::ParGridFunction& v )
    coupling_scheme->getMfemMeshData()->SetParentVelocity(v);
 }
 
-void getMfemResponse( integer cs_id, mfem::Vector& r )
+void getMfemResponse( int cs_id, mfem::Vector& r )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -269,7 +269,7 @@ void getMfemResponse( integer cs_id, mfem::Vector& r )
    coupling_scheme->getMfemMeshData()->GetParentResponse(r);
 }
 
-std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId )
+std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( int csId )
 {
    CouplingScheme* coupling_scheme = CouplingSchemeManager::getInstance().
       getCoupling(csId);
@@ -294,7 +294,7 @@ std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId )
    );
 }
 
-void getMfemGap( integer cs_id, mfem::Vector& g )
+void getMfemGap( int cs_id, mfem::Vector& g )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -306,7 +306,7 @@ void getMfemGap( integer cs_id, mfem::Vector& g )
    coupling_scheme->getMfemSubmeshData()->GetSubmeshGap(g);
 }
 
-mfem::ParGridFunction& getMfemPressure( integer cs_id )
+mfem::ParGridFunction& getMfemPressure( int cs_id )
 {
    auto coupling_scheme = CouplingSchemeManager::getInstance().getCoupling(cs_id);
    SLIC_ERROR_ROOT_IF(
@@ -336,7 +336,7 @@ void updateMfemParallelDecomposition()
       if (couplingScheme->hasMfemData())
       {
          auto mfem_data = couplingScheme->getMfemMeshData();
-         axom::Array<int> mesh_ids {2, 2};
+         ArrayT<int> mesh_ids {2, 2};
          mesh_ids[0] = mfem_data->GetMesh1ID();
          mesh_ids[1] = mfem_data->GetMesh2ID();
          // creates a new redecomp mesh based on updated coordinates and updates
@@ -468,7 +468,7 @@ void updateMfemParallelDecomposition()
 
 }
 
-void saveRedecompMesh( integer output_id )
+void saveRedecompMesh( int output_id )
 {
    CouplingSchemeManager& csManager = CouplingSchemeManager::getInstance();
    int numCouplings = csManager.getNumberOfCouplings();

--- a/src/tribol/interface/mfem_tribol.hpp
+++ b/src/tribol/interface/mfem_tribol.hpp
@@ -51,13 +51,13 @@ namespace tribol
  * @param [in] enforcement_method 
  * @param [in] binning_method 
  */
-void registerMfemCouplingScheme( integer cs_id,
-                                 integer mesh_id_1,
-                                 integer mesh_id_2,
+void registerMfemCouplingScheme( int cs_id,
+                                 int mesh_id_1,
+                                 int mesh_id_2,
                                  const mfem::ParMesh& mesh,
                                  const mfem::ParGridFunction& current_coords,
-                                 std::set<integer> b_attributes_1,
-                                 std::set<integer> b_attributes_2,
+                                 std::set<int> b_attributes_1,
+                                 std::set<int> b_attributes_2,
                                  ContactMode contact_mode,
                                  ContactCase contact_case,
                                  ContactMethod contact_method,
@@ -89,7 +89,7 @@ void registerMfemCouplingScheme( integer cs_id,
  * @param [in] cs_id The ID of the coupling scheme
  * @param [in] lor_factor The refinement factor of the LOR mesh
  */
-void setMfemLORFactor( integer cs_id, integer lor_factor );
+void setMfemLORFactor( int cs_id, int lor_factor );
 
 /**
  * @brief Clears existing penalty data and sets kinematic constant penalty
@@ -100,7 +100,7 @@ void setMfemLORFactor( integer cs_id, integer lor_factor );
  * @param mesh1_penalty Penalty parameter for the first contact surface mesh
  * @param mesh2_penalty Penalty parameter for the second contact surface mesh
  */
-void setMfemKinematicConstantPenalty( integer cs_id, real mesh1_penalty, real mesh2_penalty );
+void setMfemKinematicConstantPenalty( int cs_id, RealT mesh1_penalty, RealT mesh2_penalty );
 
 /**
  * @brief Clears existing penalty data and sets kinematic element penalty
@@ -114,7 +114,7 @@ void setMfemKinematicConstantPenalty( integer cs_id, real mesh1_penalty, real me
  * @param cs_id The ID of the coupling scheme with the MFEM mesh
  * @param modulus_coefficient MFEM coefficient defining bulk modulus over the parent-linked boundary submesh
  */
-void setMfemKinematicElementPenalty( integer cs_id, mfem::Coefficient& modulus_coefficient );
+void setMfemKinematicElementPenalty( int cs_id, mfem::Coefficient& modulus_coefficient );
 
 /**
  * @brief Adds constant gap rate penalty to the existing kinematic penalty
@@ -127,7 +127,7 @@ void setMfemKinematicElementPenalty( integer cs_id, mfem::Coefficient& modulus_c
  * @param mesh1_penalty Penalty parameter for the first contact surface mesh
  * @param mesh2_penalty Penalty parameter for the second contact surface mesh
  */
-void setMfemRateConstantPenalty( integer cs_id, real mesh1_penalty, real mesh2_penalty );
+void setMfemRateConstantPenalty( int cs_id, RealT mesh1_penalty, RealT mesh2_penalty );
 
 /**
  * @brief Adds gap rate penalty as a scaling of the existing kinematic penalty
@@ -140,7 +140,7 @@ void setMfemRateConstantPenalty( integer cs_id, real mesh1_penalty, real mesh2_p
  * @param mesh1_ratio Scaling coefficient of the kinematic penalty for the first contact surface mesh
  * @param mesh2_ratio Scaling coefficient of the kinematic penalty for the second contact surface mesh
  */
-void setMfemRatePercentPenalty( integer cs_id, real mesh1_ratio, real mesh2_ratio );
+void setMfemRatePercentPenalty( int cs_id, RealT mesh1_ratio, RealT mesh2_ratio );
 
 /**
  * @brief Adds a scale to the computed kinematic penalty
@@ -155,7 +155,7 @@ void setMfemRatePercentPenalty( integer cs_id, real mesh1_ratio, real mesh2_rati
  * @param mesh1_scale Scaling coefficient of the kinematic penalty for the first contact surface mesh
  * @param mesh2_scale Scaling coefficient of the kinematic penalty for the second contact surface mesh
  */
-void setMfemKinematicPenaltyScale( integer cs_id, real mesh1_scale, real mesh2_scale );
+void setMfemKinematicPenaltyScale( int cs_id, RealT mesh1_scale, RealT mesh2_scale );
 
 /**
  * @brief Computes element thickness for the volume elements associated with the contact surface mesh.
@@ -171,7 +171,7 @@ void setMfemKinematicPenaltyScale( integer cs_id, real mesh1_scale, real mesh2_s
  *
  * @param cs_id The ID of the coupling scheme with the MFEM mesh
  */
-void updateMfemElemThickness( integer cs_id );
+void updateMfemElemThickness( int cs_id );
 
 /**
  * @brief Sets the bulk modulus for the volume elements associated with the contact surface mesh.
@@ -187,7 +187,7 @@ void updateMfemElemThickness( integer cs_id );
  * @note Material modulus is autoamtically set when setMfemKinematicElementPenalty() is called. Call this method to
  * update material bulk moduli.
  */
-void updateMfemMaterialModulus( integer cs_id, mfem::Coefficient& modulus_coefficient );
+void updateMfemMaterialModulus( int cs_id, mfem::Coefficient& modulus_coefficient );
 
 /**
  * @brief Registers a velocity field on a MFEM mesh-defined coupling scheme
@@ -198,7 +198,7 @@ void updateMfemMaterialModulus( integer cs_id, mfem::Coefficient& modulus_coeffi
  * @param [in] cs_id The ID of the coupling scheme with the MFEM mesh
  * @param [in] v MFEM velocity ParGridFunction defined over the parent mesh
  */
-void registerMfemVelocity( integer cs_id, const mfem::ParGridFunction& v );
+void registerMfemVelocity( int cs_id, const mfem::ParGridFunction& v );
 
 /**
  * @brief Returns the response (RHS) vector to a given mfem::Vector
@@ -212,7 +212,7 @@ void registerMfemVelocity( integer cs_id, const mfem::ParGridFunction& v );
  * @param [in] cs_id The ID of the coupling scheme with the MFEM mesh
  * @param [out] r mfem::Vector of the response (RHS) vector (properly sized, pre-allocated, and initialized)
  */
-void getMfemResponse( integer cs_id, mfem::Vector& r );
+void getMfemResponse( int cs_id, mfem::Vector& r );
 
 /**
  * @brief Get assembled contact contributions for the Jacobian matrix
@@ -240,7 +240,7 @@ void getMfemResponse( integer cs_id, mfem::Vector& r );
  * @param csId Coupling scheme id with a registered MFEM mesh
  * @return Jacobian contributions as an mfem::BlockOperator
  */
-std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId );
+std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( int csId );
 
 /**
  * @brief Returns gap vector to a given mfem::Vector
@@ -255,7 +255,7 @@ std::unique_ptr<mfem::BlockOperator> getMfemBlockJacobian( integer csId );
  * @param [in] cs_id Coupling scheme id with a registered MFEM mesh
  * @param [out] g Nodal gap values (values do not have to be pre-allocated) on the parent-linked boundary submesh
  */
-void getMfemGap( integer cs_id, mfem::Vector& g );
+void getMfemGap( int cs_id, mfem::Vector& g );
 
 /**
  * @brief Returns reference to nodal pressure vector on the submesh surface
@@ -267,7 +267,7 @@ void getMfemGap( integer cs_id, mfem::Vector& g );
  * @return mfem::ParGridFunction& Nodal pressure vector defined on the
  * parent-linked boundary submesh
  */
-mfem::ParGridFunction& getMfemPressure( integer cs_id );
+mfem::ParGridFunction& getMfemPressure( int cs_id );
 
 /**
  * @brief Updates mesh parallel decomposition and related grid
@@ -285,7 +285,7 @@ void updateMfemParallelDecomposition();
  * 
  * @param output_id Unique identifier in the saved file name (usually cycle number)
  */
-void saveRedecompMesh( integer output_id );
+void saveRedecompMesh( int output_id );
 
 } /* namespace tribol */
 

--- a/src/tribol/interface/simple_tribol.cpp
+++ b/src/tribol/interface/simple_tribol.cpp
@@ -45,7 +45,7 @@ int Initialize(const int dim, bool init_slic)
    }
 
    // Initialize tribol
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
+   tribol::CommT problem_comm = TRIBOL_COMM_WORLD;
    tribol::initialize( dim, problem_comm );
 
    return 0;

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -84,7 +84,7 @@ void set_defaults()
 } /* end namepsace internal */
 
 //------------------------------------------------------------------------------
-void initialize( integer dimension, CommType comm )
+void initialize( int dimension, CommT comm )
 {
    // sanity checks
    SLIC_ASSERT( (dimension==2) || (dimension==3) );
@@ -152,7 +152,7 @@ void setPenaltyOptions( int couplingSchemeIndex, PenaltyConstraintType pen_enfrc
 } // end setPenaltyOptions()
 
 //------------------------------------------------------------------------------
-void setKinematicConstantPenalty( int meshId, double k )
+void setKinematicConstantPenalty( int meshId, RealT k )
 {
    // note, error checking done in the following registration routine
    registerRealElementField( meshId, KINEMATIC_CONSTANT_STIFFNESS, &k ); 
@@ -161,8 +161,8 @@ void setKinematicConstantPenalty( int meshId, double k )
 
 //------------------------------------------------------------------------------
 void setKinematicElementPenalty( int meshId, 
-                                 const double *material_modulus,
-                                 const double *element_thickness )
+                                 const RealT *material_modulus,
+                                 const RealT *element_thickness )
 {
    // note, error checking done in the following registration routine
    registerRealElementField( meshId, BULK_MODULUS, material_modulus ); 
@@ -171,7 +171,7 @@ void setKinematicElementPenalty( int meshId,
 } // end setKinematicElementPenalty()
 
 //------------------------------------------------------------------------------
-void setRateConstantPenalty( int meshId, double r_k )
+void setRateConstantPenalty( int meshId, RealT r_k )
 {
    // note, error checking done in the following registration routine
    registerRealElementField( meshId, RATE_CONSTANT_STIFFNESS, &r_k );
@@ -179,7 +179,7 @@ void setRateConstantPenalty( int meshId, double r_k )
 } // end setRateConstantPenalty()
 
 //------------------------------------------------------------------------------
-void setRatePercentPenalty( int meshId, double r_p )
+void setRatePercentPenalty( int meshId, RealT r_p )
 {
    // note, error checking done in the following registration routine
    registerRealElementField( meshId, RATE_PERCENT_STIFFNESS, &r_p );
@@ -187,7 +187,7 @@ void setRatePercentPenalty( int meshId, double r_p )
 } // end setRatePercentPenalty()
 
 //------------------------------------------------------------------------------
-void setAutoContactPenScale( double scale )
+void setAutoContactPenScale( RealT scale )
 {
    parameters_t & parameters = parameters_t::getInstance();
 
@@ -200,7 +200,7 @@ void setAutoContactPenScale( double scale )
 } // end setAutoContactPenScale()
 
 //------------------------------------------------------------------------------
-void setTimestepPenFrac( double frac )
+void setTimestepPenFrac( RealT frac )
 {
    parameters_t & parameters = parameters_t::getInstance();
    if (frac <= 0.)
@@ -214,7 +214,7 @@ void setTimestepPenFrac( double frac )
 } // end setTimestepPenFrac()
 
 //------------------------------------------------------------------------------
-void setContactAreaFrac( double frac )
+void setContactAreaFrac( RealT frac )
 {
    parameters_t & parameters = parameters_t::getInstance();
    if (frac < 1.e-12)
@@ -227,7 +227,7 @@ void setContactAreaFrac( double frac )
 }
 
 //------------------------------------------------------------------------------
-void setPenaltyScale( int meshId, double scale )
+void setPenaltyScale( int meshId, RealT scale )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -300,7 +300,7 @@ void setLagrangeMultiplierOptions( int couplingSchemeIndex, ImplicitEvalMode eva
 } // end setLagrangeMultiplierOptions()
 
 //------------------------------------------------------------------------------
-void setPlotCycleIncrement( double incr )
+void setPlotCycleIncrement( int incr )
 {
    parameters_t & parameters = parameters_t::getInstance();
    parameters.vis_cycle_incr = incr;
@@ -356,14 +356,14 @@ void enableTimestepVote( const bool enable )
 }
 
 //------------------------------------------------------------------------------
-void registerMesh( integer meshId,
-                   integer numCells,
-                   integer lengthNodalData,
-                   const IndexType* connectivity,
-                   integer elementType,
-                   const real* x,
-                   const real* y,
-                   const real* z )
+void registerMesh( int meshId,
+                   int numCells,
+                   int lengthNodalData,
+                   const IndexT* connectivity,
+                   int elementType,
+                   const RealT* x,
+                   const RealT* y,
+                   const RealT* z )
 {
    MeshManager & meshManager = MeshManager::getInstance();
    MeshData & mesh = meshManager.CreateMesh( meshId );
@@ -473,10 +473,10 @@ void registerMesh( integer meshId,
 } // end of registerMesh()
 
 //------------------------------------------------------------------------------
-void registerNodalDisplacements( integer meshId,
-                                 const real* dx,
-                                 const real* dy,
-                                 const real* dz )
+void registerNodalDisplacements( int meshId,
+                                 const RealT* dx,
+                                 const RealT* dy,
+                                 const RealT* dz )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -506,10 +506,10 @@ void registerNodalDisplacements( integer meshId,
 } // end registerNodalDisplacements()
 
 //------------------------------------------------------------------------------
-void registerNodalVelocities( integer meshId,
-                              const real* vx,
-                              const real* vy,
-                              const real* vz )
+void registerNodalVelocities( int meshId,
+                              const RealT* vx,
+                              const RealT* vy,
+                              const RealT* vz )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -539,10 +539,10 @@ void registerNodalVelocities( integer meshId,
 } // end registerNodalVelocities()
 
 //------------------------------------------------------------------------------
-void registerNodalResponse( integer meshId,
-                            real* rx,
-                            real* ry,
-                            real* rz )
+void registerNodalResponse( int meshId,
+                            RealT* rx,
+                            RealT* ry,
+                            RealT* rz )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -604,7 +604,7 @@ int getJacobianSparseMatrix( mfem::SparseMatrix ** sMat, int csId )
 } // end getMfemSparseMatrix()
 
 //------------------------------------------------------------------------------
-int getJacobianCSRMatrix( int** I, int** J, real** vals, int csId,
+int getJacobianCSRMatrix( int** I, int** J, RealT** vals, int csId,
                   int* n_offsets, int* n_nonzero )
 {
    // check to make sure input pointers are null
@@ -652,11 +652,11 @@ int getJacobianCSRMatrix( int** I, int** J, real** vals, int csId,
 } // end getCSRMatrix()
 
 //------------------------------------------------------------------------------
-int getElementBlockJacobians( integer csId, 
+int getElementBlockJacobians( int csId, 
                               BlockSpace row_block, 
                               BlockSpace col_block,
-                              const axom::Array<integer>** row_elem_idx,
-                              const axom::Array<integer>** col_elem_idx,
+                              const axom::Array<int>** row_elem_idx,
+                              const axom::Array<int>** col_elem_idx,
                               const axom::Array<mfem::DenseMatrix>** jacobians )
 {
    SparseMode sparse_mode = CouplingSchemeManager::getInstance().
@@ -681,8 +681,8 @@ int getElementBlockJacobians( integer csId,
 }
 
 //------------------------------------------------------------------------------
-void registerMortarGaps( integer meshId,
-                         real * gaps )
+void registerMortarGaps( int meshId,
+                         RealT * gaps )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -706,8 +706,8 @@ void registerMortarGaps( integer meshId,
 }
 
 //------------------------------------------------------------------------------
-void registerMortarPressures( integer meshId,
-                              const real * pressures )
+void registerMortarPressures( int meshId,
+                              const RealT * pressures )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -731,9 +731,9 @@ void registerMortarPressures( integer meshId,
 }
 
 //------------------------------------------------------------------------------
-void registerIntNodalField( integer meshId,
+void registerIntNodalField( int meshId,
                             const IntNodalFields field,
-                            integer * TRIBOL_UNUSED_PARAM(fieldVariable) )
+                            int * TRIBOL_UNUSED_PARAM(fieldVariable) )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -750,9 +750,9 @@ void registerIntNodalField( integer meshId,
 } // end registerIntNodalField()
 
 //------------------------------------------------------------------------------
-void registerRealElementField( integer meshId,
+void registerRealElementField( int meshId,
                                const RealElementFields field,
-                               const real * fieldVariable )
+                               const RealT * fieldVariable )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -934,9 +934,9 @@ void registerRealElementField( integer meshId,
 } // end registerRealElementField()
 
 //------------------------------------------------------------------------------
-void registerIntElementField( integer meshId,
+void registerIntElementField( int meshId,
                               const IntElementFields field,
-                              integer * TRIBOL_UNUSED_PARAM(fieldVariable) )
+                              int * TRIBOL_UNUSED_PARAM(fieldVariable) )
 {
    MeshManager & meshManager = MeshManager::getInstance();
 
@@ -953,15 +953,15 @@ void registerIntElementField( integer meshId,
 } // end registerIntElementField()
 
 //------------------------------------------------------------------------------
-void registerCouplingScheme( integer couplingSchemeIndex,
-                             integer meshId1,
-                             integer meshId2,
-                             integer contact_mode,
-                             integer contact_case,
-                             integer contact_method,
-                             integer contact_model,
-                             integer enforcement_method,
-                             integer binning_method )
+void registerCouplingScheme( int couplingSchemeIndex,
+                             int meshId1,
+                             int meshId2,
+                             int contact_mode,
+                             int contact_case,
+                             int contact_method,
+                             int contact_model,
+                             int enforcement_method,
+                             int binning_method )
 {
    // add coupling scheme. Checks for valid schemes will be performed later
    CouplingSchemeManager& couplingSchemeManager =
@@ -985,14 +985,14 @@ void registerCouplingScheme( integer couplingSchemeIndex,
 } // end registerCouplingScheme()
 
 //------------------------------------------------------------------------------
-void setInterfacePairs( integer couplingSchemeIndex,
-                        IndexType numPairs,
-                        IndexType const * const meshId1,
-                        IndexType const * const pairType1,
-                        IndexType const * const pairIndex1,
-                        IndexType const * const meshId2,
-                        IndexType const * const pairType2,
-                        IndexType const * const pairIndex2 )
+void setInterfacePairs( int couplingSchemeIndex,
+                        IndexT numPairs,
+                        IndexT const * const meshId1,
+                        IndexT const * const pairType1,
+                        IndexT const * const pairIndex1,
+                        IndexT const * const meshId2,
+                        IndexT const * const pairType2,
+                        IndexT const * const pairIndex2 )
 {
    CouplingSchemeManager& csManager = CouplingSchemeManager::getInstance();
 
@@ -1033,7 +1033,7 @@ void setInterfacePairs( integer couplingSchemeIndex,
 }
 
 //------------------------------------------------------------------------------
-integer update( integer cycle, real t, real &dt )
+int update( int cycle, RealT t, RealT &dt )
 {
    CouplingSchemeManager& csManager = CouplingSchemeManager::getInstance();
    int numCouplings = csManager.getNumberOfCouplings();

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -30,7 +30,7 @@ namespace tribol
  * \pre dimension==2 || dimensions==3
  * \pre comm != MPI_COMM_NULL
  */
-void initialize( integer dimension, CommType comm );
+void initialize( int dimension, CommT comm );
 
 /// @}
 
@@ -56,7 +56,7 @@ void setPenaltyOptions( int couplingSchemeIndex,
  * \param [in] meshId mesh id for penalty stiffness  
  * \param [in] k constant kinematic penalty stiffness
  */
-void setKinematicConstantPenalty( int meshId, double k );
+void setKinematicConstantPenalty( int meshId, RealT k );
 
 /*!
  * \brief Sets the kinematic element penalty stiffness data
@@ -68,22 +68,22 @@ void setKinematicConstantPenalty( int meshId, double k );
  *       is the number of contact faces registered for mesh with id, \p meshId.
  */
 void setKinematicElementPenalty( int meshId, 
-                                 const double *material_modulus, 
-                                 const double *element_thickness );
+                                 const RealT *material_modulus, 
+                                 const RealT *element_thickness );
 
 /*!
  * \brief Sets the constant rate penalty stiffness
  * \param [in] meshId mesh id for penalty stiffness  
  * \param [in] r_k constant rate penalty stiffness
  */
-void setRateConstantPenalty( int meshId, double r_k );
+void setRateConstantPenalty( int meshId, RealT r_k );
 
 /*!
  * \brief Sets the percent rate penalty stiffness
  * \param [in] meshId mesh id for penalty stiffness  
  * \param [in] r_p rate penalty as percent of kinematic penalty
  */
-void setRatePercentPenalty( int meshId, double r_p );
+void setRatePercentPenalty( int meshId, RealT r_p );
 
 /*!
  *
@@ -96,7 +96,7 @@ void setRatePercentPenalty( int meshId, double r_p );
  *     
  *
  */
-void setAutoContactPenScale( double scale );
+void setAutoContactPenScale( RealT scale );
 
 /*!
  *
@@ -108,7 +108,7 @@ void setAutoContactPenScale( double scale );
  * fraction of the element thickness that is allowed prior to triggering a timestep vote.
  *
  */
-void setTimestepPenFrac( double frac );
+void setTimestepPenFrac( RealT frac );
 
 /*!
  * \brief Sets the area fraction for inclusion of a contact overlap 
@@ -118,7 +118,7 @@ void setTimestepPenFrac( double frac );
  *       contact overlap with the largest of the two consituent 
  *       faces. A default ratio is provided by Tribol.
  */
-void setContactAreaFrac( double frac );
+void setContactAreaFrac( RealT frac );
 
 /*!
  * \brief Sets the penalty scale
@@ -126,7 +126,7 @@ void setContactAreaFrac( double frac );
  * \param [in] meshId ID for the mesh the penalty scale will be applied to
  * \param [in] scale the penalty scale
  */
-void setPenaltyScale( int meshId, double scale );
+void setPenaltyScale( int meshId, RealT scale );
 
 /*!
  * \brief Sets the Lagrange multiplier enforcement options
@@ -143,7 +143,7 @@ void setLagrangeMultiplierOptions( int couplingSchemeIndex, ImplicitEvalMode eva
  * \brief Sets the plot cycle increment for visualization
  * \param [in] incr cycle increment between writing plot data
  */
-void setPlotCycleIncrement( double incr );
+void setPlotCycleIncrement( int incr );
 
 /*!
  * \brief Sets the plot options for interface visualization 
@@ -204,14 +204,14 @@ void enableTimestepVote( const bool enable );
  * \pre y != nullptr
  * \pre z != nullptr (3D only)
  */
-void registerMesh( integer meshId,
-                   integer numCells,
-                   integer lengthNodalData,
-                   const IndexType* connectivity,
-                   integer cellType,
-                   const real* x,
-                   const real* y,
-                   const real* z=nullptr );
+void registerMesh( int meshId,
+                   int numCells,
+                   int lengthNodalData,
+                   const IndexT* connectivity,
+                   int cellType,
+                   const RealT* x,
+                   const RealT* y,
+                   const RealT* z=nullptr );
 
 /*!
  * \brief Registers nodal displacements on the contact surface.
@@ -228,10 +228,10 @@ void registerMesh( integer meshId,
  * \note A mesh for the given contact surface must have already been registered
  *  prior to calling this method via registerMesh()
  */
-void registerNodalDisplacements( integer meshId,
-                                 const real* dx,
-                                 const real* dy,
-                                 const real* dz=nullptr );
+void registerNodalDisplacements( int meshId,
+                                 const RealT* dx,
+                                 const RealT* dy,
+                                 const RealT* dz=nullptr );
 
 /*!
  * \brief Registers nodal velocities on the contact surface.
@@ -248,10 +248,10 @@ void registerNodalDisplacements( integer meshId,
  *  \note A mesh for the given contact surface must have already been registered
  *   prior to calling this method] via registerMesh()
  */
-void registerNodalVelocities( integer meshId,
-                              const real* vx,
-                              const real* vy,
-                              const real* vz=nullptr );
+void registerNodalVelocities( int meshId,
+                              const RealT* vx,
+                              const RealT* vy,
+                              const RealT* vz=nullptr );
 
 /*!
  * \brief Registers nodal response buffers.
@@ -268,10 +268,10 @@ void registerNodalVelocities( integer meshId,
  * \note A mesh for the given contact surface must have already been registered
  *  prior to calling this method.
  */
-void registerNodalResponse( integer meshId,
-                            real* rx,
-                            real* ry,
-                            real* rz=nullptr );
+void registerNodalResponse( int meshId,
+                            RealT* rx,
+                            RealT* ry,
+                            RealT* rz=nullptr );
 
 /*!
  * \brief Get mfem sparse matrix for method specific Jacobian matrix output 
@@ -312,7 +312,7 @@ int getJacobianSparseMatrix( mfem::SparseMatrix ** sMat, int csId );
  * \return 0 success (if CSR data exists and pointed to), nonzero for failure
  *
  */
-int getJacobianCSRMatrix( int** I, int** J, real** vals, int csId,
+int getJacobianCSRMatrix( int** I, int** J, RealT** vals, int csId,
                   int* n_offsets = nullptr, int* n_nonzero = nullptr );
 
 /*!
@@ -361,12 +361,12 @@ int getJacobianCSRMatrix( int** I, int** J, real** vals, int csId,
  *
  * \return 0 success (if Jacobians exist), nonzero for failure
  */
-int getElementBlockJacobians( integer csId, 
+int getElementBlockJacobians( int csId, 
                               BlockSpace row_block,
                               BlockSpace col_block,
-                              const axom::Array<integer>** row_elem_idx,
-                              const axom::Array<integer>** col_elem_idx,
-                              const axom::Array<mfem::DenseMatrix>** jacobians );
+                              const ArrayT<int>** row_elem_idx,
+                              const ArrayT<int>** col_elem_idx,
+                              const ArrayT<mfem::DenseMatrix>** jacobians );
 
 /*!
  * \brief Register gap field on a nonmortar surface mesh associated with the
@@ -376,8 +376,8 @@ int getElementBlockJacobians( integer csId,
  * \param gaps Array of degree-of-freedom values on the nodes of the mesh
  * representing the scalar gap field
  */
-void registerMortarGaps( integer meshId,
-                         real * gaps );
+void registerMortarGaps( int meshId,
+                         RealT * gaps );
 
 /*!
  * \brief Register pressure field on a nonmortar surface mesh associated with
@@ -387,23 +387,23 @@ void registerMortarGaps( integer meshId,
  * \param gaps Array of degree-of-freedom values on the nodes of the mesh
  * representing the scalar pressure field
  */
-void registerMortarPressures( integer meshId,
-                              const real * pressures );
+void registerMortarPressures( int meshId,
+                              const RealT * pressures );
 
 /// register an integer nodal field
-void registerIntNodalField( integer meshId,
+void registerIntNodalField( int meshId,
                             const IntNodalFields field,
-                            integer * fieldVariable );
+                            int * fieldVariable );
 
 /// register a real element field or parameter 
 void registerRealElementField( int meshId,
                                const RealElementFields field,
-                               const double * fieldVariable );
+                               const RealT * fieldVariable );
 
 /// register an integer element field
 void registerIntElementField( int meshId,
                               const IntElementFields field,
-                              integer * fieldVariable );
+                              int * fieldVariable );
 
 /// @}
 
@@ -426,15 +426,15 @@ void registerIntElementField( int meshId,
  * \note A mesh for the given contact surface must have already been registered
  *  prior to calling this method.
  */
-void registerCouplingScheme( integer couplingSchemeIndex,
-                             integer meshId1,
-                             integer meshId2,
-                             integer contact_mode,
-                             integer contact_case,
-                             integer contact_method,
-                             integer contact_model,
-                             integer enforcement_method,
-                             integer binning_method = DEFAULT_BINNING_METHOD);
+void registerCouplingScheme( int couplingSchemeIndex,
+                             int meshId1,
+                             int meshId2,
+                             int contact_mode,
+                             int contact_case,
+                             int contact_method,
+                             int contact_model,
+                             int enforcement_method,
+                             int binning_method = DEFAULT_BINNING_METHOD);
 /// @}
 
 
@@ -452,14 +452,14 @@ void registerCouplingScheme( integer couplingSchemeIndex,
  * \param [in] pairIndex2 index of the second cell in the pair list
  *
  */
-void setInterfacePairs( integer couplingSchemeIndex,
-                        IndexType numPairs,
-                        IndexType const * meshId1,
-                        IndexType const * pairType1,
-                        IndexType const * pairIndex1,
-                        IndexType const * meshId2,
-                        IndexType const * pairType2,
-                        IndexType const * pairIndex2 );
+void setInterfacePairs( int couplingSchemeIndex,
+                        IndexT numPairs,
+                        IndexT const * meshId1,
+                        IndexT const * pairType1,
+                        IndexT const * pairIndex1,
+                        IndexT const * meshId2,
+                        IndexT const * pairType2,
+                        IndexT const * pairIndex2 );
 
 
 /*!
@@ -471,7 +471,7 @@ void setInterfacePairs( integer couplingSchemeIndex,
  *
  * \return rc return code, a non-zero return code indicates an error.
  */
-integer update( integer cycle, real t, real &dt );
+int update( int cycle, RealT t, RealT &dt );
 
 /// \name Contact Library finalization methods
 /// @{

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -38,7 +38,7 @@ namespace
 {
 
 //------------------------------------------------------------------------------
-inline bool validMeshID( integer meshID )
+inline bool validMeshID( int meshID )
 {
   MeshManager & meshManager = MeshManager::getInstance();
   return (meshID==ANY_MESH) || meshManager.hasMesh( meshID );
@@ -310,15 +310,15 @@ void CouplingSchemeInfo::printEnforcementInfo()
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
-CouplingScheme::CouplingScheme( integer couplingSchemeId, 
-                                integer meshId1,
-                                integer meshId2,
-                                integer contact_mode,
-                                integer contact_case,
-                                integer contact_method,
-                                integer contact_model,
-                                integer enforcement_method,
-                                integer binning_method )
+CouplingScheme::CouplingScheme( int couplingSchemeId, 
+                                int meshId1,
+                                int meshId2,
+                                int contact_mode,
+                                int contact_case,
+                                int contact_method,
+                                int contact_model,
+                                int enforcement_method,
+                                int binning_method )
    : m_id                   ( couplingSchemeId ) 
    , m_meshId1              ( meshId1 )
    , m_meshId2              ( meshId2 )
@@ -574,7 +574,7 @@ bool CouplingScheme::isValidMethod()
    MeshManager & meshManager = MeshManager::getInstance(); 
    MeshData & mesh1 = meshManager.GetMeshInstance( this->m_meshId1 );
    MeshData & mesh2 = meshManager.GetMeshInstance( this->m_meshId2 );
-   integer dim = this->spatialDimension();
+   int dim = this->spatialDimension();
 
    // check all methods for basic validity issues for non-null meshes
    if (!this->m_nullMeshes)
@@ -916,7 +916,7 @@ void CouplingScheme::performBinning()
    return;
 }
 //------------------------------------------------------------------------------
-int CouplingScheme::apply( integer cycle, real t, real &dt ) 
+int CouplingScheme::apply( int cycle, RealT t, RealT &dt ) 
 {
   // set dimension on the contact plane manager
   parameters_t& params = parameters_t::getInstance();
@@ -928,7 +928,7 @@ int CouplingScheme::apply( integer cycle, real t, real &dt )
   cpMgr.setSpaceDim( params.dimension );
 
   // loop over number of interface pairs
-  IndexType numPairs = m_interfacePairs->getNumPairs();
+  IndexT numPairs = m_interfacePairs->getNumPairs();
 
   SLIC_DEBUG("Coupling scheme " << m_id << " has " << numPairs << " pairs.");
 
@@ -936,7 +936,7 @@ int CouplingScheme::apply( integer cycle, real t, real &dt )
   // are interacting
   int numActivePairs = 0;
   int pair_err = 0;
-  for (IndexType kp = 0; kp < numPairs; ++kp)
+  for (IndexT kp = 0; kp < numPairs; ++kp)
   {
      InterfacePair pair = m_interfacePairs->getInterfacePair(kp);
 
@@ -1134,13 +1134,13 @@ void CouplingScheme::allocateMethodData()
 } // end CouplingScheme::allocateMethodData()
 
 //------------------------------------------------------------------------------
-real CouplingScheme::getGapTol( int fid1, int fid2 ) const
+RealT CouplingScheme::getGapTol( int fid1, int fid2 ) const
 {
    MeshManager & meshManager = MeshManager::getInstance(); 
    MeshData & mesh1 = meshManager.GetMeshInstance( m_meshId1 );
    MeshData & mesh2 = meshManager.GetMeshInstance( m_meshId2 );
    parameters_t& params = parameters_t::getInstance();
-   real gap_tol = 0.;
+   RealT gap_tol = 0.;
 
    // add debug warning if this routine is called for interface methods 
    // that do not require gap tolerances 
@@ -1188,7 +1188,7 @@ real CouplingScheme::getGapTol( int fid1, int fid2 ) const
 }
 
 //------------------------------------------------------------------------------
-void CouplingScheme::computeTimeStep(real &dt)
+void CouplingScheme::computeTimeStep(RealT &dt)
 {
    // make sure velocities are registered
    MeshManager & meshManager = MeshManager::getInstance(); 
@@ -1272,7 +1272,7 @@ void CouplingScheme::computeTimeStep(real &dt)
    } // end-switch
 }
 //------------------------------------------------------------------------------
-void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
+void CouplingScheme::computeCommonPlaneTimeStep(RealT &dt)
 {
    // note: the timestep vote is based on a velocity projection 
    // and does not account for the spring stiffness in a CFL-like 
@@ -1305,7 +1305,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
    }
 
    parameters_t & parameters = parameters_t::getInstance();
-   real proj_ratio = parameters.timestep_pen_frac;
+   RealT proj_ratio = parameters.timestep_pen_frac;
    ContactPlaneManager& cpMgr = ContactPlaneManager::getInstance();
    //int num_sides = 2; // always 2 sides in a single coupling scheme
    int dim = this->spatialDimension();
@@ -1315,14 +1315,14 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
    // loop over each interface pair. Even if pair is not in contact, 
    // we still do a velocity projection for that proximate face-pair 
    // to see if interpenetration next cycle 'may' be too much
-   IndexType numPairs = m_interfacePairs->getNumPairs();
-   real dt_temp1 = dt;
-   real dt_temp2 = dt;
+   IndexT numPairs = m_interfacePairs->getNumPairs();
+   RealT dt_temp1 = dt;
+   RealT dt_temp2 = dt;
    int cpID = 0; 
    bool max_gap_msg = false;
    bool neg_dt_gap_msg = false;
    bool neg_dt_vel_proj_msg = false;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = m_interfacePairs->getInterfacePair(kp);
 
@@ -1333,38 +1333,38 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          continue;
       }
    
-      real x1[dim * numNodesPerCell1];
-      real v1[dim * numNodesPerCell1];
+      RealT x1[dim * numNodesPerCell1];
+      RealT v1[dim * numNodesPerCell1];
       mesh1.getFaceCoords( pair.pairIndex1, &x1[0] );
       mesh1.getFaceNodalVelocities( pair.pairIndex1, &v1[0] );
 
-      real x2[dim * numNodesPerCell2];
-      real v2[dim * numNodesPerCell2];
+      RealT x2[dim * numNodesPerCell2];
+      RealT v2[dim * numNodesPerCell2];
       mesh2.getFaceCoords( pair.pairIndex2, &x2[0] );
       mesh2.getFaceNodalVelocities( pair.pairIndex2, &v2[0] );
 
       /////////////////////////////////////////////////////////////
       // calculate face velocities at projected overlap centroid //
       /////////////////////////////////////////////////////////////
-      real vel_f1[dim];
-      real vel_f2[dim];
+      RealT vel_f1[dim];
+      RealT vel_f2[dim];
       initRealArray( &vel_f1[0], dim, 0. );
       initRealArray( &vel_f2[0], dim, 0. );
 
       // interpolate nodal velocity at overlap centroid as projected 
       // onto face 1
-      double cXf1 = cpMgr.m_cXf1[cpID];
-      double cYf1 = cpMgr.m_cYf1[cpID];
-      double cZf1 = (dim == 3) ? cpMgr.m_cZf1[cpID] : 0.;
+      RealT cXf1 = cpMgr.m_cXf1[cpID];
+      RealT cYf1 = cpMgr.m_cYf1[cpID];
+      RealT cZf1 = (dim == 3) ? cpMgr.m_cZf1[cpID] : 0.;
       GalerkinEval( &x1[0], cXf1, cYf1, cZf1,
                     LINEAR, PHYSICAL, dim, dim, 
                     &v1[0], &vel_f1[0] );
 
       // interpolate nodal velocity at overlap centroid as projected 
       // onto face 2
-      double cXf2 = cpMgr.m_cXf2[cpID];
-      double cYf2 = cpMgr.m_cYf2[cpID];
-      double cZf2 = (dim == 3) ? cpMgr.m_cZf2[cpID] : 0.;
+      RealT cXf2 = cpMgr.m_cXf2[cpID];
+      RealT cYf2 = cpMgr.m_cYf2[cpID];
+      RealT cZf2 = (dim == 3) ? cpMgr.m_cZf2[cpID] : 0.;
       GalerkinEval( &x2[0], cXf2, cYf2, cZf2,
                     LINEAR, PHYSICAL, dim, dim, 
                     &v2[0], &vel_f2[0] );
@@ -1385,12 +1385,12 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       // face's outward unit normal AND the overlap normal. The 
       // former is used to compute projections and the latter is 
       // used to indicate further contact using a velocity projection
-      real v1_dot_n, v2_dot_n, v1_dot_n1, v2_dot_n2;
-      real overlapNormal[dim];
+      RealT v1_dot_n, v2_dot_n, v1_dot_n1, v2_dot_n2;
+      RealT overlapNormal[dim];
       cpMgr.getContactPlaneNormal( cpID, dim, &overlapNormal[0] );
 
       // get face normals
-      real fn1[dim], fn2[dim];
+      RealT fn1[dim], fn2[dim];
       mesh1.getFaceNormal( pair.pairIndex1, dim, &fn1[0] );
       mesh2.getFaceNormal( pair.pairIndex2, dim, &fn2[0] );
 
@@ -1416,9 +1416,9 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       // zero, there may stationary interactions or tangential motion. 
       // In this case, any timestep estimate will be very large, and 
       // not control the simulation
-      real tiny = 1.e-12;
-      real tiny1 = (v1_dot_n >= 0.) ? tiny : -1.*tiny;
-      real tiny2 = (v2_dot_n >= 0.) ? tiny : -1.*tiny;
+      RealT tiny = 1.e-12;
+      RealT tiny1 = (v1_dot_n >= 0.) ? tiny : -1.*tiny;
+      RealT tiny2 = (v2_dot_n >= 0.) ? tiny : -1.*tiny;
       v1_dot_n  += tiny1;
       v2_dot_n  += tiny2;
       // add tiny amount to velocity-face_normal projections to avoid
@@ -1435,11 +1435,11 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 
       // get volume element thicknesses associated with each 
       // face in this pair and find minimum
-      real t1 = mesh1.m_elemData.m_thickness[pair.pairIndex1];
-      real t2 = mesh2.m_elemData.m_thickness[pair.pairIndex2];
+      RealT t1 = mesh1.m_elemData.m_thickness[pair.pairIndex1];
+      RealT t2 = mesh2.m_elemData.m_thickness[pair.pairIndex2];
 
       // compute the gap vector (recall gap is x1-x2 by convention)
-      real gapVec[dim];
+      RealT gapVec[dim];
       gapVec[0] = cpMgr.m_cXf1[cpID] - cpMgr.m_cXf2[cpID];
       gapVec[1] = cpMgr.m_cYf1[cpID] - cpMgr.m_cYf2[cpID];
       if (dim == 3)
@@ -1454,19 +1454,19 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       // NOT the normal of the contact plane. This is despite the 
       // fact that the contact nodal forces are resisting contact 
       // in the direction of the overlap normal. 
-      real gap_f1_n1 = dotProd( &gapVec[0], &fn1[0], dim );
-      real gap_f2_n2 = dotProd( &gapVec[0], &fn2[0], dim );
+      RealT gap_f1_n1 = dotProd( &gapVec[0], &fn1[0], dim );
+      RealT gap_f2_n2 = dotProd( &gapVec[0], &fn2[0], dim );
 
-      real dt1 = 1.e6;  // initialize as large number
-      real dt2 = 1.e6;  // initialize as large number
-      real alpha = 1.0; // multiplier on timestep estimate
+      RealT dt1 = 1.e6;  // initialize as large number
+      RealT dt2 = 1.e6;  // initialize as large number
+      RealT alpha = 1.0; // multiplier on timestep estimate
       bool dt1_check1 = false;
       bool dt2_check1 = false;
       bool dt1_vel_check = false;
       bool dt2_vel_check = false;
 
-      real max_delta1 = proj_ratio * t1;
-      real max_delta2 = proj_ratio * t2;
+      RealT max_delta1 = proj_ratio * t1;
+      RealT max_delta2 = proj_ratio * t2;
 
       // Trigger for check 1 and 2:
       // check if there is further interpen or separation based on the 
@@ -1494,8 +1494,8 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 
          // compute the difference between the 'face-gaps' and the max allowable 
          // interpen as a function of element thickness. 
-         real delta1 = max_delta1 - gap_f1_n1; // >0 not exceeding max allowable
-         real delta2 = max_delta2 + gap_f2_n2; // >0 not exceeding max allowable
+         RealT delta1 = max_delta1 - gap_f1_n1; // >0 not exceeding max allowable
+         RealT delta2 = max_delta2 + gap_f2_n2; // >0 not exceeding max allowable
 
          if (delta1 < 0 || delta2 < 0)
          {
@@ -1554,21 +1554,21 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          // compute delta between velocity projection of face-projected 
          // overlap centroid and the OTHER face's face-projected overlap 
          // centroid
-         real proj_delta_x1 = cpMgr.m_cXf1[cpID] + dt * vel_f1[0] - cpMgr.m_cXf2[cpID];
-         real proj_delta_y1 = cpMgr.m_cYf1[cpID] + dt * vel_f1[1] - cpMgr.m_cYf2[cpID];
-         real proj_delta_z1 = 0.;
+         RealT proj_delta_x1 = cpMgr.m_cXf1[cpID] + dt * vel_f1[0] - cpMgr.m_cXf2[cpID];
+         RealT proj_delta_y1 = cpMgr.m_cYf1[cpID] + dt * vel_f1[1] - cpMgr.m_cYf2[cpID];
+         RealT proj_delta_z1 = 0.;
 
-         real proj_delta_x2 = cpMgr.m_cXf2[cpID] + dt * vel_f2[0] - cpMgr.m_cXf1[cpID]; 
-         real proj_delta_y2 = cpMgr.m_cYf2[cpID] + dt * vel_f2[1] - cpMgr.m_cYf1[cpID];
-         real proj_delta_z2 = 0.;
+         RealT proj_delta_x2 = cpMgr.m_cXf2[cpID] + dt * vel_f2[0] - cpMgr.m_cXf1[cpID]; 
+         RealT proj_delta_y2 = cpMgr.m_cYf2[cpID] + dt * vel_f2[1] - cpMgr.m_cYf1[cpID];
+         RealT proj_delta_z2 = 0.;
 
          // compute the dot product between each face's delta and the OTHER 
          // face's outward unit normal. This is the magnitude of interpenetration 
          // of one face's projected overlap-centroid in the 'thickness-direction' 
          // of the other face (with whom in may be in contact currently, or in 
          // a velocity projected sense).
-         real proj_delta_n_1 = proj_delta_x1 * fn2[0] + proj_delta_y1 * fn2[1];
-         real proj_delta_n_2 = proj_delta_x2 * fn1[0] + proj_delta_y2 * fn1[1];
+         RealT proj_delta_n_1 = proj_delta_x1 * fn2[0] + proj_delta_y1 * fn2[1];
+         RealT proj_delta_n_2 = proj_delta_x2 * fn1[0] + proj_delta_y2 * fn1[1];
 
          if (dim == 3)
          {
@@ -1648,8 +1648,8 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 //------------------------------------------------------------------------------
 void CouplingScheme::writeInterfaceOutput( const std::string& dir,
                                            const VisType v_type, 
-                                           const integer cycle, 
-                                           const real t )
+                                           const int cycle, 
+                                           const RealT t )
 {
    parameters_t & parameters = parameters_t::getInstance();
    int dim = this->spatialDimension();

--- a/src/tribol/mesh/CouplingScheme.hpp
+++ b/src/tribol/mesh/CouplingScheme.hpp
@@ -103,15 +103,15 @@ public:
    *
    * Per-cycle rebinning is enabled by default.
    */
-  CouplingScheme( integer couplingSchemeId, 
-                  integer meshId1,
-                  integer meshId2,
-                  integer contact_mode,
-                  integer contact_case,
-                  integer contact_method,
-                  integer contact_model,
-                  integer enforcement_method,
-                  integer binning_method);
+  CouplingScheme( int couplingSchemeId, 
+                  int meshId1,
+                  int meshId2,
+                  int contact_mode,
+                  int contact_case,
+                  int contact_method,
+                  int contact_model,
+                  int enforcement_method,
+                  int binning_method);
 
   /*!
    * \brief Destructor.
@@ -121,12 +121,12 @@ public:
   /// \name Getters
   /// @{
 
-  integer getMeshId1() const { return m_meshId1; }
-  integer getMeshId2() const { return m_meshId2; }
+  int getMeshId1() const { return m_meshId1; }
+  int getMeshId2() const { return m_meshId2; }
 
-  integer getId() const { return m_id; }
+  int getId() const { return m_id; }
 
-  integer getNumTotalNodes() const { return m_numTotalNodes; }
+  int getNumTotalNodes() const { return m_numTotalNodes; }
 
   ContactMode getContactMode() const  { return m_contactMode; }
   ContactCase getContactCase() const  { return m_contactCase; }
@@ -144,7 +144,7 @@ public:
   CouplingSchemeErrors& getCouplingSchemeErrors() { return m_couplingSchemeErrors; }
   CouplingSchemeInfo&   getCouplingSchemeInfo()   { return m_couplingSchemeInfo; }
 
-  integer spatialDimension() const 
+  int spatialDimension() const 
   { 
      parameters_t & params = parameters_t::getInstance();
      return params.dimension; 
@@ -210,7 +210,7 @@ public:
    *
    * \return number of active interface pairs
    */
-  integer getNumActivePairs( ) const { return m_numActivePairs; }
+  int getNumActivePairs( ) const { return m_numActivePairs; }
 
   /*!
    * Get the gap tolerance that determines in contact face-pairs 
@@ -218,7 +218,7 @@ public:
    *
    * \return the gap tolerance based on the method
    */
-  real getGapTol( int fid1, int fid2 ) const;
+  RealT getGapTol( int fid1, int fid2 ) const;
 
   /*!
    * Set whether the coupling scheme has been binned
@@ -320,7 +320,7 @@ public:
    * \return 0 if successful apply
    *
    */
-  int apply( integer cycle, real t, real &dt );
+  int apply( int cycle, RealT t, RealT &dt );
 
   /*!
    * \brief Wrapper around method specific calculation of the Tribol timestep vote 
@@ -328,7 +328,7 @@ public:
    * \param [in/out] dt simulation timestep at given cycle
    *
    */
-  void computeTimeStep( real &dt );
+  void computeTimeStep( RealT &dt );
 
   /*!
    * \brief Wrapper to call method specific visualization output routines
@@ -341,8 +341,8 @@ public:
    */
   void writeInterfaceOutput( const std::string& dir,
                              const VisType v_type, 
-                             const integer cycle, 
-                             const real t );
+                             const int cycle, 
+                             const RealT t );
 
   /*!
    * \brief Sets the coupling scheme logging level member variable 
@@ -544,19 +544,19 @@ private:
    * \param [in/out] dt simulation timestep at given cycle
    *
    */
-  void computeCommonPlaneTimeStep( real &dt );
+  void computeCommonPlaneTimeStep( RealT &dt );
 
 private:
 
-  integer m_id; ///< Coupling Scheme id
+  int m_id; ///< Coupling Scheme id
 
-  integer m_meshId1; ///< Integer id for mesh 1
-  integer m_meshId2; ///< Integer id for mesh 2
+  int m_meshId1; ///< Integer id for mesh 1
+  int m_meshId2; ///< Integer id for mesh 2
 
   bool m_nullMeshes {false}; ///< True if one or both meshes are zero-element (null) meshes
   bool m_isValid {true}; ///< False if the coupling scheme is not valid per call to init()
 
-  integer m_numTotalNodes; ///< Total number of nodes in the coupling scheme
+  int m_numTotalNodes; ///< Total number of nodes in the coupling scheme
 
   ContactMode m_contactMode;             ///< Contact mode
   ContactCase m_contactCase;             ///< Contact case
@@ -573,7 +573,7 @@ private:
 
   InterfacePairs* m_interfacePairs; ///< List of interface pairs
 
-  integer m_numActivePairs; ///< number of active interface pairs from InterfacePairs list
+  int m_numActivePairs; ///< number of active interface pairs from InterfacePairs list
 
   MethodData* m_methodData; ///< method object holding required interface method data
 

--- a/src/tribol/mesh/InterfacePairs.cpp
+++ b/src/tribol/mesh/InterfacePairs.cpp
@@ -8,7 +8,7 @@
 namespace tribol
 {
 
-void InterfacePairs::reserve(integer new_size)
+void InterfacePairs::reserve(int new_size)
 {
    m_pairIndex1.reserve(new_size);
    m_pairIndex2.reserve(new_size);
@@ -41,12 +41,12 @@ void InterfacePairs::addInterfacePair( InterfacePair const& pair )
 }
 
 void InterfacePairs::updateInterfacePair( InterfacePair const& pair, 
-                                          integer const idx )
+                                          int const idx )
 {
    m_isContactCandidate[ idx ] = pair.isContactCandidate;
 }
 
-InterfacePair InterfacePairs::getInterfacePair(IndexType idx) const
+InterfacePair InterfacePairs::getInterfacePair(IndexT idx) const
 {
    SLIC_ERROR_IF(idx >= getNumPairs(), "Index out of range.");
 

--- a/src/tribol/mesh/InterfacePairs.hpp
+++ b/src/tribol/mesh/InterfacePairs.hpp
@@ -16,26 +16,26 @@ namespace tribol
 
 struct InterfacePair
 {
-   InterfacePair( integer m1, integer t1, integer i1,
-                  integer m2, integer t2, integer i2 )
+   InterfacePair( int m1, int t1, int i1,
+                  int m2, int t2, int i2 )
       : pairId(-1)
       , meshId1(m1), pairType1(t1), pairIndex1(i1)
       , meshId2(m2), pairType2(t2), pairIndex2(i2) 
       , isContactCandidate(true) {}
 
    // overload constructor with pair id
-   InterfacePair( integer m1, integer t1, integer i1,
-                  integer m2, integer t2, integer i2,
-                  integer id )
+   InterfacePair( int m1, int t1, int i1,
+                  int m2, int t2, int i2,
+                  int id )
       : pairId(id)
       , meshId1(m1), pairType1(t1), pairIndex1(i1)
       , meshId2(m2), pairType2(t2), pairIndex2(i2) 
       , isContactCandidate(true) {}
 
    // overload constructor with boolean indicating contact candidacy
-   InterfacePair( integer m1, integer t1, integer i1,
-                  integer m2, integer t2, integer i2,
-                  bool isCandidate, integer id )
+   InterfacePair( int m1, int t1, int i1,
+                  int m2, int t2, int i2,
+                  bool isCandidate, int id )
       : pairId(id)
       , meshId1(m1), pairType1(t1), pairIndex1(i1)
       , meshId2(m2), pairType2(t2), pairIndex2(i2) 
@@ -48,17 +48,17 @@ struct InterfacePair
                    , isContactCandidate(true) {}
 
    // pair id
-   integer pairId;
+   int pairId;
 
    // mesh id, face type, and face id for face 1
-   integer meshId1;
-   integer pairType1;
-   integer pairIndex1;
+   int meshId1;
+   int pairType1;
+   int pairIndex1;
 
    // mesh id, face type and face id for face 2
-   integer meshId2;
-   integer pairType2;
-   integer pairIndex2;
+   int meshId2;
+   int pairType2;
+   int pairIndex2;
 
    // boolean indicating if a binned pair is a contact candidate.
    // A contact candidate is defined as a face-pair that is deemed geometrically proximate 
@@ -78,12 +78,12 @@ public:
   ~InterfacePairs() = default;
 
   void clear();
-  void reserve(integer capacity);
+  void reserve(int capacity);
 
   void addInterfacePair( InterfacePair const& pair );
 
   void updateInterfacePair( InterfacePair const& pair,
-                            integer const idx );
+                            int const idx );
 
   void setMeshId( int side, int id )
   {
@@ -92,29 +92,29 @@ public:
      if (side == 2) m_meshId2 = id;
   }
 
-  void setPairType( int side, integer type )
+  void setPairType( int side, int type )
   {
      SLIC_ERROR_IF( side !=1 && side !=2, "mesh side not 1 or 2.");
      if (side == 1) m_pairType1 = type;
      if (side == 2) m_pairType2 = type;
   }
 
-  InterfacePair getInterfacePair(IndexType idx) const;
+  InterfacePair getInterfacePair(IndexT idx) const;
 
-  IndexType getNumPairs() const { return static_cast<IndexType>(m_pairIndex1.size()); }
+  IndexT getNumPairs() const { return static_cast<IndexT>(m_pairIndex1.size()); }
 
 private:
 
   // A list of interface pairs is defined to be between 
   // two meshes with the same elements type on each mesh
-  integer m_meshId1;
-  integer m_meshId2;
-  integer m_pairType1;
-  integer m_pairType2;
+  int m_meshId1;
+  int m_meshId2;
+  int m_pairType1;
+  int m_pairType2;
 
-  containerArray<integer> m_pairIndex1;
-  containerArray<integer> m_pairIndex2;
-  containerArray<bool>    m_isContactCandidate;
+  ArrayT<int> m_pairIndex1;
+  ArrayT<int> m_pairIndex2;
+  ArrayT<bool>    m_isContactCandidate;
 };
 
 } /* namespace tribol */

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -252,19 +252,19 @@ MeshData::MeshData()
 //------------------------------------------------------------------------------
 void MeshData::allocateArrays(int dimension)
 {
-  m_nX = new   real[m_numCells];
-  m_nY = new   real[m_numCells];
-  m_cX = new   real[m_numCells];
-  m_cY = new   real[m_numCells];
-  m_area = new real[m_numCells];
-  m_faceRadius = new real[m_numCells];
+  m_nX = new   RealT[m_numCells];
+  m_nY = new   RealT[m_numCells];
+  m_cX = new   RealT[m_numCells];
+  m_cY = new   RealT[m_numCells];
+  m_area = new RealT[m_numCells];
+  m_faceRadius = new RealT[m_numCells];
   m_nZ = nullptr;
   m_cZ = nullptr;
 
   if (dimension == 3)
   {
-    m_nZ = new real[m_numCells];
-    m_cZ = new real[m_numCells];
+    m_nZ = new RealT[m_numCells];
+    m_cZ = new RealT[m_numCells];
   }
 }
 
@@ -355,8 +355,8 @@ void MeshData::deallocateArrays()
 bool MeshData::computeFaceData( int const dim )
 {
   bool faceDataOk = true;
-  real fac = 1.0 / m_numNodesPerCell;
-  constexpr real nrmlMagTol = 1.0e-15;
+  RealT fac = 1.0 / m_numNodesPerCell;
+  constexpr RealT nrmlMagTol = 1.0e-15;
 
   // loop over all cells in the mesh
   for (int i=0; i<m_numCells; ++i) {
@@ -399,8 +399,8 @@ bool MeshData::computeFaceData( int const dim )
         auto nodeIndex = m_numNodesPerCell * i;
         auto nodeId = m_connectivity[ nodeIndex ];
         auto nextNodeId = m_connectivity[ nodeIndex+1 ];
-        real lambdaX = m_positionX[ nextNodeId ] - m_positionX[ nodeId ];
-        real lambdaY = m_positionY[ nextNodeId ] - m_positionY[ nodeId ];
+        RealT lambdaX = m_positionX[ nextNodeId ] - m_positionX[ nodeId ];
+        RealT lambdaY = m_positionY[ nextNodeId ] - m_positionY[ nodeId ];
    
         m_nX[i] = lambdaY;
         m_nY[i] = -lambdaX;
@@ -440,9 +440,9 @@ bool MeshData::computeFaceData( int const dim )
         // edge's first node and the face edge's two nodes
 
         // declare triangle edge vector components and normal components
-        real vX1, vY1, vZ1;
-        real vX2, vY2, vZ2;
-        real nX, nY, nZ; 
+        RealT vX1, vY1, vZ1;
+        RealT vX2, vY2, vZ2;
+        RealT nX, nY, nZ; 
 
         // loop over m_numNodesPerCell-1 cell edges and compute pallet normal
         for (int j=0; j<(m_numNodesPerCell-1); ++j) 
@@ -537,17 +537,17 @@ bool MeshData::computeFaceData( int const dim )
 } // end MeshData::computeFaceData()
 
 //------------------------------------------------------------------------------
-real MeshData::computeFaceRadius( int faceId ) 
+RealT MeshData::computeFaceRadius( int faceId ) 
 {
    // loop over nodes of the face and determine the maximum 
    // "link" vector from the ith node to the face center
-   real sqrRadius = 0.0;
+   RealT sqrRadius = 0.0;
    for (int i=0; i<m_numNodesPerCell; ++i) {
       const int nodeId = getFaceNodeId(faceId, i);
-      real lvx = m_positionX[nodeId] - m_cX[faceId];
-      real lvy = m_positionY[nodeId] - m_cY[faceId];
+      RealT lvx = m_positionX[nodeId] - m_cX[faceId];
+      RealT lvy = m_positionY[nodeId] - m_cY[faceId];
 
-      real lvz;
+      RealT lvz;
       if (m_positionZ != nullptr) { // for 3D
          lvz = m_positionZ[nodeId] - m_cZ[faceId];
       }
@@ -555,7 +555,7 @@ real MeshData::computeFaceRadius( int faceId )
          lvz = 0.0;
       }
 
-      real sqrLinkMag = lvx * lvx + lvy * lvy + lvz * lvz;   
+      RealT sqrLinkMag = lvx * lvx + lvy * lvy + lvz * lvz;   
      
       if (sqrLinkMag > sqrRadius) {
          sqrRadius = sqrLinkMag;
@@ -567,29 +567,29 @@ real MeshData::computeFaceRadius( int faceId )
 } // end MeshData::computeFaceRadius()
 
 //------------------------------------------------------------------------------
-real MeshData::computeEdgeLength( int faceId ) 
+RealT MeshData::computeEdgeLength( int faceId ) 
 {
    // compute the length of the edge as the magnitude of 
    // the vector defined between the two edge vertices
    const int nodeId1 = getFaceNodeId( faceId, 0 );
    const int nodeId2 = getFaceNodeId( faceId, 1 );
-   real lvx = m_positionX[nodeId2] - m_positionX[nodeId1];
-   real lvy = m_positionY[nodeId2] - m_positionY[nodeId1];
+   RealT lvx = m_positionX[nodeId2] - m_positionX[nodeId1];
+   RealT lvy = m_positionY[nodeId2] - m_positionY[nodeId1];
 
-   real len = magnitude( lvx, lvy );
+   RealT len = magnitude( lvx, lvy );
 
    return len;
 
 } // end MeshData::computeEdgeLength()
 
 //------------------------------------------------------------------------------
-void MeshData::getFaceCoords( int const faceId, real * coords )
+void MeshData::getFaceCoords( int const faceId, RealT * coords )
 {
    int dim =  (m_positionZ != nullptr) ? 3 : 2;
 
-   for (IndexType a=0; a<m_numNodesPerCell; ++a)
+   for (IndexT a=0; a<m_numNodesPerCell; ++a)
    {
-     IndexType nodeId = m_connectivity[ faceId*m_numNodesPerCell + a ];
+     IndexT nodeId = m_connectivity[ faceId*m_numNodesPerCell + a ];
 
      coords[dim * a]     = m_positionX[ nodeId ];
      coords[dim * a + 1] = m_positionY[ nodeId ];
@@ -605,7 +605,7 @@ void MeshData::getFaceCoords( int const faceId, real * coords )
 }  // end MeshData::getFaceCoords()
 
 //------------------------------------------------------------------------------
-void MeshData::getFaceNodalVelocities( int const faceId, real * nodalVel )
+void MeshData::getFaceNodalVelocities( int const faceId, RealT * nodalVel )
 {
    if (m_velX == nullptr || m_velY == nullptr)
    {
@@ -615,9 +615,9 @@ void MeshData::getFaceNodalVelocities( int const faceId, real * nodalVel )
 
    int dim =  (m_velZ != nullptr) ? 3 : 2;
 
-   for (IndexType a=0; a<m_numNodesPerCell; ++a)
+   for (IndexT a=0; a<m_numNodesPerCell; ++a)
    {
-     IndexType nodeId = m_connectivity[ faceId*m_numNodesPerCell + a ];
+     IndexT nodeId = m_connectivity[ faceId*m_numNodesPerCell + a ];
 
      nodalVel[dim * a]     = m_velX[ nodeId ];
      nodalVel[dim * a + 1] = m_velY[ nodeId ];
@@ -651,21 +651,21 @@ void MeshData::computeNodalNormals( int const dim )
       if (this->m_node_nX != nullptr)
       {
          delete[] m_node_nX;
-         m_node_nX = new real [size];
+         m_node_nX = new RealT [size];
       }
       else
       {
-         m_node_nX = new real [size];
+         m_node_nX = new RealT [size];
       }
 
       if (this->m_node_nY != nullptr)
       {
          delete[] m_node_nY;
-         m_node_nY = new real [size];
+         m_node_nY = new RealT [size];
       }
       else
       {
-         m_node_nY = new real [size];
+         m_node_nY = new RealT [size];
       }
 
       if (dim == 3)
@@ -673,11 +673,11 @@ void MeshData::computeNodalNormals( int const dim )
          if (this->m_node_nZ != nullptr)
          {
             delete[] m_node_nZ;
-            m_node_nZ = new real [size];
+            m_node_nZ = new RealT [size];
          }
          else 
          {
-            m_node_nZ = new real [size];
+            m_node_nZ = new RealT [size];
          }
 
          // initialize z component
@@ -707,7 +707,7 @@ void MeshData::computeNodalNormals( int const dim )
          // the mesh nodal normal array. If it is not, then nodeId will access some other
          // piece of memory and there may be a memory issue when numFaceNrmlsToNodes is deleted
          // at the end of this routine.
-         integer nodeId = this->m_connectivity[ this->m_numNodesPerCell * i + j ]; 
+         int nodeId = this->m_connectivity[ this->m_numNodesPerCell * i + j ]; 
          m_node_nX[ nodeId ] += this->m_nX[ i ]; // m_nX[i] is the ith face normal x-component
          m_node_nY[ nodeId ] += this->m_nY[ i ]; // see above...
 
@@ -723,7 +723,7 @@ void MeshData::computeNodalNormals( int const dim )
          // repeat loop over cell nodes for z-component
          for (int k=0; k<this->m_numNodesPerCell; ++k)
          {
-            integer nodeId = this->m_connectivity[ this->m_numNodesPerCell * i + k ]; 
+            int nodeId = this->m_connectivity[ this->m_numNodesPerCell * i + k ]; 
             m_node_nZ[ nodeId ] += this->m_nZ[ i ];
          } // end loop over cell nodes
 
@@ -752,7 +752,7 @@ void MeshData::computeNodalNormals( int const dim )
       {
          for (int i=0; i<this->m_lengthNodalData; ++i)
          {
-            real mag = magnitude( m_node_nX[i], m_node_nY[i], m_node_nZ[i] );
+            RealT mag = magnitude( m_node_nX[i], m_node_nY[i], m_node_nZ[i] );
             m_node_nX[ i ] /= mag;
             m_node_nY[ i ] /= mag;
             m_node_nZ[ i ] /= mag;
@@ -762,7 +762,7 @@ void MeshData::computeNodalNormals( int const dim )
       {
          for (int i=0; i<this->m_lengthNodalData; ++i)
          {
-            real mag = magnitude( m_node_nX[i], m_node_nY[i] );
+            RealT mag = magnitude( m_node_nX[i], m_node_nY[i] );
             m_node_nX[ i ] /= mag;
             m_node_nY[ i ] /= mag;
          }
@@ -775,7 +775,7 @@ void MeshData::computeNodalNormals( int const dim )
 } // end MeshData::computeNodalNormals()
 
 //------------------------------------------------------------------------------
-void MeshData::getFaceNormal( int const faceId, int const dim, real * nrml )
+void MeshData::getFaceNormal( int const faceId, int const dim, RealT * nrml )
 {
    nrml[0] = this->m_nX[ faceId ];
    nrml[1] = this->m_nY[ faceId ];

--- a/src/tribol/mesh/MeshData.hpp
+++ b/src/tribol/mesh/MeshData.hpp
@@ -31,8 +31,8 @@ struct MeshNodalData
    /////////////////////////
    // MORTAR NODAL FIELDS //
    /////////////////////////
-   real * m_node_gap;            ///< scalar nodal gap (used on nonmortar mesh) 
-   const real * m_node_pressure; ///< scalar nodal pressure (used on nonmortar mesh) 
+   RealT * m_node_gap;            ///< scalar nodal gap (used on nonmortar mesh) 
+   const RealT * m_node_pressure; ///< scalar nodal pressure (used on nonmortar mesh) 
 
    bool m_isGapComputed        {false}; ///< true if the nodal gaps have been computed
    bool m_is_node_gap_set      {false}; ///< true if nodal gap field is set
@@ -62,13 +62,13 @@ struct MeshElemData
    //////////////////////////////////////
    // PENALTY ENFORCEMENT ELEMENT DATA //
    //////////////////////////////////////
-   const real * m_mat_mod;             ///< Bulk/Young's modulus for contact faces
-   const real * m_thickness;           ///< Volume element thickness associated with each contact face
+   const RealT * m_mat_mod;             ///< Bulk/Young's modulus for contact faces
+   const RealT * m_thickness;           ///< Volume element thickness associated with each contact face
 
-   real m_penalty_stiffness {0.};      ///< single scalar kinematic penalty stiffness for each mesh
-   real m_penalty_scale {1.};          ///< scale factor applied to kinematic penalty only
-   real m_rate_penalty_stiffness {0.}; ///< single scalar rate penalty stiffness for each mesh
-   real m_rate_percent_stiffness {0.}; ///< rate penalty is percentage of gap penalty
+   RealT m_penalty_stiffness {0.};      ///< single scalar kinematic penalty stiffness for each mesh
+   RealT m_penalty_scale {1.};          ///< scale factor applied to kinematic penalty only
+   RealT m_rate_penalty_stiffness {0.}; ///< single scalar rate penalty stiffness for each mesh
+   RealT m_rate_percent_stiffness {0.}; ///< rate penalty is percentage of gap penalty
 
    bool m_is_kinematic_constant_penalty_set {false}; ///< True if single kinematic constant penalty is set
    bool m_is_kinematic_element_penalty_set  {false}; ///< True if the element-wise kinematic penalty is set
@@ -122,41 +122,41 @@ public:
   int m_meshId;                       ///< Mesh Id associated with this data
   bool m_isValid;                     ///< True if the mesh is valid
 
-  const real* m_positionX; ///< X-coordinates of nodes in mesh 
-  const real* m_positionY; ///< Y-coordinates of nodes in mesh 
-  const real* m_positionZ; ///< Z-coordinates of nodes in mesh 
+  const RealT* m_positionX; ///< X-coordinates of nodes in mesh 
+  const RealT* m_positionY; ///< Y-coordinates of nodes in mesh 
+  const RealT* m_positionZ; ///< Z-coordinates of nodes in mesh 
 
-  const real* m_dispX; ///< X-component of nodal displacements 
-  const real* m_dispY; ///< Y-component of nodal displacements 
-  const real* m_dispZ; ///< Z-component of nodal displacements 
+  const RealT* m_dispX; ///< X-component of nodal displacements 
+  const RealT* m_dispY; ///< Y-component of nodal displacements 
+  const RealT* m_dispZ; ///< Z-component of nodal displacements 
 
-  real * m_forceX; ///< X-component of nodal forces 
-  real * m_forceY; ///< Y-component of nodal forces 
-  real * m_forceZ; ///< Z-component of nodal forces 
+  RealT * m_forceX; ///< X-component of nodal forces 
+  RealT * m_forceY; ///< Y-component of nodal forces 
+  RealT * m_forceZ; ///< Z-component of nodal forces 
 
-  const real* m_velX; ///< X-component of nodal velocity 
-  const real* m_velY; ///< Y-component of nodal velocity
-  const real* m_velZ; ///< Z-component of nodal velocity
+  const RealT* m_velX; ///< X-component of nodal velocity 
+  const RealT* m_velY; ///< Y-component of nodal velocity
+  const RealT* m_velZ; ///< Z-component of nodal velocity
 
-  real* m_nX; ///< X-component of outward unit face normals
-  real* m_nY; ///< Y-component of outward unit face normals
-  real* m_nZ; ///< Z-component of outward unit face normals
+  RealT* m_nX; ///< X-component of outward unit face normals
+  RealT* m_nY; ///< Y-component of outward unit face normals
+  RealT* m_nZ; ///< Z-component of outward unit face normals
 
-  real* m_cX; ///< X-component of vertex averaged cell centroids
-  real* m_cY; ///< Y-component of vertex averaged cell centroids
-  real* m_cZ; ///< Z-component of vertex averaged cell centroids
+  RealT* m_cX; ///< X-component of vertex averaged cell centroids
+  RealT* m_cY; ///< Y-component of vertex averaged cell centroids
+  RealT* m_cZ; ///< Z-component of vertex averaged cell centroids
 
-  real* m_faceRadius; ///< Face radius used in low level proximity check
+  RealT* m_faceRadius; ///< Face radius used in low level proximity check
 
-  real* m_area; ///< Cell areas
+  RealT* m_area; ///< Cell areas
 
-  const IndexType* m_connectivity; ///< Cell connectivity arrays of length, m_numCells * m_numNodesPerCell
+  const IndexT* m_connectivity; ///< Cell connectivity arrays of length, m_numCells * m_numNodesPerCell
 
-  IndexType* m_sortedSurfaceNodeIds; ///< List of sorted node ids from connectivity w/o duplicates, length = m_numSurfaceNodes.
+  IndexT* m_sortedSurfaceNodeIds; ///< List of sorted node ids from connectivity w/o duplicates, length = m_numSurfaceNodes.
 
-  real* m_node_nX; ///< X-component of outward unit node normals
-  real* m_node_nY; ///< Y-component of outward unit node normals
-  real* m_node_nZ; ///< Z-component of outward unit node normals
+  RealT* m_node_nX; ///< X-component of outward unit node normals
+  RealT* m_node_nY; ///< Y-component of outward unit node normals
+  RealT* m_node_nZ; ///< Z-component of outward unit node normals
 
   MeshNodalData m_nodalFields; ///< method specific nodal fields
   MeshElemData  m_elemData;    ///< method/enforcement specific element data 
@@ -225,7 +225,7 @@ public:
    *  of the tribol proximity check.
    *
    */
-  real computeFaceRadius( int faceId );
+  RealT computeFaceRadius( int faceId );
   
   /*!
    *
@@ -236,7 +236,7 @@ public:
    * \return edge length
    *
    */
-  real computeEdgeLength( int edgeId );
+  RealT computeEdgeLength( int edgeId );
   
   /*!
    *
@@ -245,7 +245,7 @@ public:
    * \param [in/out] coords pointer to an array of stacked (x,y,z) nodal coordinates
    *
    */
-  void getFaceCoords( int const faceId, real * coords );
+  void getFaceCoords( int const faceId, RealT * coords );
 
   /*!
    *
@@ -254,7 +254,7 @@ public:
    * \param [in/out] nodalVel pointer to an array of stacked (x,y,z) nodal velocities
    *
    */
-  void getFaceNodalVelocities( int const faceId, real * nodalVel );
+  void getFaceNodalVelocities( int const faceId, RealT * nodalVel );
 
   /*!
    *
@@ -265,7 +265,7 @@ public:
    * \param [in/out] nrml pointer to array of stacked components of the face normal vector
    *
    */
-  void getFaceNormal( int const faceId, int const dim, real * nrml );
+  void getFaceNormal( int const faceId, int const dim, RealT * nrml );
 
   /// sorts unique surface node ids from connectivity and stores them on the mesh object in ascending order
   void sortSurfaceNodeIds();

--- a/src/tribol/mesh/MeshManager.hpp
+++ b/src/tribol/mesh/MeshManager.hpp
@@ -43,7 +43,7 @@ public:
    *
    * \return MeshData object
    */
-  MeshData & GetMeshInstance( integer meshID )
+  MeshData & GetMeshInstance( int meshID )
   {
     return m_meshInstances.at(meshID);
   }
@@ -55,7 +55,7 @@ public:
    *
    * \return MeshData object
    */
-  MeshData const & GetMeshInstance( integer meshID ) const
+  MeshData const & GetMeshInstance( int meshID ) const
   {
     return m_meshInstances.at(meshID);
   }
@@ -67,7 +67,7 @@ public:
    *
    * \return MeshData object
    */
-  MeshData & CreateMesh( integer meshID )
+  MeshData & CreateMesh( int meshID )
   {
     if ( hasMesh( meshID ) )
     {
@@ -81,7 +81,7 @@ public:
    *
    * \return Mesh instance
    */
-  std::unordered_map< integer, MeshData >& GetMeshInstances()
+  std::unordered_map< int, MeshData >& GetMeshInstances()
   {
     return m_meshInstances;
   }
@@ -93,13 +93,13 @@ public:
    *
    * \return True if mesh exists
    */
-  bool hasMesh( integer meshID) const
+  bool hasMesh( int meshID) const
   {
      return m_meshInstances.find(meshID) != m_meshInstances.end();
   }
 
 private:
-  std::unordered_map< integer, MeshData > m_meshInstances; ///< Unordered map of mesh instances
+  std::unordered_map< int, MeshData > m_meshInstances; ///< Unordered map of mesh instances
 
 };
 }

--- a/src/tribol/mesh/MethodCouplingData.cpp
+++ b/src/tribol/mesh/MethodCouplingData.cpp
@@ -33,11 +33,11 @@ void SurfaceContactElem::allocateMortarWts( )
    if (this->mortarWts != nullptr)
    {
       delete [] this->mortarWts;
-      this->mortarWts = new real [ this->numWts ];
+      this->mortarWts = new RealT [ this->numWts ];
    }
    else
    {
-      this->mortarWts = new real [ this->numWts ];
+      this->mortarWts = new RealT [ this->numWts ];
    }
 
    this->initializeMortarWts();
@@ -65,7 +65,7 @@ void SurfaceContactElem::allocateBlockJ( EnforcementMethod enf )
    }
 
    // number of element displacement degrees of freedom
-   integer nPrimal = this->dim * this->numFaceVert;
+   int nPrimal = this->dim * this->numFaceVert;
    for (int i{}; i < 2; ++i)
    {
       for (int j{}; j < 2; ++j)
@@ -77,7 +77,7 @@ void SurfaceContactElem::allocateBlockJ( EnforcementMethod enf )
    if (enf == LAGRANGE_MULTIPLIER)
    {
       // number of element Lagrange multiplier degrees of freedom
-      integer nDual = this->numFaceVert;
+      int nDual = this->numFaceVert;
       for (int i{}; i < 2; ++i)
       {
          blockJ(2, i).SetSize(nDual, nPrimal);
@@ -99,7 +99,7 @@ void SurfaceContactElem::deallocateElem( )
 }
 
 //------------------------------------------------------------------------------
-real SurfaceContactElem::getMortarNonmortarWt( const int a, const int b )
+RealT SurfaceContactElem::getMortarNonmortarWt( const int a, const int b )
 {
    // note: the mortar wts are stored in a stacked array with nonmortar-nonmortar 
    //       wts followed by mortar-nonmortar weights in mortar-nonmortar ordering
@@ -107,12 +107,12 @@ real SurfaceContactElem::getMortarNonmortarWt( const int a, const int b )
    int mortarNonmortarId = this->numFaceVert * this->numFaceVert + 
                        this->numFaceVert * a + b;
 
-   real wt = this->mortarWts[ mortarNonmortarId ];
+   RealT wt = this->mortarWts[ mortarNonmortarId ];
    return wt;
 }
 
 //------------------------------------------------------------------------------
-real SurfaceContactElem::getNonmortarMortarWt( const int a, const int b )
+RealT SurfaceContactElem::getNonmortarMortarWt( const int a, const int b )
 {
    // note: the mortar wts are stored in a stacked array with nonmortar-nonmortar 
    //       wts followed by mortar-nonmortar weights in mortar-nonmortar ordering.
@@ -122,19 +122,19 @@ real SurfaceContactElem::getNonmortarMortarWt( const int a, const int b )
    int nonmortarMortarId = this->numFaceVert * this->numFaceVert + 
                        this->numFaceVert * b + a;
 
-   real wt = this->mortarWts[ nonmortarMortarId ];
+   RealT wt = this->mortarWts[ nonmortarMortarId ];
    return wt;
 }
 
 //------------------------------------------------------------------------------
-real SurfaceContactElem::getNonmortarNonmortarWt( const int a, const int b )
+RealT SurfaceContactElem::getNonmortarNonmortarWt( const int a, const int b )
 {
    // note: the mortar wts are stored in a stacked array with nonmortar-nonmortar 
    //       wts followed by mortar-nonmortar weights in mortar-nonmortar ordering
 
    int nonmortarNonmortarId = this->numFaceVert * a + b;
 
-   real wt = this->mortarWts[ nonmortarNonmortarId ];
+   RealT wt = this->mortarWts[ nonmortarNonmortarId ];
    return wt;
 }
 
@@ -175,12 +175,12 @@ int SurfaceContactElem::getJacobianDimOffset( JacBlock block ) const
 //------------------------------------------------------------------------------
 MethodData::MethodData()
 :  m_blockJElemIds (
-      static_cast<axom::IndexType>(BlockSpace::NUM_BLOCK_SPACES),
-      static_cast<axom::IndexType>(BlockSpace::NUM_BLOCK_SPACES)
+      static_cast<IndexT>(BlockSpace::NUM_BLOCK_SPACES),
+      static_cast<IndexT>(BlockSpace::NUM_BLOCK_SPACES)
    ) ,
    m_blockJ (
-      static_cast<axom::IndexType>(BlockSpace::NUM_BLOCK_SPACES),
-      static_cast<axom::IndexType>(BlockSpace::NUM_BLOCK_SPACES)
+      static_cast<IndexT>(BlockSpace::NUM_BLOCK_SPACES),
+      static_cast<IndexT>(BlockSpace::NUM_BLOCK_SPACES)
    )
 {
    m_blockJ.shrink();
@@ -188,26 +188,26 @@ MethodData::MethodData()
 
 //------------------------------------------------------------------------------
 void MethodData::reserveBlockJ( 
-   axom::Array<BlockSpace>&& blockJSpaces, 
+   ArrayT<BlockSpace>&& blockJSpaces, 
    int nPairs
 )
 {
-   axom::IndexType pairFraction = static_cast<axom::IndexType>(0.5 * nPairs);
+   IndexT pairFraction = static_cast<IndexT>(0.5 * nPairs);
 
    m_blockJSpaces = std::move(blockJSpaces);
-   m_blockJElemIds.fill(axom::Array<integer>(0, 0));
+   m_blockJElemIds.fill(ArrayT<int>(0, 0));
    for (auto blockJSpace : m_blockJSpaces)
    {
-      m_blockJElemIds[static_cast<axom::IndexType>(blockJSpace)].reserve(pairFraction);
+      m_blockJElemIds[static_cast<IndexT>(blockJSpace)].reserve(pairFraction);
    }
-   m_blockJ.fill(axom::Array<mfem::DenseMatrix>(0, 0));
+   m_blockJ.fill(ArrayT<mfem::DenseMatrix>(0, 0));
    for (auto blockJSpaceI : m_blockJSpaces)
    {
       for (auto blockJSpaceJ : m_blockJSpaces)
       {
          m_blockJ(
-            static_cast<axom::IndexType>(blockJSpaceI),
-            static_cast<axom::IndexType>(blockJSpaceJ)
+            static_cast<IndexT>(blockJSpaceI),
+            static_cast<IndexT>(blockJSpaceJ)
          ).reserve(pairFraction);
       }
    }
@@ -215,8 +215,8 @@ void MethodData::reserveBlockJ(
 
 //------------------------------------------------------------------------------
 void MethodData::storeElemBlockJ( 
-   axom::Array<integer>&& blockJElemIds,
-   axom::Array<mfem::DenseMatrix, 2>& blockJ
+   ArrayT<int>&& blockJElemIds,
+   ArrayT<mfem::DenseMatrix, 2>& blockJ
 )
 {
    SLIC_ASSERT_MSG(blockJElemIds.size() == getNSpaces(),
@@ -225,13 +225,13 @@ void MethodData::storeElemBlockJ(
       "Number of rows in blockJ does not match the number of Jacobian spaces.");
    SLIC_ASSERT_MSG(blockJ.shape()[1] == getNSpaces(),
       "Number of columns in blockJ does not match the number of Jacobian spaces.");
-   for (axom::IndexType i{}; i < getNSpaces(); ++i)
+   for (IndexT i{}; i < getNSpaces(); ++i)
    {
-      axom::IndexType blockIdxI = static_cast<axom::IndexType>(m_blockJSpaces[i]);
+      IndexT blockIdxI = static_cast<IndexT>(m_blockJSpaces[i]);
       m_blockJElemIds[blockIdxI].push_back(blockJElemIds[i]);
-      for (axom::IndexType j{}; j < getNSpaces(); ++j)
+      for (IndexT j{}; j < getNSpaces(); ++j)
       {
-         axom::IndexType blockIdxJ = static_cast<axom::IndexType>(m_blockJSpaces[j]);
+         IndexT blockIdxJ = static_cast<IndexT>(m_blockJSpaces[j]);
          m_blockJ(blockIdxI, blockIdxJ).push_back(blockJ(i, j));
       }
    }
@@ -269,8 +269,8 @@ void MortarData::assembleJacobian( SurfaceContactElem & elem, SparseMode s_mode 
    // grab the two meshes in this coupling scheme
    MeshManager& meshManager = MeshManager::getInstance();
 
-   IndexType const mortarId = elem.meshId1;
-   IndexType const nonmortarId  = elem.meshId2;
+   IndexT const mortarId = elem.meshId1;
+   IndexT const nonmortarId  = elem.meshId2;
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh  = meshManager.GetMeshInstance( nonmortarId );
@@ -331,31 +331,31 @@ void MortarData::assembleJacobian( SurfaceContactElem & elem, SparseMode s_mode 
          // introduced at the (i,j) element
          // Mortar-Lagrange multiplier block (0, 2)
          this->m_smat->Add( i, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId ]);
          this->m_smat->Add( i+1, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId + dimOffset ]);
          this->m_smat->Add( i+2, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId + 2*dimOffset ]); // assume 3D for now
 
          // Nonmortar-Lagrange Multiplier block (1, 2)
          i = elem.dim * nonmortarNodeIdA; // nonmortar row contributions
          this->m_smat->Add( i, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId  ]);
          this->m_smat->Add( i+1, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId + dimOffset ]);
          this->m_smat->Add( i+2, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ localId + 2*dimOffset ]); // assume 3D for now
 
          ////////////////////////////////////////////////////////////////
@@ -372,31 +372,31 @@ void MortarData::assembleJacobian( SurfaceContactElem & elem, SparseMode s_mode 
 
          // Lagrange-multiplier-mortar block (2, 0)
          this->m_smat->Add( i, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ localId ]);
          this->m_smat->Add( i, j+1, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ localId + dimOffset ]);
          this->m_smat->Add( i, j+2, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ localId + 2*dimOffset ]); // assume 3D for now
 
          // Lagrange multiplier-nonmortar block (2, 1)
          j = elem.dim * nonmortarNodeIdA; // nonmortar column contributions
          this->m_smat->Add( i, j, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ localId  ]);
          this->m_smat->Add( i, j+1, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ localId + dimOffset ]);
          this->m_smat->Add( i, j+2, elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ localId + 2*dimOffset ]); // assume 3D for now
 
          //////////////////////////////////////////////////
@@ -426,14 +426,14 @@ void MortarData::assembleMortarWts( SurfaceContactElem & elem, SparseMode s_mode
    // grab the two meshes in this coupling scheme
    MeshManager& meshManager = MeshManager::getInstance();
 
-   IndexType const mortarId = elem.meshId1;
-   IndexType const nonmortarId  = elem.meshId2; 
+   IndexT const mortarId = elem.meshId1;
+   IndexT const nonmortarId  = elem.meshId2; 
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh  = meshManager.GetMeshInstance( nonmortarId );
 
    // Note: The node ids between the two are assumed to 
-   // be unique and contiguous using the integer ids in the 
+   // be unique and contiguous using the int ids in the 
    // mortar and nonmortar mesh connectivity arrays with the number 
    // of nodes specified for each mesh being the number of mortar
    // and the number of nonmortar nodes for each mesh, respectively.
@@ -487,7 +487,7 @@ void MortarData::assembleMortarWts( SurfaceContactElem & elem, SparseMode s_mode
 } // end of MortarData::assembleMortarWts()
 
 //------------------------------------------------------------------------------
-void MortarData::getCSRArrays( int** I, int** J, real** vals,
+void MortarData::getCSRArrays( int** I, int** J, RealT** vals,
                                int* n_offsets, int* n_nonzero)
 {
    if (this->m_smat == nullptr)

--- a/src/tribol/mesh/MethodCouplingData.hpp
+++ b/src/tribol/mesh/MethodCouplingData.hpp
@@ -36,16 +36,16 @@ struct SurfaceContactElem
    SurfaceContactElem( );
 
    /// Overloaded Constructor
-   SurfaceContactElem( integer dimension, ///< [in] Dimension of the problem
-                       real * x1,         ///< [in] Vertex coordinates of first face
-                       real * x2,         ///< [in] Vertex coordinates of second face
-                       real * xOverlap,   ///< [in] Vertex coordinates of overlap
-                       integer nFV,       ///< [in] Number of face vertices
-                       integer nPV,       ///< [in] Number of overlap vertices
-                       integer mId1,      ///< [in] Id for mesh 1
-                       integer mId2,      ///< [in] Id for mesh 2
-                       integer fId1,      ///< [in] Id for face 1
-                       integer fId2       ///< [in] Id for face 2
+   SurfaceContactElem( int dimension, ///< [in] Dimension of the problem
+                       RealT * x1,         ///< [in] Vertex coordinates of first face
+                       RealT * x2,         ///< [in] Vertex coordinates of second face
+                       RealT * xOverlap,   ///< [in] Vertex coordinates of overlap
+                       int nFV,       ///< [in] Number of face vertices
+                       int nPV,       ///< [in] Number of overlap vertices
+                       int mId1,      ///< [in] Id for mesh 1
+                       int mId2,      ///< [in] Id for mesh 2
+                       int fId1,      ///< [in] Id for face 1
+                       int fId2       ///< [in] Id for face 2
                      )
      : dim(dimension)
      , meshId1(mId1)
@@ -73,27 +73,27 @@ struct SurfaceContactElem
       this->deallocateElem();
    }
 
-   integer dim;          ///< Problem dimension
-   integer meshId1;      ///< Mesh Id for face 1 (mortar)
-   integer meshId2;      ///< Mesh Id for face 2 (nonmortar)
-   integer faceId1;      ///< Face Id for face 1 (mortar)
-   integer faceId2;      ///< Face Id for face 2 (nonmortar)
-   real * faceCoords1;   ///< Coordinates of face 1 in 3D
-   real * faceCoords2;   ///< Coordinates of face 2 in 3D
-   real * faceNormal1;   ///< Components of face 1 normal
-   real * faceNormal2;   ///< Components of face 2 normal
-   real * overlapCoords; ///< Coordinates of overlap vertices in 3D
-   real * overlapNormal; ///< Components of overlap normal
-   integer numFaceVert;  ///< Number of face vertices/nodes
-   integer numPolyVert;  ///< Number of overlap vertices
-   real overlapArea;     ///< Area of polygonal overlap
+   int dim;          ///< Problem dimension
+   int meshId1;      ///< Mesh Id for face 1 (mortar)
+   int meshId2;      ///< Mesh Id for face 2 (nonmortar)
+   int faceId1;      ///< Face Id for face 1 (mortar)
+   int faceId2;      ///< Face Id for face 2 (nonmortar)
+   RealT * faceCoords1;   ///< Coordinates of face 1 in 3D
+   RealT * faceCoords2;   ///< Coordinates of face 2 in 3D
+   RealT * faceNormal1;   ///< Components of face 1 normal
+   RealT * faceNormal2;   ///< Components of face 2 normal
+   RealT * overlapCoords; ///< Coordinates of overlap vertices in 3D
+   RealT * overlapNormal; ///< Components of overlap normal
+   int numFaceVert;  ///< Number of face vertices/nodes
+   int numPolyVert;  ///< Number of overlap vertices
+   RealT overlapArea;     ///< Area of polygonal overlap
 
-   real * mortarWts;   ///< Stacked array of mortar wts for mortar methods
+   RealT * mortarWts;   ///< Stacked array of mortar wts for mortar methods
    int numWts;         ///< Number of mortar weights
 
    int numActiveGaps;  ///< Number of local face-pair active gaps
 
-   axom::Array<mfem::DenseMatrix, 2> blockJ;
+   ArrayT<mfem::DenseMatrix, 2> blockJ;
 
    /// routine to allocate space to store mortar weights
    void allocateMortarWts();
@@ -108,7 +108,7 @@ struct SurfaceContactElem
    * \param [in] b NONMORTAR node id
    *
    */
-   real getMortarNonmortarWt( const int a, const int b );
+   RealT getMortarNonmortarWt( const int a, const int b );
 
   /*!
    * \brief routine to return nonmortar-mortar mortar weights
@@ -117,7 +117,7 @@ struct SurfaceContactElem
    * \param [in] b MORTAR node id
    *
    */
-   real getNonmortarMortarWt( const int a, const int b );
+   RealT getNonmortarMortarWt( const int a, const int b );
 
   /*!
    * \brief routine to return nonmortar-nonmortar mortar weight
@@ -126,7 +126,7 @@ struct SurfaceContactElem
    * \param [in] b NONMORTAR node id
    *
    */
-   real getNonmortarNonmortarWt( const int a, const int b );
+   RealT getNonmortarNonmortarWt( const int a, const int b );
 
   /*!
    * \brief get array index for x-dimension face-pair Jacobian contribution
@@ -211,9 +211,9 @@ public:
     *
     * \param [in] blockJSpaces list of block spaces used in the Jacobian matrix
     * \param [in] nPairs approximate number of contacting face-pairs (used to
-    * allocate memory in the axom::Array)
+    * allocate memory in the ArrayT)
     */
-   void reserveBlockJ( axom::Array<BlockSpace>&& blockJSpaces, int nPairs );
+   void reserveBlockJ( ArrayT<BlockSpace>&& blockJSpaces, int nPairs );
    
    /*!
     * \brief store an element contribution to all blocks of the Jacobian matrix
@@ -224,8 +224,8 @@ public:
     * entry corresponds to a block of the Jacobian matrix)
     */
    void storeElemBlockJ( 
-      axom::Array<integer>&& blockJElemIds,
-      axom::Array<mfem::DenseMatrix, 2>& blockJ
+      ArrayT<int>&& blockJElemIds,
+      ArrayT<mfem::DenseMatrix, 2>& blockJ
    );
 
    /*!
@@ -233,10 +233,10 @@ public:
     *
     * See @ref getElementBlockJacobians for a definition of the blocks.
     */
-   integer getNSpaces() const { return m_blockJSpaces.size(); }
+   int getNSpaces() const { return m_blockJSpaces.size(); }
 
    /*!
-   * \brief Get the element ids for each entry of the getBlockJ 2D axom::Array
+   * \brief Get the element ids for each entry of the getBlockJ 2D ArrayT
    * sorted by block space
    *
    * \note Method returns a nested array. With getBlockJElementIds()[i][j], the
@@ -247,7 +247,7 @@ public:
    *
    * \return nested array identifying element ids for a given block space
    */
-   const axom::Array<axom::Array<integer>>& getBlockJElementIds() const
+   const ArrayT<ArrayT<int>>& getBlockJElementIds() const
    { 
       return m_blockJElemIds;
    }
@@ -264,16 +264,16 @@ public:
    * \return nested array identifying element Jacobian contributions for given
    * test and trial block spaces
    */
-   const axom::Array<axom::Array<mfem::DenseMatrix>, 2>& getBlockJ() const
+   const ArrayT<ArrayT<mfem::DenseMatrix>, 2>& getBlockJ() const
    {
       return m_blockJ;
    }
 
 private:
 
-   axom::Array<BlockSpace> m_blockJSpaces; ///< list of Jacobian blocks in use
-   axom::Array<axom::Array<integer>> m_blockJElemIds; ///< element ids for element Jacobian contributions
-   axom::Array<axom::Array<mfem::DenseMatrix>, 2> m_blockJ; ///< element Jacobian contributions by block
+   ArrayT<BlockSpace> m_blockJSpaces; ///< list of Jacobian blocks in use
+   ArrayT<ArrayT<int>> m_blockJElemIds; ///< element ids for element Jacobian contributions
+   ArrayT<ArrayT<mfem::DenseMatrix>, 2> m_blockJ; ///< element Jacobian contributions by block
 };
 
 //------------------------------------------------------------------------------
@@ -290,7 +290,7 @@ public:
     */
    ~MortarData();
 
-   integer m_numTotalNodes;
+   int m_numTotalNodes;
 
    /*!
     * \brief allocate object's mfem sparse matrix
@@ -330,7 +330,7 @@ public:
     */
    void getCSRArrays( int** I, 
                       int** J, 
-                      real** vals,
+                      RealT** vals,
                       int* n_offsets = nullptr, 
                       int* n_nonzero = nullptr );
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -50,7 +50,7 @@ void SubmeshLORTransfer::SubmeshToLOR(
 std::unique_ptr<mfem::ParGridFunction> SubmeshLORTransfer::CreateLORGridFunction(
   mfem::ParMesh& lor_mesh,
   std::unique_ptr<mfem::FiniteElementCollection> lor_fec,
-  integer vdim
+  int vdim
 )
 {
   auto lor_gridfn = std::make_unique<mfem::ParGridFunction>( 
@@ -231,9 +231,9 @@ void ParentField::UpdateField(ParentRedecompTransfer& parent_redecomp_xfer)
   update_data_ = std::make_unique<UpdateData>(parent_redecomp_xfer, parent_gridfn_);
 }
 
-std::vector<const real*> ParentField::GetRedecompFieldPtrs() const
+std::vector<const RealT*> ParentField::GetRedecompFieldPtrs() const
 {
-  auto data_ptrs = std::vector<const real*>(3, nullptr);
+  auto data_ptrs = std::vector<const RealT*>(3, nullptr);
   if (GetRedecompGridFn().FESpace()->GetNDofs() > 0)
   {
     for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
@@ -244,9 +244,9 @@ std::vector<const real*> ParentField::GetRedecompFieldPtrs() const
   return data_ptrs;
 }
 
-std::vector<real*> ParentField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
+std::vector<RealT*> ParentField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
 {
-  auto data_ptrs = std::vector<real*>(3, nullptr);
+  auto data_ptrs = std::vector<RealT*>(3, nullptr);
   if (redecomp_gridfn.FESpace()->GetNDofs() > 0)
   {
     for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
@@ -303,9 +303,9 @@ void PressureField::UpdateField(SubmeshRedecompTransfer& submesh_redecomp_xfer)
   update_data_ = std::make_unique<UpdateData>(submesh_redecomp_xfer, submesh_gridfn_);
 }
 
-std::vector<const real*> PressureField::GetRedecompFieldPtrs() const
+std::vector<const RealT*> PressureField::GetRedecompFieldPtrs() const
 {
-  auto data_ptrs = std::vector<const real*>(3, nullptr);
+  auto data_ptrs = std::vector<const RealT*>(3, nullptr);
   if (GetRedecompGridFn().FESpace()->GetNDofs() > 0)
   {
     for (size_t i{}; i < static_cast<size_t>(GetRedecompGridFn().FESpace()->GetVDim()); ++i)
@@ -316,9 +316,9 @@ std::vector<const real*> PressureField::GetRedecompFieldPtrs() const
   return data_ptrs;
 }
 
-std::vector<real*> PressureField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
+std::vector<RealT*> PressureField::GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn)
 {
-  auto data_ptrs = std::vector<real*>(3, nullptr);
+  auto data_ptrs = std::vector<RealT*>(3, nullptr);
   if (redecomp_gridfn.FESpace()->GetNDofs() > 0)
   {
     for (size_t i{}; i < static_cast<size_t>(redecomp_gridfn.FESpace()->GetVDim()); ++i)
@@ -359,12 +359,12 @@ PressureField::UpdateData::UpdateData(
 }
 
 MfemMeshData::MfemMeshData(
-  integer mesh_id_1,
-  integer mesh_id_2,
+  int mesh_id_1,
+  int mesh_id_2,
   const mfem::ParMesh& parent_mesh,
   const mfem::ParGridFunction& current_coords,
-  std::set<integer>&& attributes_1,
-  std::set<integer>&& attributes_2
+  std::set<int>&& attributes_1,
+  std::set<int>&& attributes_2
 )
 : mesh_id_1_ { mesh_id_1 },
   mesh_id_2_ { mesh_id_2 },
@@ -450,7 +450,7 @@ void MfemMeshData::UpdateMfemMeshData()
     *redecomp_elem_thickness_ = 0.0;
     redecomp_xfer.TransferToSerial(*elem_thickness_, *redecomp_elem_thickness_);
     // set element thickness on tribol mesh
-    tribol_elem_thickness_1_ = std::make_unique<axom::Array<double>>(
+    tribol_elem_thickness_1_ = std::make_unique<ArrayT<RealT>>(
       0, GetElemMap1().empty() ? 1 : GetElemMap1().size());
     for (auto redecomp_e : GetElemMap1())
     {
@@ -458,7 +458,7 @@ void MfemMeshData::UpdateMfemMeshData()
       redecomp_elem_thickness_->GetValues(redecomp_e, quad_val);
       tribol_elem_thickness_1_->push_back(quad_val[0]);
     }
-    tribol_elem_thickness_2_ = std::make_unique<axom::Array<double>>(
+    tribol_elem_thickness_2_ = std::make_unique<ArrayT<RealT>>(
       0, GetElemMap2().empty() ? 1 : GetElemMap2().size());
     for (auto redecomp_e : GetElemMap2())
     {
@@ -474,7 +474,7 @@ void MfemMeshData::UpdateMfemMeshData()
     *redecomp_material_modulus_ = 0.0;
     redecomp_xfer.TransferToSerial(*material_modulus_, *redecomp_material_modulus_);
     // set material modulus on tribol mesh
-    tribol_material_modulus_1_ = std::make_unique<axom::Array<double>>(
+    tribol_material_modulus_1_ = std::make_unique<ArrayT<RealT>>(
       0, GetElemMap1().empty() ? 1 : GetElemMap1().size());
     for (auto redecomp_e : GetElemMap1())
     {
@@ -482,7 +482,7 @@ void MfemMeshData::UpdateMfemMeshData()
       redecomp_material_modulus_->GetValues(redecomp_e, quad_val);
       tribol_material_modulus_1_->push_back(quad_val[0]);
     }
-    tribol_material_modulus_2_ = std::make_unique<axom::Array<double>>(
+    tribol_material_modulus_2_ = std::make_unique<ArrayT<RealT>>(
       0, GetElemMap2().empty() ? 1 : GetElemMap2().size());
     for (auto redecomp_e : GetElemMap2())
     {
@@ -535,7 +535,7 @@ void MfemMeshData::ClearRatePenaltyData()
   rate_percent_ratio_2_.reset(nullptr);
 }
 
-void MfemMeshData::SetLORFactor(integer lor_factor)
+void MfemMeshData::SetLORFactor(int lor_factor)
 {
   if (lor_factor <= 1)
   {
@@ -659,8 +659,8 @@ MfemMeshData::UpdateData::UpdateData(
   const mfem::ParFiniteElementSpace& parent_fes,
   mfem::ParGridFunction& submesh_gridfn,
   SubmeshLORTransfer* submesh_lor_xfer,
-  const std::set<integer>& attributes_1,
-  const std::set<integer>& attributes_2
+  const std::set<int>& attributes_1,
+  const std::set<int>& attributes_2
 )
 : redecomp_mesh_ { lor_mesh ? 
     redecomp::RedecompMesh(*lor_mesh) :
@@ -675,8 +675,8 @@ MfemMeshData::UpdateData::UpdateData(
 }
 
 void MfemMeshData::UpdateData::UpdateConnectivity(
-  const std::set<integer>& attributes_1,
-  const std::set<integer>& attributes_2
+  const std::set<int>& attributes_1,
+  const std::set<int>& attributes_2
 )
 {
   conn_1_.reserve(redecomp_mesh_.GetNE() * num_verts_per_elem_);
@@ -746,8 +746,8 @@ const MfemMeshData::UpdateData& MfemMeshData::GetUpdateData() const
 
 mfem::ParSubMesh MfemMeshData::CreateSubmesh(
   const mfem::ParMesh& parent_mesh,
-  const std::set<integer>& attributes_1,
-  const std::set<integer>& attributes_2
+  const std::set<int>& attributes_1,
+  const std::set<int>& attributes_2
 )
 {
   // TODO: Create PR for mfem::ParSubMesh::CreateFromBoundary taking a const
@@ -809,7 +809,7 @@ MfemSubmeshData::MfemSubmeshData(
   mfem::ParSubMesh& submesh,
   mfem::ParMesh* lor_mesh,
   std::unique_ptr<mfem::FiniteElementCollection> pressure_fec,
-  integer pressure_vdim
+  int pressure_vdim
 )
 : submesh_pressure_ {
     new mfem::ParFiniteElementSpace(
@@ -974,13 +974,13 @@ std::unique_ptr<mfem::BlockOperator> MfemJacobianData::GetMfemBlockJacobian(
   const auto& elem_map_2 = parent_data_.GetElemMap2();
   // empty data structures are needed even when no meshes are on rank since TransferToParallelSparse() needs to be
   // called on all ranks (even those without data)
-  auto mortar_elems = axom::Array<integer>(0, 0);
-  auto nonmortar_elems = axom::Array<integer>(0, 0);
-  auto lm_elems = axom::Array<integer>(0, 0);
-  auto elem_J_1_ptr = std::make_unique<axom::Array<mfem::DenseMatrix>>(0, 0);
-  auto elem_J_2_ptr = std::make_unique<axom::Array<mfem::DenseMatrix>>(0, 0);
-  const axom::Array<mfem::DenseMatrix>* elem_J_1 = elem_J_1_ptr.get();
-  const axom::Array<mfem::DenseMatrix>* elem_J_2 = elem_J_2_ptr.get();
+  auto mortar_elems = ArrayT<int>(0, 0);
+  auto nonmortar_elems = ArrayT<int>(0, 0);
+  auto lm_elems = ArrayT<int>(0, 0);
+  auto elem_J_1_ptr = std::make_unique<ArrayT<mfem::DenseMatrix>>(0, 0);
+  auto elem_J_2_ptr = std::make_unique<ArrayT<mfem::DenseMatrix>>(0, 0);
+  const ArrayT<mfem::DenseMatrix>* elem_J_1 = elem_J_1_ptr.get();
+  const ArrayT<mfem::DenseMatrix>* elem_J_2 = elem_J_2_ptr.get();
   // this means both of the meshes exist
   if (method_data != nullptr && !elem_map_1.empty() && !elem_map_2.empty())
   {
@@ -1029,7 +1029,7 @@ std::unique_ptr<mfem::BlockOperator> MfemJacobianData::GetMfemBlockJacobian(
   auto J = submesh_J.GetJ();
   auto submesh_vector_fes = parent_data_.GetSubmeshFESpace();
   auto mpi = redecomp::MPIUtility(submesh_vector_fes.GetComm());
-  auto submesh_dof_offsets = axom::Array<int>(mpi.NRanks() + 1, mpi.NRanks() + 1);
+  auto submesh_dof_offsets = ArrayT<int>(mpi.NRanks() + 1, mpi.NRanks() + 1);
   // we need the dof offsets of each rank.  check if mfem stores this or if we
   // need to create it.
   if (HYPRE_AssumedPartitionCheck())

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -126,7 +126,7 @@ private:
   static std::unique_ptr<mfem::ParGridFunction> CreateLORGridFunction(
     mfem::ParMesh& lor_mesh,
     std::unique_ptr<mfem::FiniteElementCollection> lor_fec,
-    integer vdim
+    int vdim
   );
 
   /**
@@ -419,21 +419,21 @@ public:
   /**
    * @brief Get pointers to component arrays of the redecomp mesh grid function
    *
-   * @return std::vector<const real*> of length 3
+   * @return std::vector<const RealT*> of length 3
    *
    * @note The third entry is nullptr in two dimensions
    */
-  std::vector<const real*> GetRedecompFieldPtrs() const;
+  std::vector<const RealT*> GetRedecompFieldPtrs() const;
   
   /**
    * @brief Get pointers to component arrays of the redecomp mesh grid function
    * 
    * @param redecomp_gridfn Redecomp mesh grid function
-   * @return std::vector<real*> of length 3
+   * @return std::vector<RealT*> of length 3
    *
    * @note The third entry is nullptr in two dimensions
    */
-  static std::vector<real*> GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn);
+  static std::vector<RealT*> GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn);
 
 private:
 
@@ -553,23 +553,23 @@ public:
   /**
    * @brief Get pointers to component arrays of the redecomp mesh grid function
    *
-   * @return std::vector<const real*> of length 3
+   * @return std::vector<const RealT*> of length 3
    *
    * @note Unused entries are nullptr.  Only the first entry is used with
    * frictionless contact.
    */
-  std::vector<const real*> GetRedecompFieldPtrs() const;
+  std::vector<const RealT*> GetRedecompFieldPtrs() const;
   
   /**
    * @brief Get pointers to component arrays of a redecomp mesh grid function
    *
    * @param redecomp_gridfn Redecomp mesh grid function
-   * @return std::vector<real*> of length 3
+   * @return std::vector<RealT*> of length 3
    *
    * @note Unused entries are nullptr.  Only the first entry is used with
    * frictionless contact.
    */
-  static std::vector<real*> GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn);
+  static std::vector<RealT*> GetRedecompFieldPtrs(mfem::GridFunction& redecomp_gridfn);
 
 private:
   /**
@@ -648,12 +648,12 @@ public:
    * in the second Tribol registered mesh
    */
   MfemMeshData(
-    integer mesh_id_1,
-    integer mesh_id_2,
+    int mesh_id_1,
+    int mesh_id_2,
     const mfem::ParMesh& parent_mesh,
     const mfem::ParGridFunction& current_coords,
-    std::set<integer>&& attributes_1,
-    std::set<integer>&& attributes_2
+    std::set<int>&& attributes_1,
+    std::set<int>&& attributes_2
   );
 
   /**
@@ -685,23 +685,23 @@ public:
   /**
    * @brief Get the integer identifier for the first Tribol registered mesh
    *
-   * @return integer 
+   * @return int 
    */
-  integer GetMesh1ID() const { return mesh_id_1_; }
+  int GetMesh1ID() const { return mesh_id_1_; }
 
   /**
    * @brief Get the integer identifier for the second Tribol registered mesh
    *
-   * @return integer 
+   * @return int 
    */
-  integer GetMesh2ID() const { return mesh_id_2_; }
+  int GetMesh2ID() const { return mesh_id_2_; }
 
   /**
    * @brief Get the number of elements in the first Tribol registered mesh
    *
-   * @return integer 
+   * @return int 
    */
-  integer GetMesh1NE() const
+  int GetMesh1NE() const
   { 
     return GetUpdateData().conn_1_.size() / GetUpdateData().num_verts_per_elem_;
   }
@@ -709,9 +709,9 @@ public:
   /**
    * @brief Get the number of elements in the second Tribol registered mesh
    *
-   * @return integer 
+   * @return int 
    */
-  integer GetMesh2NE() const
+  int GetMesh2NE() const
   {
     return GetUpdateData().conn_2_.size() / GetUpdateData().num_verts_per_elem_;
   }
@@ -719,16 +719,16 @@ public:
   /**
    * @brief Get the total number of vertices in both Tribol registered meshes
    *
-   * @return integer 
+   * @return int 
    */
-  integer GetNV() const { return GetUpdateData().redecomp_mesh_.GetNV(); }
+  int GetNV() const { return GetUpdateData().redecomp_mesh_.GetNV(); }
 
   /**
    * @brief Get the connectivity for the first Tribol registered mesh
    *
    * @return const IndexType* 
    */
-  const IndexType* GetMesh1Conn() const
+  const IndexT* GetMesh1Conn() const
   {
     return GetUpdateData().conn_1_.data();
   }
@@ -738,7 +738,7 @@ public:
    *
    * @return const IndexType* 
    */
-  const IndexType* GetMesh2Conn() const
+  const IndexT* GetMesh2Conn() const
   {
     return GetUpdateData().conn_2_.data();
   }
@@ -746,7 +746,7 @@ public:
   /**
    * @brief Get the element type for both Tribol registered meshes
    *
-   * @return integer 
+   * @return InterfaceElementType
    */
   InterfaceElementType GetElemType() const { return GetUpdateData().elem_type_; }
 
@@ -754,11 +754,11 @@ public:
    * @brief Get pointers to component arrays of the coordinates on the
    * redecomp mesh
    *
-   * @return std::vector<const real*> of length 3
+   * @return std::vector<const RealT*> of length 3
    *
    * @note The third entry is nullptr in two dimensions
    */
-  std::vector<const real*> GetRedecompCoordsPtrs() const 
+  std::vector<const RealT*> GetRedecompCoordsPtrs() const 
   { 
     return coords_.GetRedecompFieldPtrs();
   }
@@ -767,11 +767,11 @@ public:
    * @brief Get pointers to component arrays of the nodal response on the
    * redecomp mesh
    *
-   * @return std::vector<real*> of length 3
+   * @return std::vector<RealT*> of length 3
    *
    * @note The third entry is nullptr in two dimensions
    */
-  std::vector<real*> GetRedecompResponsePtrs()
+  std::vector<RealT*> GetRedecompResponsePtrs()
   {
     return ParentField::GetRedecompFieldPtrs(redecomp_response_);
   }
@@ -824,11 +824,11 @@ public:
   /**
    * @brief Get pointers to component arrays of the velocity on the RedecompMesh
    * 
-   * @return std::vector<const real*> of length 3
+   * @return std::vector<const RealT*> of length 3
    *
    * @note The third entry is nullptr in two dimensions
    */
-  std::vector<const real*> GetRedecompVelocityPtrs() const
+  std::vector<const RealT*> GetRedecompVelocityPtrs() const
   {
     return velocity_->GetRedecompFieldPtrs();
   }
@@ -848,9 +848,9 @@ public:
    * 
    * @param penalty Penalty value for the first registered Tribol mesh
    */
-  void SetMesh1KinematicConstantPenalty(real penalty)
+  void SetMesh1KinematicConstantPenalty(RealT penalty)
   { 
-    kinematic_constant_penalty_1_ = std::make_unique<double>(penalty);
+    kinematic_constant_penalty_1_ = std::make_unique<RealT>(penalty);
   }
 
   /**
@@ -858,17 +858,17 @@ public:
    * 
    * @param penalty Penalty value for the second registered Tribol mesh
    */
-  void SetMesh2KinematicConstantPenalty(real penalty)
+  void SetMesh2KinematicConstantPenalty(RealT penalty)
   { 
-    kinematic_constant_penalty_2_ = std::make_unique<double>(penalty);
+    kinematic_constant_penalty_2_ = std::make_unique<RealT>(penalty);
   }
 
   /**
    * @brief Get the kinematic constant penalty parameter for the first registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh1KinematicConstantPenalty() const
+  const RealT* GetMesh1KinematicConstantPenalty() const
   { 
     return kinematic_constant_penalty_1_.get();
   }
@@ -876,9 +876,9 @@ public:
   /**
    * @brief Get the kinematic constant penalty parameter for the second registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh2KinematicConstantPenalty() const
+  const RealT* GetMesh2KinematicConstantPenalty() const
   { 
     return kinematic_constant_penalty_2_.get();
   }
@@ -888,9 +888,9 @@ public:
    * 
    * @param scale Penalty scale value for the first registered Tribol mesh
    */
-  void SetMesh1KinematicPenaltyScale(real scale)
+  void SetMesh1KinematicPenaltyScale(RealT scale)
   {
-    kinematic_penalty_scale_1_ = std::make_unique<double>(scale);
+    kinematic_penalty_scale_1_ = std::make_unique<RealT>(scale);
   }
 
   /**
@@ -898,52 +898,52 @@ public:
    * 
    * @param scale Penalty scale value for the second registered Tribol mesh
    */
-  void SetMesh2KinematicPenaltyScale(real scale)
+  void SetMesh2KinematicPenaltyScale(RealT scale)
   {
-    kinematic_penalty_scale_2_ = std::make_unique<double>(scale);
+    kinematic_penalty_scale_2_ = std::make_unique<RealT>(scale);
   }
 
   /**
    * @brief Get the kinematic penalty scale for the first registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh1KinematicPenaltyScale() const { return kinematic_penalty_scale_1_.get(); }
+  const RealT* GetMesh1KinematicPenaltyScale() const { return kinematic_penalty_scale_1_.get(); }
 
   /**
    * @brief Get the kinematic penalty scale for the second registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh2KinematicPenaltyScale() const { return kinematic_penalty_scale_2_.get(); }
+  const RealT* GetMesh2KinematicPenaltyScale() const { return kinematic_penalty_scale_2_.get(); }
 
   /**
    * @brief Sets the rate constant penalty for the first registered Tribol mesh
    * 
    * @param penalty Rate constant penalty value for the first registered Tribol mesh
    */
-  void SetMesh1RateConstantPenalty(real penalty) { rate_constant_penalty_1_ = std::make_unique<double>(penalty); }
+  void SetMesh1RateConstantPenalty(RealT penalty) { rate_constant_penalty_1_ = std::make_unique<RealT>(penalty); }
 
   /**
    * @brief Sets the rate constant penalty for the second registered Tribol mesh
    * 
    * @param penalty Rate penalty value for the second registered Tribol mesh
    */
-  void SetMesh2RateConstantPenalty(real penalty) { rate_constant_penalty_2_ = std::make_unique<double>(penalty); }
+  void SetMesh2RateConstantPenalty(RealT penalty) { rate_constant_penalty_2_ = std::make_unique<RealT>(penalty); }
 
   /**
    * @brief Get the rate constant penalty for the first registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh1RateConstantPenalty() const { return rate_constant_penalty_1_.get(); }
+  const RealT* GetMesh1RateConstantPenalty() const { return rate_constant_penalty_1_.get(); }
 
   /**
    * @brief Get the rate constant penalty for the second registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh2RateConstantPenalty() const { return rate_constant_penalty_2_.get(); }
+  const RealT* GetMesh2RateConstantPenalty() const { return rate_constant_penalty_2_.get(); }
 
   /**
    * @brief Sets the rate penalty as a ratio of the kinematic penalty for the
@@ -951,7 +951,7 @@ public:
    *
    * @param ratio Rate ratio for the first registered Tribol mesh
    */
-  void SetMesh1RatePercentPenalty(real ratio) { rate_percent_ratio_1_ = std::make_unique<double>(ratio); }
+  void SetMesh1RatePercentPenalty(RealT ratio) { rate_percent_ratio_1_ = std::make_unique<RealT>(ratio); }
 
   /**
    * @brief Sets the rate penalty as a ratio of the kinematic penalty for the
@@ -959,29 +959,29 @@ public:
    * 
    * @param ratio Rate ratio for the second registered Tribol mesh
    */
-  void SetMesh2RatePercentPenalty(real ratio) { rate_percent_ratio_2_ = std::make_unique<double>(ratio); }
+  void SetMesh2RatePercentPenalty(RealT ratio) { rate_percent_ratio_2_ = std::make_unique<RealT>(ratio); }
 
   /**
    * @brief Get the rate penalty ratio for the first registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh1RatePercentPenalty() const { return rate_percent_ratio_1_.get(); }
+  const RealT* GetMesh1RatePercentPenalty() const { return rate_percent_ratio_1_.get(); }
 
   /**
    * @brief Get the rate penalty ratio for the second registered Tribol mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetMesh2RatePercentPenalty() const { return rate_percent_ratio_2_.get(); }
+  const RealT* GetMesh2RatePercentPenalty() const { return rate_percent_ratio_2_.get(); }
 
   /**
    * @brief Get a pointer to the element thickness array for the first Tribol
    * registered mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetRedecompElemThickness1() const
+  const RealT* GetRedecompElemThickness1() const
   {
     return tribol_elem_thickness_1_->data();
   }
@@ -990,9 +990,9 @@ public:
    * @brief Get a pointer to the element thickness array for the second Tribol
    * registered mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetRedecompElemThickness2() const
+  const RealT* GetRedecompElemThickness2() const
   {
     return tribol_elem_thickness_2_->data();
   }
@@ -1001,9 +1001,9 @@ public:
    * @brief Get a pointer to the material modulus array for the first Tribol
    * registered mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetRedecompMaterialModulus1() const
+  const RealT* GetRedecompMaterialModulus1() const
   {
     return tribol_material_modulus_1_->data();
   }
@@ -1012,9 +1012,9 @@ public:
    * @brief Get a pointer to the material modulus array for the second Tribol
    * registered mesh
    *
-   * @return const real* 
+   * @return const RealT* 
    */
-  const real* GetRedecompMaterialModulus2() const
+  const RealT* GetRedecompMaterialModulus2() const
   {
     return tribol_material_modulus_2_->data();
   }
@@ -1023,9 +1023,9 @@ public:
    * @brief Get the map from Tribol registered mesh 1 element indices to
    * redecomp mesh element indices
    *
-   * @return const std::vector<integer>& 
+   * @return const std::vector<int>& 
    */
-  const std::vector<integer>& GetElemMap1() const
+  const std::vector<int>& GetElemMap1() const
   {
     return GetUpdateData().elem_map_1_;
   }
@@ -1034,9 +1034,9 @@ public:
    * @brief Get the map from Tribol registered mesh 2 element indices to
    * redecomp mesh element indices
    *
-   * @return const std::vector<integer>& 
+   * @return const std::vector<int>& 
    */
-  const std::vector<integer>& GetElemMap2() const
+  const std::vector<int>& GetElemMap2() const
   {
     return GetUpdateData().elem_map_2_;
   }
@@ -1128,7 +1128,7 @@ public:
    *
    * @param lor_factor Number of element subdivisions per dimension
    */
-  void SetLORFactor(integer lor_factor);
+  void SetLORFactor(int lor_factor);
 
   /**
    * @brief Computes element thicknesses for volume elements attached to the contact surface
@@ -1171,8 +1171,8 @@ private:
       const mfem::ParFiniteElementSpace& parent_fes,
       mfem::ParGridFunction& submesh_gridfn,
       SubmeshLORTransfer* submesh_lor_xfer,
-      const std::set<integer>& attributes_1,
-      const std::set<integer>& attributes_2
+      const std::set<int>& attributes_1,
+      const std::set<int>& attributes_2
     );
 
     /**
@@ -1189,25 +1189,25 @@ private:
      * @brief Redecomp mesh element connectivity for the first Tribol registered
      * mesh
      */
-    axom::Array<integer, 2> conn_1_;
+    ArrayT<int, 2> conn_1_;
 
     /**
      * @brief Redecomp mesh element connectivity for the second Tribol
      * registered mesh
      */
-    axom::Array<integer, 2> conn_2_;
+    ArrayT<int, 2> conn_2_;
 
     /**
      * @brief Map from first Tribol registered mesh element indices to redecomp
      * mesh element indices
      */
-    std::vector<integer> elem_map_1_;
+    std::vector<int> elem_map_1_;
 
     /**
      * @brief Map from second Tribol registered mesh element indices to redecomp
      * mesh element indices
      */
-    std::vector<integer> elem_map_2_;
+    std::vector<int> elem_map_2_;
 
     /**
     * @brief Type of elements on the contact meshes
@@ -1217,7 +1217,7 @@ private:
     /**
     * @brief Number of vertices on each element in the contact meshes
     */
-    integer num_verts_per_elem_;
+    int num_verts_per_elem_;
 
   private:
     /**
@@ -1230,8 +1230,8 @@ private:
      * registered mesh
      */
     void UpdateConnectivity(
-      const std::set<integer>& attributes_1,
-      const std::set<integer>& attributes_2
+      const std::set<int>& attributes_1,
+      const std::set<int>& attributes_2
     );
 
     /**
@@ -1266,19 +1266,19 @@ private:
    */
   static mfem::ParSubMesh CreateSubmesh(
     const mfem::ParMesh& parent_mesh,
-    const std::set<integer>& attributes_1,
-    const std::set<integer>& attributes_2
+    const std::set<int>& attributes_1,
+    const std::set<int>& attributes_2
   );
 
   /**
    * @brief First mesh identifier
    */
-  integer mesh_id_1_;
+  int mesh_id_1_;
 
   /**
    * @brief Second mesh identifier
    */
-  integer mesh_id_2_;
+  int mesh_id_2_;
 
   /**
    * @brief Volume mesh of parent domain
@@ -1288,12 +1288,12 @@ private:
   /**
    * @brief Mesh boundary attributes identifying first mesh
    */
-  const std::set<integer> attributes_1_;
+  const std::set<int> attributes_1_;
 
   /**
    * @brief Mesh boundary attributes identifying second mesh
    */
-  const std::set<integer> attributes_2_;
+  const std::set<int> attributes_2_;
 
   /**
    * @brief Submesh containing boundary elements of both contact surfaces
@@ -1313,7 +1313,7 @@ private:
   /**
    * @brief Refinement factor for refined mesh
    */
-  integer lor_factor_;
+  int lor_factor_;
 
   /**
    * @brief Contains LOR mesh if low-order refinement is being used; nullptr
@@ -1336,44 +1336,44 @@ private:
   /**
    * @brief Kinematic constant contact penalty for the first Tribol registered mesh
    */
-  std::unique_ptr<real> kinematic_constant_penalty_1_;
+  std::unique_ptr<RealT> kinematic_constant_penalty_1_;
 
   /**
    * @brief Kinematic constant contact penalty for the second Tribol registered mesh
    */
-  std::unique_ptr<real> kinematic_constant_penalty_2_;
+  std::unique_ptr<RealT> kinematic_constant_penalty_2_;
 
   /**
    * @brief Scaling of kinematic penalty for the first Tribol registered mesh
    */
-  std::unique_ptr<real> kinematic_penalty_scale_1_;
+  std::unique_ptr<RealT> kinematic_penalty_scale_1_;
 
   /**
    * @brief Scaling of kinematic penalty for the second Tribol registered mesh
    */
-  std::unique_ptr<real> kinematic_penalty_scale_2_;
+  std::unique_ptr<RealT> kinematic_penalty_scale_2_;
 
   /**
    * @brief Rate constant contact penalty for the first Tribol registered mesh
    */
-  std::unique_ptr<real> rate_constant_penalty_1_;
+  std::unique_ptr<RealT> rate_constant_penalty_1_;
 
   /**
    * @brief Rate constant contact penalty for the second Tribol registered mesh
    */
-  std::unique_ptr<real> rate_constant_penalty_2_;
+  std::unique_ptr<RealT> rate_constant_penalty_2_;
 
   /**
    * @brief Rate percent penalty as a ratio of kinematic penalty for the first
    * Tribol registered mesh
    */
-  std::unique_ptr<real> rate_percent_ratio_1_;
+  std::unique_ptr<RealT> rate_percent_ratio_1_;
 
   /**
    * @brief Rate percent penalty as a ratio of kinematic penalty for the second
    * Tribol registered mesh
    */
-  std::unique_ptr<real> rate_percent_ratio_2_;
+  std::unique_ptr<RealT> rate_percent_ratio_2_;
 
   /**
    * @brief Stores element thicknesses for element-based penalty calculations on
@@ -1389,12 +1389,12 @@ private:
   /**
    * @brief Element thicknesses for the first Tribol registered mesh
    */
-  std::unique_ptr<axom::Array<real>> tribol_elem_thickness_1_;
+  std::unique_ptr<ArrayT<RealT>> tribol_elem_thickness_1_;
 
   /**
    * @brief Element thicknesses for the second Tribol registered mesh
    */
-  std::unique_ptr<axom::Array<real>> tribol_elem_thickness_2_;
+  std::unique_ptr<ArrayT<RealT>> tribol_elem_thickness_2_;
 
   /**
    * @brief Stores material moduli for element-based penalty calculations on
@@ -1410,12 +1410,12 @@ private:
   /**
    * @brief Material moduli for the first Tribol registered mesh
    */
-  std::unique_ptr<axom::Array<real>> tribol_material_modulus_1_;
+  std::unique_ptr<ArrayT<RealT>> tribol_material_modulus_1_;
 
   /**
    * @brief Material moduli for the second Tribol registered mesh
    */
-  std::unique_ptr<axom::Array<real>> tribol_material_modulus_2_;
+  std::unique_ptr<ArrayT<RealT>> tribol_material_modulus_2_;
 
   /**
    * @brief UpdateData object created upon call to UpdateMeshData()
@@ -1483,7 +1483,7 @@ public:
     mfem::ParSubMesh& submesh,
     mfem::ParMesh* lor_mesh,
     std::unique_ptr<mfem::FiniteElementCollection> pressure_fec,
-    integer pressure_vdim
+    int pressure_vdim
   );
 
   /**
@@ -1498,12 +1498,12 @@ public:
    * @brief Get pointers to component arrays of the pressure on the redecomp
    * mesh
    *
-   * @return std::vector<const real*> of length 3
+   * @return std::vector<const RealT*> of length 3
    *
    * @note Unused entries are nullptr.  Only the first entry is used with
    * frictionless contact.
    */
-  std::vector<const real*> GetRedecompPressurePtrs() const
+  std::vector<const RealT*> GetRedecompPressurePtrs() const
   {
     return pressure_.GetRedecompFieldPtrs();
   }
@@ -1531,12 +1531,12 @@ public:
   /**
    * @brief Get pointers to component arrays of the gap on the redecomp mesh
    * 
-   * @return std::vector<real*> of length 3
+   * @return std::vector<RealT*> of length 3
    *
    * @note Unused entries are nullptr.  Only the first entry is used with
    * frictionless contact.
    */
-  std::vector<real*> GetRedecompGapPtrs()
+  std::vector<RealT*> GetRedecompGapPtrs()
   {
     return PressureField::GetRedecompFieldPtrs(redecomp_gap_);
   }

--- a/src/tribol/physics/AlignedMortar.cpp
+++ b/src/tribol/physics/AlignedMortar.cpp
@@ -42,7 +42,7 @@ void ComputeAlignedMortarWeights( SurfaceContactElem & elem )
    // also initializes the array
    elem.allocateMortarWts();
 
-   real phiNonmortarA, phiNonmortarB, phiMortarA;
+   RealT phiNonmortarA, phiNonmortarB, phiMortarA;
 
    // loop over nodes "a", where node "a" can be a nonmortar node or a mortar node
    for (int a=0; a<elem.numFaceVert; ++a)
@@ -55,7 +55,7 @@ void ComputeAlignedMortarWeights( SurfaceContactElem & elem )
          for (int ip=0; ip<integ.numIPs; ++ip)
          {
 
-            real xi[2]; 
+            RealT xi[2]; 
             xi[0] = integ.xy[ integ.ipDim * ip ];
             xi[1] = integ.xy[ integ.ipDim * ip + 1 ];
             LinIsoQuadShapeFunc( xi[0], xi[1], a, phiMortarA );
@@ -89,7 +89,7 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
    // get mesh instance to store gaps on mesh data object
    MeshManager& meshManager = MeshManager::getInstance();
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( elem.meshId2 );
-   IndexType const * const nonmortarConn = nonmortarMesh.m_connectivity;
+   IndexT const * const nonmortarConn = nonmortarMesh.m_connectivity;
 
    SLIC_ERROR_IF(nonmortarMesh.m_nodalFields.m_node_gap == nullptr, 
                  "ComputeNodalGap< ALIGNED_MORTAR >: allocate gaps on mesh data object.");
@@ -99,16 +99,16 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
 
    // set the distance magnitude tolerance as the longest edge of 
    // the mortar face
-   real magTol;
-   real magTest = 0.;
+   RealT magTol;
+   RealT magTest = 0.;
    for (int k=0; k<elem.numFaceVert; ++k)
    {
       int idPlus = (k == (elem.numFaceVert-1)) ? 0 : k+1;
-      real dx = elem.faceCoords1[ elem.dim * idPlus ] - elem.faceCoords1[ elem.dim * k ];
-      real dy = elem.faceCoords1[ elem.dim * idPlus + 1 ] - elem.faceCoords1[ elem.dim * k + 1 ];
-      real dz = elem.faceCoords1[ elem.dim * idPlus + 2 ] - elem.faceCoords1[ elem.dim * k + 2 ];
+      RealT dx = elem.faceCoords1[ elem.dim * idPlus ] - elem.faceCoords1[ elem.dim * k ];
+      RealT dy = elem.faceCoords1[ elem.dim * idPlus + 1 ] - elem.faceCoords1[ elem.dim * k + 1 ];
+      RealT dz = elem.faceCoords1[ elem.dim * idPlus + 2 ] - elem.faceCoords1[ elem.dim * k + 2 ];
 
-      real mag = magnitude( dx, dy, dz );
+      RealT mag = magnitude( dx, dy, dz );
 
       magTol = (mag > magTest) ? mag : magTest;
       magTest = mag;
@@ -119,7 +119,7 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
    {
 
       // get global nonmortar node number from connectivity
-      real nrml_a[elem.dim];
+      RealT nrml_a[elem.dim];
       int glbId = nonmortarConn[ elem.numFaceVert * elem.faceId2 + a ];
       nrml_a[0] = nonmortarMesh.m_node_nX[ glbId ];
       nrml_a[1] = nonmortarMesh.m_node_nY[ glbId ];
@@ -133,8 +133,8 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
       // nonmortar node "a" 
       //////////////////////////////////////////////
       int mortarNodeId;
-      real v[3] = {0., 0., 0.};
-      real magTest = magTol; 
+      RealT v[3] = {0., 0., 0.};
+      RealT magTest = magTol; 
       // loop over nodes on the mortar side 
       for (int b=0; b<elem.numFaceVert; ++b)
       {
@@ -142,7 +142,7 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
          v[1] = elem.faceCoords1[ elem.dim * b + 1 ] - elem.faceCoords2[ elem.dim * a + 1 ];
          v[2] = elem.faceCoords1[ elem.dim * b + 2 ] - elem.faceCoords2[ elem.dim * a + 2 ];
 
-         real magV = magnitude( v[0], v[1], v[2] );
+         RealT magV = magnitude( v[0], v[1], v[2] );
 
          if (magV < magTest)
          {
@@ -167,34 +167,34 @@ void ComputeNodalGap< ALIGNED_MORTAR >( SurfaceContactElem & elem )
 void ComputeAlignedMortarGaps( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    ////////////////////////////////////////////////////////////////////////
    //
    // Grab pointers to mesh data
    //
    ////////////////////////////////////////////////////////////////////////
-   IndexType const mortarId = cs->getMeshId1();
-   IndexType const nonmortarId =  cs->getMeshId2();
+   IndexT const mortarId = cs->getMeshId1();
+   IndexT const nonmortarId =  cs->getMeshId2();
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh  = meshManager.GetMeshInstance( nonmortarId );
-   IndexType const numNodesPerFace = mortarMesh.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mortarMesh.m_numNodesPerCell;
 
-   real const * const x1 = mortarMesh.m_positionX;
-   real const * const y1 = mortarMesh.m_positionY; 
-   real const * const z1 = mortarMesh.m_positionZ; 
-   IndexType const * const mortarConn= mortarMesh.m_connectivity;
+   RealT const * const x1 = mortarMesh.m_positionX;
+   RealT const * const y1 = mortarMesh.m_positionY; 
+   RealT const * const z1 = mortarMesh.m_positionZ; 
+   IndexT const * const mortarConn= mortarMesh.m_connectivity;
 
-   real const * const x2 = nonmortarMesh.m_positionX; 
-   real const * const y2 = nonmortarMesh.m_positionY;
-   real const * const z2 = nonmortarMesh.m_positionZ;
-   IndexType const * nonmortarConn = nonmortarMesh.m_connectivity;
+   RealT const * const x2 = nonmortarMesh.m_positionX; 
+   RealT const * const y2 = nonmortarMesh.m_positionY;
+   RealT const * const z2 = nonmortarMesh.m_positionZ;
+   IndexT const * nonmortarConn = nonmortarMesh.m_connectivity;
 
    // compute nodal normals (do this outside the element loop)
    // This routine is guarded against a null mesh
@@ -202,15 +202,15 @@ void ComputeAlignedMortarGaps( CouplingScheme const * cs )
  
    // declare local variables to hold face nodal coordinates
    // and overlap vertex coordinates
-   real mortarX[ dim * numNodesPerFace ];
-   real nonmortarX[ dim * numNodesPerFace ];
-   real* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
+   RealT mortarX[ dim * numNodesPerFace ];
+   RealT nonmortarX[ dim * numNodesPerFace ];
+   RealT* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
 
    ////////////////////////////
    // compute nonmortar gaps //
    ////////////////////////////
    int cpID = 0;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -220,8 +220,8 @@ void ComputeAlignedMortarGaps( CouplingScheme const * cs )
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
       // populate nodal coordinates array. For the aligned mortar 
       // gap equations, the nodal coordinates are NOT to be projected 
@@ -239,7 +239,7 @@ void ComputeAlignedMortarGaps( CouplingScheme const * cs )
          nonmortarX[ id+2 ] = z2[ nonmortarConn[ numNodesPerFace * index2 + i ] ];
       }
 
-      overlapX = new real[ dim * cpManager.m_numPolyVert[ cpID ]];  
+      overlapX = new RealT[ dim * cpManager.m_numPolyVert[ cpID ]];  
       initRealArray( overlapX, dim*cpManager.m_numPolyVert[cpID], 0. );
 
       // construct array of polygon overlap vertex coordinates
@@ -281,40 +281,40 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
 {
 
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    ////////////////////////////////////////////////////////////////////////
    //
    // Grab pointers to mesh data
    //
    ////////////////////////////////////////////////////////////////////////
-   IndexType const mortarId = cs->getMeshId1();
-   IndexType const nonmortarId =  cs->getMeshId2();
+   IndexT const mortarId = cs->getMeshId1();
+   IndexT const nonmortarId =  cs->getMeshId2();
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh  = meshManager.GetMeshInstance( nonmortarId );
-   IndexType const numNodesPerFace = mortarMesh.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mortarMesh.m_numNodesPerCell;
 
-   real const * const x1 = mortarMesh.m_positionX;
-   real const * const y1 = mortarMesh.m_positionY; 
-   real const * const z1 = mortarMesh.m_positionZ; 
-   real * const fx1 = mortarMesh.m_forceX;
-   real * const fy1 = mortarMesh.m_forceY; 
-   real * const fz1 = mortarMesh.m_forceZ; 
-   IndexType const * const mortarConn= mortarMesh.m_connectivity;
+   RealT const * const x1 = mortarMesh.m_positionX;
+   RealT const * const y1 = mortarMesh.m_positionY; 
+   RealT const * const z1 = mortarMesh.m_positionZ; 
+   RealT * const fx1 = mortarMesh.m_forceX;
+   RealT * const fy1 = mortarMesh.m_forceY; 
+   RealT * const fz1 = mortarMesh.m_forceZ; 
+   IndexT const * const mortarConn= mortarMesh.m_connectivity;
 
-   real const * const x2 = nonmortarMesh.m_positionX; 
-   real const * const y2 = nonmortarMesh.m_positionY;
-   real const * const z2 = nonmortarMesh.m_positionZ;
-   real * const fx2 = nonmortarMesh.m_forceX; 
-   real * const fy2 = nonmortarMesh.m_forceY;
-   real * const fz2 = nonmortarMesh.m_forceZ;
-   IndexType const * nonmortarConn = nonmortarMesh.m_connectivity;
+   RealT const * const x2 = nonmortarMesh.m_positionX; 
+   RealT const * const y2 = nonmortarMesh.m_positionY;
+   RealT const * const z2 = nonmortarMesh.m_positionZ;
+   RealT * const fx2 = nonmortarMesh.m_forceX; 
+   RealT * const fy2 = nonmortarMesh.m_forceY;
+   RealT * const fz2 = nonmortarMesh.m_forceZ;
+   IndexT const * nonmortarConn = nonmortarMesh.m_connectivity;
 
    ///////////////////////////////////////////////////////
    //                                                   //
@@ -337,7 +337,7 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
    // compute equilibrium residual and/or Jacobian contributions //
    ////////////////////////////////////////////////////////////////
    int cpID = 0;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -347,8 +347,8 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
       //////////////////////////////////
       // compute equilibrium residual //
@@ -372,11 +372,11 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
          // note: we don't have to interpolate the nodal pressure for mortar and nonmortar 
          // sides for the aligned mortar case (i.e. no interpolation necessary for coincident 
          // mortar and nonmortar nodes).
-         real forceX = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] * 
+         RealT forceX = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] * 
                        nonmortarMesh.m_node_nX[ nonmortarIdA ];
-         real forceY = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] *
+         RealT forceY = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] *
                        nonmortarMesh.m_node_nY[ nonmortarIdA ];
-         real forceZ = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] * 
+         RealT forceZ = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdA ] * 
                        nonmortarMesh.m_node_nZ[ nonmortarIdA ];
 
          fx2[ nonmortarIdA ]  -= forceX;
@@ -405,9 +405,9 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
       {
          // declare local variables to hold face nodal coordinates
          // and overlap vertex coordinates
-         real mortarX[ dim * numNodesPerFace ];
-         real nonmortarX[ dim * numNodesPerFace ];
-         real* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
+         RealT mortarX[ dim * numNodesPerFace ];
+         RealT nonmortarX[ dim * numNodesPerFace ];
+         RealT* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
 
          // populate nodal coordinates array. For the aligned mortar 
          // gap equations, the nodal coordinates are NOT to be projected 
@@ -425,7 +425,7 @@ int ApplyNormal< ALIGNED_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * c
             nonmortarX[ id+2 ] = z2[ nonmortarConn[ numNodesPerFace * index2 + i ] ];
          }
 
-         overlapX = new real[ dim * cpManager.m_numPolyVert[ cpID ]];  
+         overlapX = new RealT[ dim * cpManager.m_numPolyVert[ cpID ]];  
          initRealArray( overlapX, dim*cpManager.m_numPolyVert[cpID], 0. );
 
          // construct array of polygon overlap vertex coordinates

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -22,8 +22,8 @@
 namespace tribol
 {
 
-real ComputePenaltyStiffnessPerArea( const real K1_over_t1,
-                                     const real K2_over_t2 )
+RealT ComputePenaltyStiffnessPerArea( const RealT K1_over_t1,
+                                     const RealT K2_over_t2 )
 {
    // compute face-pair specific penalty stiffness per unit area.
    // Note: This assumes that each face has a spring stiffness 
@@ -45,9 +45,9 @@ real ComputePenaltyStiffnessPerArea( const real K1_over_t1,
 } // end ComputePenaltyStiffnessPerArea
 
 //------------------------------------------------------------------------------
-real ComputeGapRatePressure( ContactPlaneManager& cpMgr, 
+RealT ComputeGapRatePressure( ContactPlaneManager& cpMgr, 
                              int cpID, int meshId1, int meshId2, 
-                             int fId1, int fId2, double element_penalty,
+                             int fId1, int fId2, RealT element_penalty,
                              int dim, RatePenaltyCalculation rate_calc )
 {
    MeshManager& meshManager = MeshManager::getInstance();
@@ -55,7 +55,7 @@ real ComputeGapRatePressure( ContactPlaneManager& cpMgr,
    MeshData& m2 = meshManager.GetMeshInstance( meshId2 );
 
    // compute the correct rate_penalty
-   double rate_penalty = 0.;
+   RealT rate_penalty = 0.;
    switch (rate_calc)
    {
       case NO_RATE_PENALTY:
@@ -84,13 +84,13 @@ real ComputeGapRatePressure( ContactPlaneManager& cpMgr,
    int numNodesPerCell1 = m1.m_numNodesPerCell;
    int numNodesPerCell2 = m2.m_numNodesPerCell;
 
-   double x1[dim * numNodesPerCell1];
-   double v1[dim * numNodesPerCell1];
+   RealT x1[dim * numNodesPerCell1];
+   RealT v1[dim * numNodesPerCell1];
    m1.getFaceCoords( fId1, &x1[0] );
    m1.getFaceNodalVelocities( fId1, &v1[0] );
 
-   double x2[dim * numNodesPerCell2];
-   double v2[dim * numNodesPerCell2];
+   RealT x2[dim * numNodesPerCell2];
+   RealT v2[dim * numNodesPerCell2];
    m2.getFaceCoords( fId2, &x2[0] );
    m2.getFaceNodalVelocities( fId2, &v2[0] );
 
@@ -98,31 +98,31 @@ real ComputeGapRatePressure( ContactPlaneManager& cpMgr,
    // compute velocity Galerkin approximation at projected // 
    // overlap centroid                                     //
    //////////////////////////////////////////////////////////
-   real vel_f1[dim];
-   real vel_f2[dim];
+   RealT vel_f1[dim];
+   RealT vel_f2[dim];
    initRealArray( &vel_f1[0], dim, 0. );
    initRealArray( &vel_f2[0], dim, 0. );
 
    // interpolate nodal velocity at overlap centroid as projected 
    // onto face 1
-   double cXf1 = cpMgr.m_cXf1[cpID];
-   double cYf1 = cpMgr.m_cYf1[cpID];
-   double cZf1 = (dim == 3) ? cpMgr.m_cZf1[cpID] : 0.;
+   RealT cXf1 = cpMgr.m_cXf1[cpID];
+   RealT cYf1 = cpMgr.m_cYf1[cpID];
+   RealT cZf1 = (dim == 3) ? cpMgr.m_cZf1[cpID] : 0.;
    GalerkinEval( &x1[0], cXf1, cYf1, cZf1,
                  LINEAR, PHYSICAL, dim, dim, 
                  &v1[0], &vel_f1[0] );
 
    // interpolate nodal velocity at overlap centroid as projected 
    // onto face 2
-   double cXf2 = cpMgr.m_cXf2[cpID];
-   double cYf2 = cpMgr.m_cYf2[cpID];
-   double cZf2 = (dim == 3) ? cpMgr.m_cZf2[cpID] : 0.;
+   RealT cXf2 = cpMgr.m_cXf2[cpID];
+   RealT cYf2 = cpMgr.m_cYf2[cpID];
+   RealT cZf2 = (dim == 3) ? cpMgr.m_cZf2[cpID] : 0.;
    GalerkinEval( &x2[0], cXf2, cYf2, cZf2,
                  LINEAR, PHYSICAL, dim, dim, 
                  &v2[0], &vel_f2[0] );
 
    // compute velocity gap vector
-   double velGap[dim];
+   RealT velGap[dim];
    velGap[0] = vel_f1[0] - vel_f2[0];
    velGap[1] = vel_f1[1] - vel_f2[1];
    if (dim == 3)
@@ -160,34 +160,34 @@ template< >
 int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    LoggingLevel logLevel = cs->getLoggingLevel(); 
 
    ////////////////////////////////
    // Grab pointers to mesh data //
    ////////////////////////////////
-   IndexType const meshId1 = cs->getMeshId1();
-   IndexType const meshId2 = cs->getMeshId2();
+   IndexT const meshId1 = cs->getMeshId1();
+   IndexT const meshId2 = cs->getMeshId2();
 
    MeshData& mesh1 = meshManager.GetMeshInstance( meshId1 );
    MeshData& mesh2 = meshManager.GetMeshInstance( meshId2 );
-   IndexType const numNodesPerFace = mesh1.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mesh1.m_numNodesPerCell;
 
-   real * const fx1 = mesh1.m_forceX;
-   real * const fy1 = mesh1.m_forceY; 
-   real * const fz1 = mesh1.m_forceZ; 
-   IndexType const * const nodalConnectivity1 = mesh1.m_connectivity;
+   RealT * const fx1 = mesh1.m_forceX;
+   RealT * const fy1 = mesh1.m_forceY; 
+   RealT * const fz1 = mesh1.m_forceZ; 
+   IndexT const * const nodalConnectivity1 = mesh1.m_connectivity;
 
-   real * const fx2 = mesh2.m_forceX; 
-   real * const fy2 = mesh2.m_forceY;
-   real * const fz2 = mesh2.m_forceZ;
-   IndexType const * nodalConnectivity2 = mesh2.m_connectivity;
+   RealT * const fx2 = mesh2.m_forceX; 
+   RealT * const fy2 = mesh2.m_forceY;
+   RealT * const fz2 = mesh2.m_forceZ;
+   IndexT const * nodalConnectivity2 = mesh2.m_connectivity;
 
 
    ///////////////////////////////
@@ -196,7 +196,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
    int cpID = 0;
    int err = 0;
    bool neg_thickness {false};
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -206,15 +206,15 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
-      real gap = cpManager.m_gap[ cpID ];
-      real A = cpManager.m_area[ cpID ]; // face-pair overlap area
+      RealT gap = cpManager.m_gap[ cpID ];
+      RealT A = cpManager.m_area[ cpID ]; // face-pair overlap area
 
       // don't proceed for gaps that don't violate the constraints. This check 
       // allows for numerically zero interpenetration.
-      real gap_tol = cs->getGapTol( index1, index2 );
+      RealT gap_tol = cs->getGapTol( index1, index2 );
 
       if ( gap > gap_tol )
       {
@@ -228,17 +228,17 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       }
 
       // debug force sums
-      real dbg_sum_force1 {0.};
-      real dbg_sum_force2 {0.};
+      RealT dbg_sum_force1 {0.};
+      RealT dbg_sum_force2 {0.};
 
       /////////////////////////////////////////////
       // kinematic penalty stiffness calculation //
       /////////////////////////////////////////////
-      real penalty_stiff_per_area {0.};
+      RealT penalty_stiff_per_area {0.};
       const EnforcementOptions& enforcement_options = const_cast<EnforcementOptions&>(cs->getEnforcementOptions());
       const PenaltyEnforcementOptions& pen_enfrc_options = enforcement_options.penalty_options;
-      real pen_scale1 = mesh1.m_elemData.m_penalty_scale;
-      real pen_scale2 = mesh2.m_elemData.m_penalty_scale;
+      RealT pen_scale1 = mesh1.m_elemData.m_penalty_scale;
+      RealT pen_scale2 = mesh2.m_elemData.m_penalty_scale;
       switch (pen_enfrc_options.kinematic_calculation)
       {
          case KINEMATIC_CONSTANT: 
@@ -280,7 +280,7 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       ////////////////////////////////////////////////////
 
       // compute total pressure based on constraint type
-      real totalPressure = 0.;
+      RealT totalPressure = 0.;
       cpManager.m_pressure[ cpID ] = gap * penalty_stiff_per_area; // kinematic contribution
       switch(pen_enfrc_options.constraint_type)
       {
@@ -316,9 +316,9 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       ///////////////////////////////////////////
 
       // construct array of nodal coordinates
-      real xf1[ dim * numNodesPerFace ];
-      real xf2[ dim * numNodesPerFace ];
-      real xVert[dim * cpManager.m_numPolyVert[cpID]];  
+      RealT xf1[ dim * numNodesPerFace ];
+      RealT xf2[ dim * numNodesPerFace ];
+      RealT xVert[dim * cpManager.m_numPolyVert[cpID]];  
 
       initRealArray( &xf1[0], dim*numNodesPerFace, 0. );
       initRealArray( &xf2[0], dim*numNodesPerFace, 0. );
@@ -346,9 +346,9 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
                                     meshId1, meshId2, index1, index2 );
 
       // set SurfaceContactElem face normals and overlap normal
-      real faceNormal1[dim];
-      real faceNormal2[dim];
-      real overlapNormal[dim];
+      RealT faceNormal1[dim];
+      RealT faceNormal2[dim];
+      RealT overlapNormal[dim];
 
       mesh1.getFaceNormal( index1, dim, &faceNormal1[0] );
       mesh2.getFaceNormal( index2, dim, &faceNormal2[0] );
@@ -359,8 +359,8 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       cntctElem.overlapNormal = &overlapNormal[0];
 
       // create arrays to hold nodal residual weak form integral evaluations
-      real phi1[numNodesPerFace];
-      real phi2[numNodesPerFace];
+      RealT phi1[numNodesPerFace];
+      RealT phi2[numNodesPerFace];
       initRealArray( &phi1[0], numNodesPerFace, 0. );
       initRealArray( &phi2[0], numNodesPerFace, 0. );
 
@@ -377,14 +377,14 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       //  contact pressure, and overlap area)                              //
       ///////////////////////////////////////////////////////////////////////
 
-      real phi_sum_1 = 0.;
-      real phi_sum_2 = 0.;
+      RealT phi_sum_1 = 0.;
+      RealT phi_sum_2 = 0.;
 
       // compute contact force (spring force)
-      real contact_force = totalPressure * A;
-      real force_x = overlapNormal[0] * contact_force;
-      real force_y = overlapNormal[1] * contact_force;
-      real force_z = 0.;
+      RealT contact_force = totalPressure * A;
+      RealT force_x = overlapNormal[0] * contact_force;
+      RealT force_y = overlapNormal[1] * contact_force;
+      RealT force_z = 0.;
       if (dim == 3)
       {
          force_z = overlapNormal[2] * contact_force;
@@ -393,11 +393,11 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
       //////////////////////////////////////////////////////
       // loop over nodes and compute contact nodal forces //
       //////////////////////////////////////////////////////
-      for( IndexType a=0 ; a < numNodesPerFace ; ++a )
+      for( IndexT a=0 ; a < numNodesPerFace ; ++a )
       {
 
-        IndexType node0 = nodalConnectivity1[ index1*numNodesPerFace + a ];
-        IndexType node1 = nodalConnectivity2[ index2*numNodesPerFace + a ];
+        IndexT node0 = nodalConnectivity1[ index1*numNodesPerFace + a ];
+        IndexT node1 = nodalConnectivity2[ index2*numNodesPerFace + a ];
 
         if (logLevel == TRIBOL_DEBUG)
         {
@@ -405,13 +405,13 @@ int ApplyNormal< COMMON_PLANE, PENALTY >( CouplingScheme const * cs )
            phi_sum_2 += phi2[a];
         }
  
-        const real nodal_force_x1 = force_x * phi1[a];
-        const real nodal_force_y1 = force_y * phi1[a];
-        const real nodal_force_z1 = force_z * phi1[a];
+        const RealT nodal_force_x1 = force_x * phi1[a];
+        const RealT nodal_force_y1 = force_y * phi1[a];
+        const RealT nodal_force_z1 = force_z * phi1[a];
 
-        const real nodal_force_x2 = force_x * phi2[a];
-        const real nodal_force_y2 = force_y * phi2[a];
-        const real nodal_force_z2 = force_z * phi2[a];
+        const RealT nodal_force_x2 = force_x * phi2[a];
+        const RealT nodal_force_y2 = force_y * phi2[a];
+        const RealT nodal_force_z2 = force_z * phi2[a];
 
         if (logLevel == TRIBOL_DEBUG)
         {

--- a/src/tribol/physics/CommonPlane.hpp
+++ b/src/tribol/physics/CommonPlane.hpp
@@ -24,8 +24,8 @@ namespace tribol
  * \pre Bulk modulus and element thickness arrays are registered by host code 
  *
  */
-real ComputePenaltyStiffnessPerArea( const real K1_over_t1,
-                                     const real K2_over_t2 );
+RealT ComputePenaltyStiffnessPerArea( const RealT K1_over_t1,
+                                      const RealT K2_over_t2 );
 
 /*!
  *

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -41,12 +41,12 @@ void ComputeMortarWeights( SurfaceContactElem & elem )
 //   TWBPolyInt( elem, integ, 3 );
 
    // get individual arrays of coordinates for each face
-   real x1[elem.numFaceVert];
-   real y1[elem.numFaceVert];
-   real z1[elem.numFaceVert];
-   real x2[elem.numFaceVert];
-   real y2[elem.numFaceVert];
-   real z2[elem.numFaceVert];
+   RealT x1[elem.numFaceVert];
+   RealT y1[elem.numFaceVert];
+   RealT z1[elem.numFaceVert];
+   RealT x2[elem.numFaceVert];
+   RealT y2[elem.numFaceVert];
+   RealT z2[elem.numFaceVert];
 
    for (int i=0; i<elem.numFaceVert; ++i)
    {
@@ -62,7 +62,7 @@ void ComputeMortarWeights( SurfaceContactElem & elem )
    // also initializes the array
    elem.allocateMortarWts();
 
-   real phiNonmortarA, phiNonmortarB, phiMortarA;
+   RealT phiNonmortarA, phiNonmortarB, phiMortarA;
 
    // loop over number of nodes on the nonmortar or mortar depending on whether forming 
    // nonmortar/nonmortar or mortar/nonmortar weights
@@ -84,8 +84,8 @@ void ComputeMortarWeights( SurfaceContactElem & elem )
             // integration point (as projected onto the current configuration 
             // face) to obtain a (xi,eta) coordinate pair in parent space 
             // for the evaluation of Lagrange shape functions
-            real xp[3] = { integ.xy[elem.dim*ip], integ.xy[elem.dim*ip+1], integ.xy[elem.dim*ip+2] };
-            real xi[2] = { 0., 0. };
+            RealT xp[3] = { integ.xy[elem.dim*ip], integ.xy[elem.dim*ip+1], integ.xy[elem.dim*ip+2] };
+            RealT xi[2] = { 0., 0. };
 
             InvIso( xp, x1, y1, z1, elem.numFaceVert, xi );
             LinIsoQuadShapeFunc( xi[0], xi[1], a, phiMortarA );
@@ -123,7 +123,7 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
    // get mesh instance to store gaps on mesh data object
    MeshManager& meshManager = MeshManager::getInstance();
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( elem.meshId2 );
-   IndexType const * const nonmortarConn = nonmortarMesh.m_connectivity;
+   IndexT const * const nonmortarConn = nonmortarMesh.m_connectivity;
 
    // will populate local gaps on nonmortar face on nonmortar mesh data object
    SLIC_ERROR_IF(nonmortarMesh.m_nodalFields.m_node_gap == nullptr,
@@ -139,11 +139,11 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
    for (int a=0; a<elem.numFaceVert; ++a)
    {
       // initialize gap1 and gap2 terms
-      real g1 = 0.;
-      real g2 = 0.;
+      RealT g1 = 0.;
+      RealT g2 = 0.;
 
       // get global nonmortar node number from connectivity
-      real nrml_a[elem.dim];
+      RealT nrml_a[elem.dim];
       int glbId = nonmortarConn[ elem.numFaceVert * elem.faceId2 + a ];
       nrml_a[0] = nonmortarMesh.m_node_nX[ glbId ];
       nrml_a[1] = nonmortarMesh.m_node_nY[ glbId ];
@@ -160,8 +160,8 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
          // a = mortar node and b = nonmortar node, BUT FOR THE GAP COMPUTATION,
          // THE SUM OF MORTAR WEIGHTS IS ACTUALLY OVER SHAPE FUNCTIONS 
          // DEFINED AT NODE "b", SO WE NEED TO USE (n_ab)^T.
-         real nab_1 = elem.getNonmortarMortarWt( a, b ); // nonmortar-mortar weight
-         real nab_2 = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight
+         RealT nab_1 = elem.getNonmortarMortarWt( a, b ); // nonmortar-mortar weight
+         RealT nab_2 = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight
 
          g1 += dotProd( &nrml_a[0], &elem.faceCoords1[ elem.dim * b ], elem.dim ) *
                nab_1;
@@ -180,34 +180,34 @@ void ComputeNodalGap< SINGLE_MORTAR >( SurfaceContactElem & elem )
 void ComputeSingleMortarGaps( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    ////////////////////////////////////////////////////////////////////////
    //
    // Grab pointers to mesh data
    //
    ////////////////////////////////////////////////////////////////////////
-   IndexType const mortarId = cs->getMeshId1();
-   IndexType const nonmortarId = cs->getMeshId2();
+   IndexT const mortarId = cs->getMeshId1();
+   IndexT const nonmortarId = cs->getMeshId2();
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarId );
-   IndexType const numNodesPerFace = mortarMesh.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mortarMesh.m_numNodesPerCell;
 
-   real const * const x1 = mortarMesh.m_positionX;
-   real const * const y1 = mortarMesh.m_positionY; 
-   real const * const z1 = mortarMesh.m_positionZ; 
-   IndexType const * const mortarConn= mortarMesh.m_connectivity;
+   RealT const * const x1 = mortarMesh.m_positionX;
+   RealT const * const y1 = mortarMesh.m_positionY; 
+   RealT const * const z1 = mortarMesh.m_positionZ; 
+   IndexT const * const mortarConn= mortarMesh.m_connectivity;
 
-   real const * const x2 = nonmortarMesh.m_positionX; 
-   real const * const y2 = nonmortarMesh.m_positionY;
-   real const * const z2 = nonmortarMesh.m_positionZ;
-   IndexType const * nonmortarConn = nonmortarMesh.m_connectivity;
+   RealT const * const x2 = nonmortarMesh.m_positionX; 
+   RealT const * const y2 = nonmortarMesh.m_positionY;
+   RealT const * const z2 = nonmortarMesh.m_positionZ;
+   IndexT const * nonmortarConn = nonmortarMesh.m_connectivity;
 
    // compute nodal normals (do this outside the element loop)
    // Note, this is guarded against zero element meshes
@@ -215,20 +215,20 @@ void ComputeSingleMortarGaps( CouplingScheme const * cs )
 
    // declare local variables to hold face nodal coordinates
    // and overlap vertex coordinates
-   IndexType size = dim * numNodesPerFace;
-   real mortarX[ size ];
-   real nonmortarX[ size ];
+   IndexT size = dim * numNodesPerFace;
+   RealT mortarX[ size ];
+   RealT nonmortarX[ size ];
 
    // projected coords
-   real mortarX_bar[ size ];
-   real nonmortarX_bar[ size ];
-   real* overlapX;
+   RealT mortarX_bar[ size ];
+   RealT nonmortarX_bar[ size ];
+   RealT* overlapX;
 
    ////////////////////////////////////////////////////////////////////
    // compute nonmortar gaps to determine active set of contact dofs //
    ////////////////////////////////////////////////////////////////////
    int cpID = 0;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -238,16 +238,16 @@ void ComputeSingleMortarGaps( CouplingScheme const * cs )
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
       // populate the current configuration nodal coordinates for the 
       // two faces
       for (int i=0; i<numNodesPerFace; ++i)
       {
          int id = dim * i;
-         IndexType mortar_id = mortarConn[ numNodesPerFace * index1 + i ];
-         IndexType nonmortar_id  = nonmortarConn[ numNodesPerFace * index2 + i ];
+         IndexT mortar_id = mortarConn[ numNodesPerFace * index1 + i ];
+         IndexT nonmortar_id  = nonmortarConn[ numNodesPerFace * index2 + i ];
 
          mortarX[ id ]   = x1[ mortar_id ];
          mortarX[ id+1 ] = y1[ mortar_id ];
@@ -265,7 +265,7 @@ void ComputeSingleMortarGaps( CouplingScheme const * cs )
          nonmortarX_bar[ id+2 ] = z2[ nonmortar_id ];
       }
 
-      overlapX = new real[ dim * cpManager.m_numPolyVert[ cpID ]];
+      overlapX = new RealT[ dim * cpManager.m_numPolyVert[ cpID ]];
       initRealArray( overlapX, dim*cpManager.m_numPolyVert[cpID], 0. );
 
       // get projected face coordinates
@@ -317,45 +317,45 @@ template< >
 int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    MeshManager& meshManager = MeshManager::getInstance();
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
    ////////////////////////////////
    //                            //
    // Grab pointers to mesh data //
    //                            //
    ////////////////////////////////
-   IndexType const mortarId = cs->getMeshId1();
-   IndexType const nonmortarId = cs->getMeshId2();
+   IndexT const mortarId = cs->getMeshId1();
+   IndexT const nonmortarId = cs->getMeshId2();
 
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( nonmortarId );
-   IndexType const numNodesPerFace = mortarMesh.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mortarMesh.m_numNodesPerCell;
 
-   real const * const x1 = mortarMesh.m_positionX;
-   real const * const y1 = mortarMesh.m_positionY; 
-   real const * const z1 = mortarMesh.m_positionZ; 
-   real * const fx1 = mortarMesh.m_forceX;
-   real * const fy1 = mortarMesh.m_forceY; 
-   real * const fz1 = mortarMesh.m_forceZ; 
-   IndexType const * const mortarConn= mortarMesh.m_connectivity;
+   RealT const * const x1 = mortarMesh.m_positionX;
+   RealT const * const y1 = mortarMesh.m_positionY; 
+   RealT const * const z1 = mortarMesh.m_positionZ; 
+   RealT * const fx1 = mortarMesh.m_forceX;
+   RealT * const fy1 = mortarMesh.m_forceY; 
+   RealT * const fz1 = mortarMesh.m_forceZ; 
+   IndexT const * const mortarConn= mortarMesh.m_connectivity;
 
-   real const * const x2 = nonmortarMesh.m_positionX; 
-   real const * const y2 = nonmortarMesh.m_positionY;
-   real const * const z2 = nonmortarMesh.m_positionZ;
-   real * const fx2 = nonmortarMesh.m_forceX; 
-   real * const fy2 = nonmortarMesh.m_forceY;
-   real * const fz2 = nonmortarMesh.m_forceZ;
-   IndexType const * nonmortarConn = nonmortarMesh.m_connectivity;
+   RealT const * const x2 = nonmortarMesh.m_positionX; 
+   RealT const * const y2 = nonmortarMesh.m_positionY;
+   RealT const * const z2 = nonmortarMesh.m_positionZ;
+   RealT * const fx2 = nonmortarMesh.m_forceX; 
+   RealT * const fy2 = nonmortarMesh.m_forceY;
+   RealT * const fz2 = nonmortarMesh.m_forceZ;
+   IndexT const * nonmortarConn = nonmortarMesh.m_connectivity;
 
    // projected coords
-   real mortarX_bar[ dim * numNodesPerFace ];
-   real nonmortarX_bar[ dim * numNodesPerFace ];
-   real* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
+   RealT mortarX_bar[ dim * numNodesPerFace ];
+   RealT nonmortarX_bar[ dim * numNodesPerFace ];
+   RealT* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
 
    ///////////////////////////////////////////////////////
    //                                                   //
@@ -396,7 +396,7 @@ int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs
    //                                                            //
    ////////////////////////////////////////////////////////////////
    int cpID = 0;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -406,16 +406,16 @@ int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
       // populate the current configuration nodal coordinates for the 
       // two faces
       for (int i=0; i<numNodesPerFace; ++i)
       {
          int id = dim * i;
-         IndexType mortar_id = mortarConn[ numNodesPerFace * index1 + i];
-         IndexType nonmortar_id = nonmortarConn[ numNodesPerFace * index2 + i ]; 
+         IndexT mortar_id = mortarConn[ numNodesPerFace * index1 + i];
+         IndexT nonmortar_id = nonmortarConn[ numNodesPerFace * index2 + i ]; 
          // arrays for projected coords
          mortarX_bar[ id ]   = x1[ mortar_id ];
          mortarX_bar[ id+1 ] = y1[ mortar_id ];
@@ -425,7 +425,7 @@ int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs
          nonmortarX_bar[ id+2 ] = z2[ nonmortar_id ];
       }
 
-      overlapX = new real[ dim * cpManager.m_numPolyVert[ cpID ]];
+      overlapX = new RealT[ dim * cpManager.m_numPolyVert[ cpID ]];
       initRealArray( overlapX, dim*cpManager.m_numPolyVert[cpID], 0. );
 
       // get projected face coordinates
@@ -473,11 +473,11 @@ int ApplyNormal< SINGLE_MORTAR, LAGRANGE_MULTIPLIER >( CouplingScheme const * cs
             // in the computation after the geometric filtering and judge contact 
             // activity based on the gap AND the pressure solution
 
-            real forceX = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
+            RealT forceX = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
                           nonmortarMesh.m_node_nX[ nonmortarIdB ];
-            real forceY = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
+            RealT forceY = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
                           nonmortarMesh.m_node_nY[ nonmortarIdB ];
-            real forceZ = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
+            RealT forceZ = nonmortarMesh.m_nodalFields.m_node_pressure[ nonmortarIdB ] * 
                           nonmortarMesh.m_node_nZ[ nonmortarIdB ];
 
             // contact nodal force is the interpolated force using mortar 
@@ -546,7 +546,7 @@ void ComputeResidualJacobian< SINGLE_MORTAR, DUAL >( SurfaceContactElem & elem )
 {
    MeshManager& meshManager = MeshManager::getInstance();
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( elem.meshId2 );
-   IndexType const * const nonmortarConn = nonmortarMesh.m_connectivity;
+   IndexT const * const nonmortarConn = nonmortarMesh.m_connectivity;
 
    // loop over "a" nodes accumulating sums of mortar/nonmortar 
    // and nonmortar/nonmortar weights
@@ -558,7 +558,7 @@ void ComputeResidualJacobian< SINGLE_MORTAR, DUAL >( SurfaceContactElem & elem )
       {
          // get global nonmortar node id to index into nodal normals on 
          // nonmortar mesh
-         real nrml_b[elem.dim];
+         RealT nrml_b[elem.dim];
          int glbId = nonmortarConn[ elem.numFaceVert * elem.faceId2 + b ];
 
          // We assemble ALL nonmortar node contributions, even if gap is in separation.
@@ -575,38 +575,38 @@ void ComputeResidualJacobian< SINGLE_MORTAR, DUAL >( SurfaceContactElem & elem )
          }
 
          // get mortar-nonmortar and nonmortar-nonmortar mortar weights
-         real n_mortar_b = elem.getMortarNonmortarWt( a, b ); // mortar-nonmortar weight
-         real n_nonmortar_b  = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight, note negative in formulation
+         RealT n_mortar_b = elem.getMortarNonmortarWt( a, b ); // mortar-nonmortar weight
+         RealT n_nonmortar_b  = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight, note negative in formulation
          
          // fill Jrp element-pair Jacobian blocks
          // Fill block (0, 2)
          int elem_xdof = elem.getJacobianIndex(SurfaceContactElem::JrpBlock, a, b );
          int dim_offset = elem.getJacobianDimOffset(SurfaceContactElem::JrpBlock);
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof ]                += nrml_b[0] * n_mortar_b;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof + dim_offset ]   += nrml_b[1] * n_mortar_b;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::MORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::MORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof + 2*dim_offset ] += nrml_b[2] * n_mortar_b;
 
          // Fill block (1, 2)
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof ]                -= nrml_b[0] * n_nonmortar_b;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof + dim_offset ]   -= nrml_b[1] * n_nonmortar_b;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR),
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER)
+            static_cast<IndexT>(BlockSpace::NONMORTAR),
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER)
          ).Data()[ elem_xdof + 2*dim_offset ] -= nrml_b[2] * n_nonmortar_b;
 
       } // end loop over b nodes
@@ -622,7 +622,7 @@ void ComputeConstraintJacobian< SINGLE_MORTAR, PRIMAL >( SurfaceContactElem & el
 {
    MeshManager& meshManager = MeshManager::getInstance();
    MeshData& nonmortarMesh = meshManager.GetMeshInstance( elem.meshId2 );
-   IndexType const * const nonmortarConn = nonmortarMesh.m_connectivity;
+   IndexT const * const nonmortarConn = nonmortarMesh.m_connectivity;
 
    // loop over nonmortar nodes for which we are accumulating Jacobian 
    // contributions
@@ -630,7 +630,7 @@ void ComputeConstraintJacobian< SINGLE_MORTAR, PRIMAL >( SurfaceContactElem & el
    {
       // get global nonmortar node id to index into nodal normals on 
       // nonmortar mesh
-      real nrml_a[elem.dim];
+      RealT nrml_a[elem.dim];
       int glbId = nonmortarConn[ elem.numFaceVert * elem.faceId2 + a ];
 
       // We assemble ALL nonmortar node contributions even if gap is in separation.
@@ -651,38 +651,38 @@ void ComputeConstraintJacobian< SINGLE_MORTAR, PRIMAL >( SurfaceContactElem & el
       for (int b = 0; b<elem.numFaceVert; ++b)
       {
          // get nonmortar-mortar and nonmortar-nonmortar mortar weights
-         real n_mortar_a = elem.getNonmortarMortarWt( a, b ); // nonmortar-mortar weight
-         real n_nonmortar_a  = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight, note negative in formulation
+         RealT n_mortar_a = elem.getNonmortarMortarWt( a, b ); // nonmortar-mortar weight
+         RealT n_nonmortar_a  = elem.getNonmortarNonmortarWt( a, b ); // nonmortar-nonmortar weight, note negative in formulation
 
          // fill Jgu element-pair Jacobian blocks
          // Fill block (2, 0)
          int dim_offset = elem.getJacobianDimOffset(SurfaceContactElem::JguBlock);
          int elem_xdof = elem.getJacobianIndex(SurfaceContactElem::JguBlock, a, b );
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ elem_xdof ]                += nrml_a[0] * n_mortar_a;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ elem_xdof + dim_offset ]   += nrml_a[1] * n_mortar_a;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::MORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::MORTAR)
          ).Data()[ elem_xdof + 2*dim_offset ] += nrml_a[2] * n_mortar_a;
 
          // Fill block (2, 1)
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ elem_xdof ]                -= nrml_a[0] * n_nonmortar_a;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ elem_xdof + dim_offset ]   -= nrml_a[1] * n_nonmortar_a;
          elem.blockJ(
-            static_cast<axom::IndexType>(BlockSpace::LAGRANGE_MULTIPLIER),
-            static_cast<axom::IndexType>(BlockSpace::NONMORTAR)
+            static_cast<IndexT>(BlockSpace::LAGRANGE_MULTIPLIER),
+            static_cast<IndexT>(BlockSpace::NONMORTAR)
          ).Data()[ elem_xdof + 2*dim_offset ] -= nrml_a[2] * n_nonmortar_a;
 
       } // end loop over b nodes
@@ -726,17 +726,17 @@ template< >
 int GetMethodData< MORTAR_WEIGHTS >( CouplingScheme const * cs )
 {
    InterfacePairs const * const pairs = cs->getInterfacePairs();
-   IndexType const numPairs = pairs->getNumPairs();
+   IndexT const numPairs = pairs->getNumPairs();
 
    ContactPlaneManager& cpManager = ContactPlaneManager::getInstance();
    parameters_t& parameters = parameters_t::getInstance();
-   integer const dim = parameters.dimension;
+   int const dim = parameters.dimension;
 
-   IndexType const mortarId = cs->getMeshId1();
-   IndexType const nonmortarId = cs->getMeshId2();
+   IndexT const mortarId = cs->getMeshId1();
+   IndexT const nonmortarId = cs->getMeshId2();
    MeshManager& meshManager = MeshManager::getInstance();
    MeshData& mortarMesh = meshManager.GetMeshInstance( mortarId );
-   IndexType const numNodesPerFace = mortarMesh.m_numNodesPerCell;
+   IndexT const numNodesPerFace = mortarMesh.m_numNodesPerCell;
 
    ////////////////////////////////
    //                            //
@@ -756,18 +756,18 @@ int GetMethodData< MORTAR_WEIGHTS >( CouplingScheme const * cs )
 
    // declare local variables to hold face nodal coordinates
    // and overlap vertex coordinates
-   IndexType size = dim * numNodesPerFace;
+   IndexT size = dim * numNodesPerFace;
 
    // projected coords
-   real mortarX_bar[ size ];
-   real nonmortarX_bar[ size ];
+   RealT mortarX_bar[ size ];
+   RealT nonmortarX_bar[ size ];
    initRealArray( &mortarX_bar[0], size, 0. );
    initRealArray( &nonmortarX_bar[0], size, 0. );
 
-   real* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
+   RealT* overlapX; // [dim * cpManager.m_numPolyVert[cpID]];  
 
    int cpID = 0;
-   for (IndexType kp = 0; kp < numPairs; ++kp)
+   for (IndexT kp = 0; kp < numPairs; ++kp)
    {
       InterfacePair pair = pairs->getInterfacePair(kp);
 
@@ -777,10 +777,10 @@ int GetMethodData< MORTAR_WEIGHTS >( CouplingScheme const * cs )
       }
 
       // get pair indices
-      IndexType index1 = pair.pairIndex1;
-      IndexType index2 = pair.pairIndex2;
+      IndexT index1 = pair.pairIndex1;
+      IndexT index2 = pair.pairIndex2;
 
-      overlapX = new real[ dim * cpManager.m_numPolyVert[ cpID ]];
+      overlapX = new RealT[ dim * cpManager.m_numPolyVert[ cpID ]];
       initRealArray( overlapX, dim*cpManager.m_numPolyVert[cpID], 0. );
 
       // get projected face coordinates

--- a/src/tribol/physics/Physics.cpp
+++ b/src/tribol/physics/Physics.cpp
@@ -19,8 +19,8 @@ namespace tribol
 {
 
 int ApplyInterfacePhysics( CouplingScheme const * cs,
-                           integer TRIBOL_UNUSED_PARAM(cycle),
-                           real TRIBOL_UNUSED_PARAM(t) )
+                           int TRIBOL_UNUSED_PARAM(cycle),
+                           RealT TRIBOL_UNUSED_PARAM(t) )
 {
    // call the appropriate normal and tangential interface physics
    // routines based on method, enforcement strategy, and interface

--- a/src/tribol/physics/Physics.hpp
+++ b/src/tribol/physics/Physics.hpp
@@ -29,7 +29,7 @@ class CouplingScheme;
  *
  */
 int ApplyInterfacePhysics( CouplingScheme const * cs,
-                           integer cycle, real t );
+                           int cycle, RealT t );
 /*!
  *
  * \brief applies interface method in the normal direction

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -17,13 +17,11 @@
 #include "axom/slam.hpp"
 #include "axom/primal.hpp"
 #include "axom/spin.hpp"
-#include "axom/quest.hpp"
 
 // Define some namespace aliases to help with axom usage
 namespace slam = axom::slam;
 namespace primal = axom::primal;
 namespace spin = axom::spin;
-namespace quest = axom::quest;
 
 namespace tribol
 {
@@ -34,10 +32,10 @@ namespace tribol
 bool geomFilter( InterfacePair & iPair, ContactMode const mode )
 {
    // alias variables off the InterfacePair
-   integer const & meshId1 = iPair.meshId1;
-   integer const & meshId2 = iPair.meshId2;
-   integer const & faceId1 = iPair.pairIndex1;
-   integer const & faceId2 = iPair.pairIndex2;
+   int const & meshId1 = iPair.meshId1;
+   int const & meshId2 = iPair.meshId2;
+   int const & faceId1 = iPair.pairIndex1;
+   int const & faceId2 = iPair.pairIndex2;
 
    /// CHECK #1: Check to make sure the two face ids are not the same
    ///           and the two mesh ids are not the same.
@@ -77,9 +75,9 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
 
    /// CHECK #3: Check that face normals are opposing up to some tolerance.
    ///           This uses a hard coded normal tolerance for this check.
-   real nrmlTol = -0.173648177; // taken as cos(100) between face pair
+   RealT nrmlTol = -0.173648177; // taken as cos(100) between face pair
 
-   real m_nZ1, m_nZ2;
+   RealT m_nZ1, m_nZ2;
    if ( dim == 3 )
    {
       m_nZ1 = mesh1.m_nZ[ faceId1 ];
@@ -91,7 +89,7 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
       m_nZ2 = 0.;
    }
 
-   real nrmlCheck = mesh1.m_nX[faceId1] * mesh2.m_nX[faceId2] +
+   RealT nrmlCheck = mesh1.m_nX[faceId1] * mesh2.m_nX[faceId2] +
                     mesh1.m_nY[faceId1] * mesh2.m_nY[faceId2] +
                     m_nZ1 * m_nZ2;
 
@@ -112,14 +110,14 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
    ///                The face radii are taken to be the magnitude of the
    ///                longest vector from that face's vertex averaged
    ///                centroid to one its nodes.
-   real offset_tol = 0.05;
+   RealT offset_tol = 0.05;
    if (dim == 3)
    {
-      real r1 = mesh1.m_faceRadius[ faceId1 ];
-      real r2 = mesh2.m_faceRadius[ faceId2 ];
+      RealT r1 = mesh1.m_faceRadius[ faceId1 ];
+      RealT r2 = mesh2.m_faceRadius[ faceId2 ];
 
       // set maximum offset of face centroids for inclusion
-      real distMax = r1 + r2; // default is sum of face radii
+      RealT distMax = r1 + r2; // default is sum of face radii
 
       // check if the contact mode is conforming, in which case the
       // faces are supposed to be aligned
@@ -131,11 +129,11 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
       }
 
       // compute the distance between the two face centroids
-      real distX = mesh2.m_cX[ faceId2 ] - mesh1.m_cX[ faceId1 ];
-      real distY = mesh2.m_cY[ faceId2 ] - mesh1.m_cY[ faceId1 ];
-      real distZ = mesh2.m_cZ[ faceId2 ] - mesh1.m_cZ[ faceId1 ];
+      RealT distX = mesh2.m_cX[ faceId2 ] - mesh1.m_cX[ faceId1 ];
+      RealT distY = mesh2.m_cY[ faceId2 ] - mesh1.m_cY[ faceId1 ];
+      RealT distZ = mesh2.m_cZ[ faceId2 ] - mesh1.m_cZ[ faceId1 ];
 
-      real distMag = magnitude(distX, distY, distZ );
+      RealT distMag = magnitude(distX, distY, distZ );
 
       if (distMag >= (distMax)) {
          iPair.isContactCandidate = false;
@@ -145,11 +143,11 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
    else if (dim == 2)
    {
       // get 1/2 edge length off the mesh data
-      real e1 = 0.5 * mesh1.m_area[ faceId1 ];
-      real e2 = 0.5 * mesh2.m_area[ faceId2 ];
+      RealT e1 = 0.5 * mesh1.m_area[ faceId1 ];
+      RealT e2 = 0.5 * mesh2.m_area[ faceId2 ];
 
       // set maximum offset of edge centroids for inclusion
-      real distMax = e1 + e2; // default is sum of 1/2 edge lengths
+      RealT distMax = e1 + e2; // default is sum of 1/2 edge lengths
 
       // check if the contact mode is conforming, in which case the
       // edges are supposed to be aligned
@@ -161,10 +159,10 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
       }
 
       // compute the distance between the two edge centroids
-      real distX = mesh2.m_cX[ faceId2 ] - mesh1.m_cX[ faceId1 ];
-      real distY = mesh2.m_cY[ faceId2 ] - mesh1.m_cY[ faceId1 ];
+      RealT distX = mesh2.m_cX[ faceId2 ] - mesh1.m_cX[ faceId1 ];
+      RealT distY = mesh2.m_cY[ faceId2 ] - mesh1.m_cY[ faceId1 ];
 
-      real distMag = magnitude(distX, distY);
+      RealT distMag = magnitude(distX, distY);
 
       if (distMag >= (distMax))
       {
@@ -193,16 +191,16 @@ template<int D>
 class MeshWrapper
 {
 private:
-   using VertSet = slam::PositionSet<IndexType>;
-   using ElemSet = slam::PositionSet<IndexType>;
-   using RTStride = slam::policies::RuntimeStride<IndexType>;
-   using Card = slam::policies::ConstantCardinality<IndexType, RTStride>;
-   using Ind = slam::policies::CArrayIndirection<IndexType, const IndexType>;
-   using ElemVertRelation = slam::StaticRelation<IndexType, IndexType, Card, Ind,ElemSet,VertSet>;
+   using VertSet = slam::PositionSet<IndexT>;
+   using ElemSet = slam::PositionSet<IndexT>;
+   using RTStride = slam::policies::RuntimeStride<IndexT>;
+   using Card = slam::policies::ConstantCardinality<IndexT, RTStride>;
+   using Ind = slam::policies::CArrayIndirection<IndexT, const IndexT>;
+   using ElemVertRelation = slam::StaticRelation<IndexT, IndexT, Card, Ind,ElemSet,VertSet>;
 
 public:
-   using PointType = primal::Point<real, D>;
-   using BBox = primal::BoundingBox<real, D>;
+   using PointType = primal::Point<double, D>;
+   using BBox = primal::BoundingBox<double, D>;
 
    MeshWrapper() : m_meshData(nullptr) {}
 
@@ -232,12 +230,12 @@ public:
     * \param vId Vertex Id
     * \return A primal Point instance
     */
-   PointType getVertex(IndexType vId)
+   PointType getVertex(IndexT vId)
    {
       return PointType::make_point(
-            m_meshData->m_positionX[vId],
-            m_meshData->m_positionY[vId],
-            (D == 3) ? m_meshData->m_positionZ[vId] : real() );
+            static_cast<double>(m_meshData->m_positionX[vId]),
+            static_cast<double>(m_meshData->m_positionY[vId]),
+            (D == 3) ? static_cast<double>(m_meshData->m_positionZ[vId]) : double() );
    }
 
    /*!
@@ -245,7 +243,7 @@ public:
     * \param vId Vertex Id
     * \return A primal BoundingBox instance
     */
-   BBox elementBoundingBox(IndexType eId)
+   BBox elementBoundingBox(IndexT eId)
    {
       BBox box;
 
@@ -258,10 +256,10 @@ public:
    }
 
    /*! Returns the number of vertices in the mesh */
-   integer numVerts() const { return m_vertSet.size(); }
+   int numVerts() const { return m_vertSet.size(); }
 
    /*! Returns the number of elements in the mesh */
-   integer numElems() const { return m_elemSet.size(); }
+   int numElems() const { return m_elemSet.size(); }
 
 private:
    const MeshData* m_meshData;
@@ -302,11 +300,11 @@ public:
    {
       MeshManager & meshManager = MeshManager::getInstance();
 
-      integer meshId1 = m_couplingScheme->getMeshId1();
+      int meshId1 = m_couplingScheme->getMeshId1();
       MeshData const & meshData1 = meshManager.GetMeshInstance(meshId1);
       m_meshWrapper1 = MeshWrapper<D>(&meshData1);
 
-      integer meshId2 = m_couplingScheme->getMeshId2();
+      int meshId2 = m_couplingScheme->getMeshId2();
       MeshData const & meshData2 = meshManager.GetMeshInstance(meshId2);
       m_meshWrapper2 = MeshWrapper<D>(&meshData2);
 
@@ -319,7 +317,7 @@ public:
    void generateSpatialIndex()
    {
       // TODO does this tolerance need to scale with the mesh?
-      const real bboxTolerance = 1e-6;
+      constexpr double bboxTolerance = 1e-6;
 
       // Find the bounding boxes of the elements in the first mesh
       // Store them in an array for efficient reuse
@@ -352,17 +350,17 @@ public:
       }
 
       // inflate grid box slightly so elem bounding boxes are not on grid bdry
-      m_gridBBox.scale(1 + bboxTolerance);
+      m_gridBBox.scale(1.0 + bboxTolerance);
 
       ranges /= m_meshWrapper1.numElems();
 
       // Compute grid resolution from average bbox size
       typename ImplicitGridType::GridCell resolution;
       SpaceVec bboxRange = m_gridBBox.range();
-      const real scaleFac = 0.5; // TODO is this mesh dependent?
+      const RealT scaleFac = 0.5; // TODO is this mesh dependent?
       for(int i=0; i < D; ++i)
       {
-         resolution[i] = static_cast<IndexType>(
+         resolution[i] = static_cast<IndexT>(
                std::ceil( scaleFac * bboxRange[i] / ranges[i] ));
       }
 
@@ -405,13 +403,13 @@ public:
       // Extract some mesh metadata from coupling scheme / mesh manageer
       MeshManager & meshManager = MeshManager::getInstance();
 
-      integer meshId1 = m_couplingScheme->getMeshId1();
+      int meshId1 = m_couplingScheme->getMeshId1();
       MeshData const & meshData1 = meshManager.GetMeshInstance(meshId1);
-      int cellType1 = static_cast<integer>(meshData1.m_elementType);
+      int cellType1 = static_cast<int>(meshData1.m_elementType);
 
-      integer meshId2 = m_couplingScheme->getMeshId2();
+      int meshId2 = m_couplingScheme->getMeshId2();
       MeshData const & meshData2 = meshManager.GetMeshInstance(meshId2);
-      int cellType2 = static_cast<integer>(meshData2.m_elementType);
+      int cellType2 = static_cast<int>(meshData2.m_elementType);
 
       InterfacePairs* contactPairs = m_couplingScheme->getInterfacePairs();
 
@@ -428,7 +426,7 @@ public:
          auto candidateBits = m_grid.getCandidates( bbox );
 
          // Add candidates
-         for(IndexType fromIdx = candidateBits.find_first() ;
+         for(IndexT fromIdx = candidateBits.find_first() ;
              fromIdx != BitsetType::npos ;
              fromIdx = candidateBits.find_next( fromIdx) )
          {
@@ -469,7 +467,7 @@ private:
       constexpr double sc = 1./3.;
 
       int d = bbox.getLongestDimension();
-      const real expansionFac =  sc * bbox.range()[d];
+      const double expansionFac =  sc * bbox.range()[d];
       bbox.expand(expansionFac);
    }
 
@@ -481,7 +479,7 @@ private:
 
    ImplicitGridType m_grid;
    SpatialBoundingBox m_gridBBox;
-   containerArray<SpatialBoundingBox> m_meshBBoxes1;
+   ArrayT<SpatialBoundingBox> m_meshBBoxes1;
 
 };
 
@@ -494,13 +492,13 @@ private:
  {
     MeshManager & meshManager = MeshManager::getInstance();
 
-    integer meshId1 = cs->getMeshId1();
+    int meshId1 = cs->getMeshId1();
     MeshData const & meshData1 = meshManager.GetMeshInstance(meshId1);
-    integer mesh1NumElems = meshData1.m_numCells;
+    int mesh1NumElems = meshData1.m_numCells;
 
-    integer meshId2 = cs->getMeshId2();
+    int meshId2 = cs->getMeshId2();
     MeshData const & meshData2 = meshManager.GetMeshInstance(meshId2);
-    integer mesh2NumElems = meshData2.m_numCells;
+    int mesh2NumElems = meshData2.m_numCells;
 
     int numPairs = mesh1NumElems * mesh2NumElems;
 
@@ -508,8 +506,8 @@ private:
     contactPairs->clear();
     contactPairs->reserve( numPairs );
 
-    int cellType1 = static_cast<integer>(meshData1.m_elementType);
-    int cellType2 = static_cast<integer>(meshData2.m_elementType);
+    int cellType1 = static_cast<int>(meshData1.m_elementType);
+    int cellType2 = static_cast<int>(meshData2.m_elementType);
 
     int k = 0;
     for(int fromIdx = 0; fromIdx < mesh1NumElems; ++fromIdx)

--- a/src/tribol/utils/ContactPlaneOutput.cpp
+++ b/src/tribol/utils/ContactPlaneOutput.cpp
@@ -54,9 +54,9 @@ int GetVtkElementId( const InterfaceElementType type )
 
 //------------------------------------------------------------------------------
 void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
-                                 const integer csId, const integer meshId1,
-                                 const integer meshId2, const integer dim,
-                                 const integer cycle, const real time )
+                                 const int csId, const int meshId1,
+                                 const int meshId2, const int dim,
+                                 const int cycle, const RealT time )
 {
    ContactPlaneManager& cpMgr = ContactPlaneManager::getInstance();
    MeshManager & meshManager = MeshManager::getInstance();
@@ -214,7 +214,7 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
          }
          faces << std::endl;
 
-         // print cell types as VTK integer IDs
+         // print cell types as VTK int IDs
          {
             fmt::print(faces, "CELL_TYPES {}\n", 2*cpSize);
             const int vtkid1 = dim==3? 7 : 3; // 7 is VTK_POLYGON; 3 is VTK_LINE
@@ -322,7 +322,7 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
             k += nVerts;
          }
 
-         // print cell types as VTK integer IDs
+         // print cell types as VTK int IDs
          {
             fmt::print(overlap, "CELL_TYPES {}\n", cpSize);
             const int vtkid = dim==3? 7 : 3; // 7 is VTK_POLYGON; 3 is VTK_LINE
@@ -456,7 +456,7 @@ void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type,
          mesh << std::endl;
       } // end i-loop over cells
 
-      // specify integer id for each cell type.
+      // specify int id for each cell type.
       // For 4-node quad, id = 9.
       const int mesh1_element_id = GetVtkElementId( mesh1.m_elementType );
       const int mesh2_element_id = GetVtkElementId( mesh2.m_elementType );

--- a/src/tribol/utils/ContactPlaneOutput.hpp
+++ b/src/tribol/utils/ContactPlaneOutput.hpp
@@ -7,6 +7,7 @@
 #define SRC_UTILS_CONTACTPLANEOUTPUT_HPP_
 
 #include "tribol/types.hpp"
+#include "tribol/common/Parameters.hpp"
 
 // AXOM includes
 #include "axom/slic.hpp" 
@@ -35,9 +36,9 @@ class ContactPlaneManager;
  *
  */
 void WriteContactPlaneMeshToVtk( const std::string& dir, const VisType v_type, 
-                                 const integer csId, const integer meshId1, 
-                                 const integer meshId2, const integer dim,
-                                 const integer cycle, const real t );
+                                 const int csId, const int meshId1, 
+                                 const int meshId2, const int dim,
+                                 const int cycle, const RealT t );
 
 
 } // end of namespace "tribol"

--- a/src/tribol/utils/Math.cpp
+++ b/src/tribol/utils/Math.cpp
@@ -14,17 +14,17 @@
 namespace tribol
 {
 
-real magnitude( real const vx, 
-                real const vy, 
-                real const vz )
+RealT magnitude( RealT const vx, 
+                RealT const vy, 
+                RealT const vz )
 {
    return sqrt(vx * vx + vy * vy + vz * vz);
 }
 
 //------------------------------------------------------------------------------
-real magnitude( real const * const v, int const dim )
+RealT magnitude( RealT const * const v, int const dim )
 {
-   real mag = 0.;
+   RealT mag = 0.;
    for (int i=0; i<dim; ++i)
    {
       mag += v[i] * v[i]; 
@@ -33,17 +33,17 @@ real magnitude( real const * const v, int const dim )
 }
 
 //------------------------------------------------------------------------------
-real magnitude( real const vx, real const vy )
+RealT magnitude( RealT const vx, RealT const vy )
 {
    return sqrt(vx * vx + vy * vy);
 }
 
 //------------------------------------------------------------------------------
-real dotProd( real const * const v, 
-              real const * const w, 
+RealT dotProd( RealT const * const v, 
+              RealT const * const w, 
               int const dim )
 {
-   real z = 0;
+   RealT z = 0;
    for (int i=0; i<dim; ++i)
    {
       z += v[i] * w[i]; 
@@ -53,26 +53,26 @@ real dotProd( real const * const v,
 }
 
 //------------------------------------------------------------------------------
-real dotProd( real const aX, real const aY, real const aZ,
-              real const bX, real const bY, real const bZ )
+RealT dotProd( RealT const aX, RealT const aY, RealT const aZ,
+              RealT const bX, RealT const bY, RealT const bZ )
 {
    return aX*bX + aY*bY + aZ*bZ;
 }
 
 //------------------------------------------------------------------------------
-real magCrossProd( real const a[3], real const b[3] )
+RealT magCrossProd( RealT const a[3], RealT const b[3] )
 {
-   real vi = a[1] * b[2] - a[2] * b[1];
-   real vj = a[2] * b[0] - a[0] * b[2];
-   real vk = a[0] * b[1] - a[1] * b[0];
+   RealT vi = a[1] * b[2] - a[2] * b[1];
+   RealT vj = a[2] * b[0] - a[0] * b[2];
+   RealT vk = a[0] * b[1] - a[1] * b[0];
 
    return magnitude( vi, vj, vk );
 }
 
 //------------------------------------------------------------------------------
-void crossProd( real const aX, real const aY, real const aZ,
-                real const bX, real const bY, real const bZ,
-                real &prodX, real &prodY, real &prodZ )
+void crossProd( RealT const aX, RealT const aY, RealT const aZ,
+                RealT const bX, RealT const bY, RealT const bZ,
+                RealT &prodX, RealT &prodY, RealT &prodZ )
 {
    prodX = aY * bZ - aZ * bY;
    prodY = aZ * bX - aX * bZ;
@@ -103,7 +103,7 @@ int binary_search( const int * const array,
    int R = n-1;
    while (L <= R)
    {
-      int m = floor((L + R) / 2);
+      int m = (L + R) / 2;
       if (array[m] < val)
       {
          L = m + 1;
@@ -148,17 +148,17 @@ void bubble_sort( int * const array,
 }
 
 //------------------------------------------------------------------------------
-void allocRealArray( real** arr, int length, real init_val )
+void allocRealArray( RealT** arr, int length, RealT init_val )
 {
    SLIC_ERROR_IF( length==0, "allocRealArray: please specify nonzero length " << 
                   "for array allocation." );
 
-   *arr = new real [length];
+   *arr = new RealT [length];
    initRealArray( *arr, length, init_val );
 }
 
 //------------------------------------------------------------------------------
-void allocRealArray( real** arr, const int length, const real* const data )
+void allocRealArray( RealT** arr, const int length, const RealT* const data )
 {
    SLIC_ERROR_IF( length==0, "allocRealArray: please specify nonzero length " << 
                   "for array allocation." );
@@ -168,7 +168,7 @@ void allocRealArray( real** arr, const int length, const real* const data )
       SLIC_ERROR( "allocRealArray: input data pointer not set." );
    }
 
-   *arr = new real[ length ];
+   *arr = new RealT[ length ];
 
    for (int i=0; i<length; ++i)
    {
@@ -220,7 +220,7 @@ void allocBoolArray( bool** arr, int length, bool init_val )
 }
 
 //------------------------------------------------------------------------------
-void initRealArray( real * arr, int length, real init_val )
+void initRealArray( RealT * arr, int length, RealT init_val )
 {
    SLIC_ERROR_IF( arr == nullptr, "initRealArray(): " << 
                   "input pointer to array is null." );

--- a/src/tribol/utils/Math.hpp
+++ b/src/tribol/utils/Math.hpp
@@ -12,46 +12,46 @@ namespace tribol
 {
 
 /// returns the magnitude of a 3-vector
-real magnitude( real const vx,  ///< [in] x-component of the input vector
-                real const vy,  ///< [in] y-component of the input vector
-                real const vz   ///< [in] z-component of the input vector
+RealT magnitude( RealT const vx,  ///< [in] x-component of the input vector
+                RealT const vy,  ///< [in] y-component of the input vector
+                RealT const vz   ///< [in] z-component of the input vector
               );
 
 /// returns the magnitude of a 2-vector
-real magnitude( real const vx,  ///< [in] x-component of the input vector
-                real const vy   ///< [in] y-component of the input vector
+RealT magnitude( RealT const vx,  ///< [in] x-component of the input vector
+                RealT const vy   ///< [in] y-component of the input vector
               );
 
 /// returns the dot product of two vectors
-real dotProd( real const * const v,  ///< [in] first vector
-              real const * const w,  ///< [in] second vector 
+RealT dotProd( RealT const * const v,  ///< [in] first vector
+              RealT const * const w,  ///< [in] second vector 
               int const dim          ///< [in] dimension of the vectors
             );
 
 /// returns the dot product of two 3-vectors with component-wise input
-real dotProd( real const aX,  ///< [in] x-component of first vector
-              real const aY,  ///< [in] y-component of first vector
-              real const aZ,  ///< [in] z-component of first vector
-              real const bX,  ///< [in] x-component of second vector
-              real const bY,  ///< [in] y-component of second vector
-              real const bZ   ///< [in] z-component of second vector
+RealT dotProd( RealT const aX,  ///< [in] x-component of first vector
+              RealT const aY,  ///< [in] y-component of first vector
+              RealT const aZ,  ///< [in] z-component of first vector
+              RealT const bX,  ///< [in] x-component of second vector
+              RealT const bY,  ///< [in] y-component of second vector
+              RealT const bZ   ///< [in] z-component of second vector
             );
               
 /// returns the magnitude of the cross product of two 3-vectors
-real magCrossProd( real const a[3],  ///< [in] array of components of first 3-vector
-                   real const b[3]   ///< [in] array of components of second 3-vector
+RealT magCrossProd( RealT const a[3],  ///< [in] array of components of first 3-vector
+                   RealT const b[3]   ///< [in] array of components of second 3-vector
                  );
 
 /// computes and returns the constituent cross product terms of two 3-vectors with component-wise input
-void crossProd( real const aX,  ///< [in] x-component of first vector
-                real const aY,  ///< [in] y-component of first vector
-                real const aZ,  ///< [in] z-component of first vector
-                real const bX,  ///< [in] x-component of second vector
-                real const bY,  ///< [in] y-component of second vector
-                real const bZ,  ///< [in] z-component of second vector
-                real &prodX,    ///< [in,out] j x k (i-component) product term
-                real &prodY,    ///< [in,out] i x k (j-component) product term 
-                real &prodZ     ///< [in,out] i x j (k-component) product term
+void crossProd( RealT const aX,  ///< [in] x-component of first vector
+                RealT const aY,  ///< [in] y-component of first vector
+                RealT const aZ,  ///< [in] z-component of first vector
+                RealT const bX,  ///< [in] x-component of second vector
+                RealT const bY,  ///< [in] y-component of second vector
+                RealT const bZ,  ///< [in] z-component of second vector
+                RealT &prodX,    ///< [in,out] j x k (i-component) product term
+                RealT &prodY,    ///< [in,out] i x k (j-component) product term 
+                RealT &prodZ     ///< [in,out] i x j (k-component) product term
               );
 
 /// binary search algorithm on presorted array
@@ -71,10 +71,10 @@ void bubble_sort( int * const array, ///< [in] Input array of integers
                 );
 
 /// allocate and initialize an array of reals
-void allocRealArray( real** arr, int length, real init_val );
+void allocRealArray( RealT** arr, int length, RealT init_val );
 
 /// allocate an array of reals and initialize with a pointer to data
-void allocRealArray( real** arr, const int length, const real* const data );
+void allocRealArray( RealT** arr, const int length, const RealT* const data );
 
 /// allocate and initialize an array of integers
 void allocIntArray( int** arr, int length, int init_val );
@@ -86,7 +86,7 @@ void allocIntArray( int** arr, const int length, const int* const data );
 void allocBoolArray( bool** arr, int length, bool init_val );
 
 /// initialize a array of reals
-void initRealArray( real* arr, int length, real init_val );
+void initRealArray( RealT* arr, int length, RealT init_val );
 
 /// initialize a array of integers
 void initIntArray( int* arr, int length, int init_val ); 

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -336,12 +336,12 @@ void TestMesh::clear( bool keepCoords )
 
 //------------------------------------------------------------------------------
 void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElemsZ1, 
-                                    real xMin1, real yMin1, real zMin1,
-                                    real xMax1, real yMax1, real zMax1,
+                                    RealT xMin1, RealT yMin1, RealT zMin1,
+                                    RealT xMax1, RealT yMax1, RealT zMax1,
                                     int numElemsX2, int numElemsY2, int numElemsZ2,
-                                    real xMin2, real yMin2, real zMin2, 
-                                    real xMax2, real yMax2, real zMax2,
-                                    real thetaMortar, real thetaNonmortar )
+                                    RealT xMin2, RealT yMin2, RealT zMin2, 
+                                    RealT xMax2, RealT yMax2, RealT zMax2,
+                                    RealT thetaMortar, RealT thetaNonmortar )
 {
    // NOTE: ONLY CONTACT INTERACTIONS IN THE Z-DIRECTION ARE SUPPORTED 
    // AT THE MOMENT.
@@ -359,9 +359,9 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
    // ASSUMING contact is in the Z-Direction, check to make sure that the 
    // gap of interpenetration is not greater than either block's element 
    // dimension
-   real h1 = (zMax1 - zMin1) / numElemsZ1;
-   real h2 = (zMax2 - zMin2) / numElemsZ2;
-   real mesh_gap = zMin2 - zMax1;
+   RealT h1 = (zMax1 - zMin1) / numElemsZ1;
+   RealT h2 = (zMax2 - zMin2) / numElemsZ2;
+   RealT mesh_gap = zMin2 - zMax1;
 
    SLIC_ERROR_IF( mesh_gap < -h1, "TestMesh::setupContactMeshHex(): " << 
                   "Initial mesh configuration has a gap greater than the " << 
@@ -391,15 +391,15 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
    this->elConn2   = new int[ this->numNodesPerElement * this->numNonmortarElements ];
    this->faceConn1 = new int[ this->numNodesPerFace * this->numMortarFaces ];
    this->faceConn2 = new int[ this->numNodesPerFace * this->numNonmortarFaces ];
-   this->x = new double[ this->numTotalNodes ];
-   this->y = new double[ this->numTotalNodes ];
-   this->z = new double[ this->numTotalNodes ];
+   this->x = new RealT[ this->numTotalNodes ];
+   this->y = new RealT[ this->numTotalNodes ];
+   this->z = new RealT[ this->numTotalNodes ];
 
    // setup mesh nodal coordinate arrays
    int ndOffset;
    int numElemsX, numElemsY, numElemsZ;
-   real xMax, yMax, zMax, xMin, yMin, zMin;
-   real theta;
+   RealT xMax, yMax, zMax, xMin, yMin, zMin;
+   RealT theta;
    int * elConn, * faceConn;
    for ( int iblk = 0; iblk<2; ++iblk)
    {
@@ -439,9 +439,9 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
       int numNodesX = numElemsX + 1;
       int numNodesY = numElemsY + 1;
       int numNodesZ = numElemsZ + 1;
-      real hx = (xMax - xMin) / numElemsX;
-      real hy = (yMax - yMin) / numElemsY;
-      real hz = (zMax - zMin) / numElemsZ;
+      RealT hx = (xMax - xMin) / numElemsX;
+      RealT hy = (yMax - yMin) / numElemsY;
+      RealT hz = (zMax - zMin) / numElemsZ;
 
       // compute mesh coordinates
       int ctr = 0;
@@ -452,7 +452,7 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
             for (int i=0; i<numNodesX; ++i)
             {
                int idx = ndOffset + ctr;
-               real xyz[3];
+               RealT xyz[3];
 
                // compute coordinates
                xyz[0] = xMin + i * hx;
@@ -466,14 +466,14 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
 
                if (rotationX && rotationY)
                {
-                  real rot0 = std::cos(theta * M_PI/180);
-                  real rot1 = -std::sin(theta * M_PI/180);
-                  real rot2 = -rot1;
-                  real rot3 = rot0;
+                  RealT rot0 = std::cos(theta * M_PI/180);
+                  RealT rot1 = -std::sin(theta * M_PI/180);
+                  RealT rot2 = -rot1;
+                  RealT rot3 = rot0;
                   
-                  real x_temp = xyz[0]*rot0 + xyz[1]*rot1;
-                  real y_temp = xyz[0]*rot2 + xyz[1]*rot3;
-                  real z_temp = xyz[2];
+                  RealT x_temp = xyz[0]*rot0 + xyz[1]*rot1;
+                  RealT y_temp = xyz[0]*rot2 + xyz[1]*rot3;
+                  RealT z_temp = xyz[2];
 
                   xyz[0] = x_temp;
                   xyz[1] = y_temp;
@@ -554,12 +554,12 @@ void TestMesh::setupContactMeshHex( int numElemsX1, int numElemsY1, int numElems
 
 //------------------------------------------------------------------------------
 void TestMesh::setupContactMeshTet( int numElemsX1, int numElemsY1, int numElemsZ1,
-                                    real xMin1, real yMin1, real zMin1,
-                                    real xMax1, real yMax1, real zMax1,
+                                    RealT xMin1, RealT yMin1, RealT zMin1,
+                                    RealT xMax1, RealT yMax1, RealT zMax1,
                                     int numElemsX2, int numElemsY2, int numElemsZ2,
-                                    real xMin2, real yMin2, real zMin2,
-                                    real xMax2, real yMax2, real zMax2,
-                                    real thetaMortar, real thetaNonmortar )
+                                    RealT xMin2, RealT yMin2, RealT zMin2,
+                                    RealT xMax2, RealT yMax2, RealT zMax2,
+                                    RealT thetaMortar, RealT thetaNonmortar )
 {
    // NOTE: ONLY CONTACT INTERACTIONS IN THE Z-DIRECTION ARE SUPPORTED 
    // AT THE MOMENT.
@@ -768,7 +768,7 @@ void TestMesh::setupContactMeshTet( int numElemsX1, int numElemsY1, int numElems
 
 } // end setupContactMeshTet()
 //------------------------------------------------------------------------------
-void TestMesh::allocateAndSetVelocities( int meshId, real valX, real valY, real valZ )
+void TestMesh::allocateAndSetVelocities( int meshId, RealT valX, RealT valY, RealT valZ )
 {
    // Check that mesh ids are not the same. The TestMesh class was built around 
    // testing the mortar method with Lagrange multiplier enforcement, which does not 
@@ -834,12 +834,12 @@ void TestMesh::allocateAndSetVelocities( int meshId, real valX, real valY, real 
    }
 
    SLIC_DEBUG_IF( deleteVels, "TestMesh::allocateAndSetVelocities(): " << 
-                       "a velocity array has been deleted and reallocated." );
+                       "a velocity array has been deleted and RealTlocated." );
 
 } // end TestMesh::allocateAndSetVelocities()
 
 //------------------------------------------------------------------------------
-void TestMesh::allocateAndSetBulkModulus( int meshId, real val )
+void TestMesh::allocateAndSetBulkModulus( int meshId, RealT val )
 {
    // Check that mesh ids are the same. The TestMesh class was built around 
    // testing the mortar method with Lagrange multiplier enforcement, which does 
@@ -877,12 +877,12 @@ void TestMesh::allocateAndSetBulkModulus( int meshId, real val )
    }
 
    SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetBulkModulus(): " << 
-                  "a bulk modulus array has been deleted and reallocated." );
+                  "a bulk modulus array has been deleted and RealTlocated." );
 
 } // end TestMesh::allocateAndSetBulkModulus()
 
 //------------------------------------------------------------------------------
-void TestMesh::allocateAndSetElementThickness( int meshId, real t )
+void TestMesh::allocateAndSetElementThickness( int meshId, RealT t )
 {
    // check to see if pointers have been set
    bool deleteData = false; 
@@ -913,7 +913,7 @@ void TestMesh::allocateAndSetElementThickness( int meshId, real t )
    }
 
    SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetElementThickness(): " << 
-                  "an element thickness array has been deleted and reallocated." );
+                  "an element thickness array has been deleted and RealTlocated." );
 
 } // end TestMesh::allocateAndSetElementThickness()
 
@@ -929,9 +929,9 @@ int TestMesh::simpleTribolSetupAndUpdate( ContactMethod method,
                   "must construct hex or tet mesh prior to calling this routine." );
 
    // grab coordinate data
-   real * x = this->x;
-   real * y = this->y;
-   real * z = this->z;
+   RealT * x = this->x;
+   RealT * y = this->y;
+   RealT * z = this->z;
 
    switch (method)
    {
@@ -957,7 +957,7 @@ int TestMesh::simpleTribolSetupAndUpdate( ContactMethod method,
       }
    } // end switch on method
  
-   const double area_frac = 1.e-03;
+   const RealT area_frac = 1.e-03;
 
    SimpleCouplingSetup( this->dim,
                         this->cellType,
@@ -989,12 +989,12 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
                                     TestControlParameters& params )
 {
    // grab coordinate data
-   real * x = this->x;
-   real * y = this->y;
-   real * z = this->z;
+   RealT * x = this->x;
+   RealT * y = this->y;
+   RealT * z = this->z;
 
    // initialize tribol
-   CommType problem_comm = TRIBOL_COMM_WORLD;
+   CommT problem_comm = TRIBOL_COMM_WORLD;
    initialize( this->dim, problem_comm );
 
    // register mesh. Note: Tribol will still work with global integer 
@@ -1091,7 +1091,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
          {
             SLIC_DEBUG_ROOT( "TestMesh::tribolSetupAndUpdate(): " <<
                              "mortar_bulk_mod not set; registering default value." );
-            this->mortar_bulk_mod = new real[ this->numMortarFaces ];
+            this->mortar_bulk_mod = new RealT[ this->numMortarFaces ];
             for (int i=0; i<this->numMortarFaces; ++i)
             {
                this->mortar_bulk_mod[i] = params.const_penalty; // non-physical for testing 
@@ -1101,7 +1101,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
          {
             SLIC_DEBUG_ROOT( "TestMesh::tribolSetupAndUpdate(): " <<
                              "mortar_element_thickness not set; registering default value." );
-            this->mortar_element_thickness = new real[ this->numMortarFaces ];
+            this->mortar_element_thickness = new RealT[ this->numMortarFaces ];
             for (int i=0; i<this->numMortarFaces; ++i)
             {
                this->mortar_element_thickness[i] = 1.; // non-physical for testing
@@ -1112,7 +1112,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
          { 
             SLIC_DEBUG_ROOT( "TestMesh::tribolSetupAndUpdate(): " <<
                              "nonmortar_bulk_mod not set; registering default value." );
-            this->nonmortar_bulk_mod = new real[ this->numNonmortarFaces ];
+            this->nonmortar_bulk_mod = new RealT[ this->numNonmortarFaces ];
             for (int i=0; i<this->numNonmortarFaces; ++i)
             {
                this->nonmortar_bulk_mod[i] = params.const_penalty; // non-physical for testing
@@ -1122,7 +1122,7 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
          {  
             SLIC_DEBUG_ROOT( "TestMesh::tribolSetupAndUpdate(): " <<
                              "nonmortar_element_thickness not set; registering default value." );
-            this->nonmortar_element_thickness = new real[ this->numNonmortarFaces ];
+            this->nonmortar_element_thickness = new RealT[ this->numNonmortarFaces ];
             for (int i=0; i<this->numNonmortarFaces; ++i)
             {
                this->nonmortar_element_thickness[i] = 1.; // non-physical for testing
@@ -1234,7 +1234,7 @@ void TestMesh::setupPatchTestDirichletBCs( int meshId,
                                            int numElemsZ, 
                                            int nodeIdOffset, 
                                            bool inHomogeneousGap, 
-                                           real inHomogeneousZVal )
+                                           RealT inHomogeneousZVal )
 {
    SLIC_ERROR_IF( !this->mesh_constructed, "TestMesh::setupPatchTestDirichletBCs(): " << 
                   "mesh must be constructed prior to calling this routine." );
@@ -1258,7 +1258,7 @@ void TestMesh::setupPatchTestDirichletBCs( int meshId,
    int numNodes = numNodesX * numNodesY * numNodesZ;
 
    int* nodeIdsX, *nodeIdsY, *nodeIdsZ;
-   real* valX, *valY, *valZ;
+   RealT* valX, *valY, *valZ;
    if (mortar) // mortar BCs
    {
       this->dirNodesX1 = new int[ numNodes ];
@@ -1268,9 +1268,9 @@ void TestMesh::setupPatchTestDirichletBCs( int meshId,
       nodeIdsY = this->dirNodesY1;
       nodeIdsZ = this->dirNodesZ1;
 
-      this->iDirValX1 = new real[ numNodes ];
-      this->iDirValY1 = new real[ numNodes ];
-      this->iDirValZ1 = new real[ numNodes ];
+      this->iDirValX1 = new RealT[ numNodes ];
+      this->iDirValY1 = new RealT[ numNodes ];
+      this->iDirValZ1 = new RealT[ numNodes ];
       valX     = this->iDirValX1;
       valY     = this->iDirValY1;
       valZ     = this->iDirValZ1;
@@ -1284,9 +1284,9 @@ void TestMesh::setupPatchTestDirichletBCs( int meshId,
       nodeIdsY = this->dirNodesY2;
       nodeIdsZ = this->dirNodesZ2;
    
-      this->iDirValX2 = new real[ numNodes ];
-      this->iDirValY2 = new real[ numNodes ];
-      this->iDirValZ2 = new real[ numNodes ];
+      this->iDirValX2 = new RealT[ numNodes ];
+      this->iDirValY2 = new RealT[ numNodes ];
+      this->iDirValZ2 = new RealT[ numNodes ];
       valX     = this->iDirValX2;
       valY     = this->iDirValY2;
       valZ     = this->iDirValZ2;
@@ -1517,7 +1517,7 @@ void TestMesh::setupMfemMesh( bool fix_orientation )
 
    for (int i=0; i<this->numMortarNodes; ++i)
    {
-      double vert[3] = {0., 0., 0.}; 
+      RealT vert[3] = {0., 0., 0.}; 
       vert[ 0 ] = this->x[ i ];
       vert[ 1 ] = this->y[ i ];
       vert[ 2 ] = this->z[ i ];
@@ -1557,7 +1557,7 @@ void TestMesh::setupMfemMesh( bool fix_orientation )
 
    for (int i=0; i<this->numNonmortarNodes; ++i)
    { 
-      double vert[3] = {0., 0., 0.}; 
+      RealT vert[3] = {0., 0., 0.}; 
       int offset = this->numMortarNodes;
       vert[ 0 ] = this->x[ offset + i ];
       vert[ 1 ] = this->y[ offset + i ];
@@ -1592,7 +1592,7 @@ void TestMesh::setupMfemMesh( bool fix_orientation )
 
 //------------------------------------------------------------------------------
 void TestMesh::computeEquilibriumJacobian( mfem::SparseMatrix* A,
-                                           real const nu, real const youngs )
+                                           RealT const nu, RealT const youngs )
 {
    SLIC_ERROR_IF( this->mfem_mesh == nullptr, 
                   "TestMesh::computeEquilibriumJacobian(): must call setupMfemMesh() " << 
@@ -1606,11 +1606,11 @@ void TestMesh::computeEquilibriumJacobian( mfem::SparseMatrix* A,
    
    // compute 1st Lame parameter from Youngs modulus and Poisson's ratio 
    // (required for MFEM integrator)
-   double lambda_val { (youngs * nu) / ((1. + nu) * (1. - 2. * nu)) }; 
+   RealT lambda_val { (youngs * nu) / ((1. + nu) * (1. - 2. * nu)) }; 
 
    // compute shear modulus from Young's Modulus and Poisson's ratio
    // (required for MFEM integrator)
-   double mu_val { youngs / (2.*(1.+nu)) }; 
+   RealT mu_val { youngs / (2.*(1.+nu)) }; 
    mfem::ConstantCoefficient lambda(lambda_val);
    mfem::ConstantCoefficient mu(mu_val);
 
@@ -1677,7 +1677,7 @@ void TestMesh::computeElementJacobianContributions( mfem::SparseMatrix * const A
          {
             for (int j=0; j<numCols; ++j)
             {
-               double val = elmat(i,j);
+               RealT val = elmat(i,j);
                matrix << val << "  ";
             }
             matrix << "\n";
@@ -1794,7 +1794,7 @@ void TestMesh::tribolMatrixToSystemMatrix( mfem::DenseMatrix * const ATribol,
 } // end TestMesh::tribolMatrixToSystemMatrix()
 
 //------------------------------------------------------------------------------
-void TestMesh::getGapEvals( real * const v )
+void TestMesh::getGapEvals( RealT * const v )
 {
    SLIC_ERROR_IF( v == nullptr, "TestMesh::getGapEvals(): input pointer is null." );
    int presDofCtr = 0;
@@ -1822,7 +1822,7 @@ void TestMesh::enforceDirichletBCs( mfem::SparseMatrix * const A,
                   "input pointer to rhs vector, b, is null." );
 
    int * dirBCX, * dirBCY, * dirBCZ, * presDofs;
-   double *dirValX, *dirValY, *dirValZ;
+   RealT *dirValX, *dirValY, *dirValZ;
    int numBlkNodes;
 
    int presCtr = 0;
@@ -1862,21 +1862,21 @@ void TestMesh::enforceDirichletBCs( mfem::SparseMatrix * const A,
          if (dirBCX[m] >= 0)
          {
             int bcRowIdX = this->dim * dirBCX[m];
-            double dirBCValX = dirValX[m];
+            RealT dirBCValX = dirValX[m];
             A->EliminateRowCol( bcRowIdX, dirBCValX, *b );
          }
 
          if (dirBCY[m] >= 0)
          {
             int bcRowIdY = this->dim * dirBCY[m]+1;
-            double dirBCValY = dirValY[m];
+            RealT dirBCValY = dirValY[m];
             A->EliminateRowCol( bcRowIdY, dirBCValY, *b );
          }
 
          if (dirBCZ[m] >= 0)
          {
             int bcRowIdZ = this->dim * dirBCZ[m]+2;
-            double dirBCValZ = dirValZ[m];
+            RealT dirBCValZ = dirValZ[m];
             A->EliminateRowCol( bcRowIdZ, dirBCValZ, *b );
          }
 
@@ -1906,7 +1906,7 @@ void TestMesh::enforceDirichletBCs( mfem::SparseMatrix * const A,
 } // end TestMesh::enforceDirichletBCs()
 
 //------------------------------------------------------------------------------
-void TestMesh::testMeshToVtk( const std::string& dir, int cycle, double time )
+void TestMesh::testMeshToVtk( const std::string& dir, int cycle, RealT time )
 {
    std::ostringstream suffix_mesh;
    suffix_mesh << std::setfill('0') << std::setw(7) << cycle << ".vtk";
@@ -1924,7 +1924,7 @@ void TestMesh::testMeshToVtk( const std::string& dir, int cycle, double time )
 
    // Add the cycle and time to FieldData
    mesh << "FIELD FieldData 2\n";
-   mesh << "TIME 1 1 double\n";
+   mesh << "TIME 1 1 RealT\n";
    mesh << time << "\n";
    mesh << "CYCLE 1 1 int\n";
    mesh << cycle << "\n";

--- a/src/tribol/utils/TestUtils.hpp
+++ b/src/tribol/utils/TestUtils.hpp
@@ -60,16 +60,16 @@ struct TestControlParameters
       // no-op
    }
 
-   real dt {0.};
-   real auto_contact_pen_frac {0.95};
+   RealT dt {0.};
+   RealT auto_contact_pen_frac {0.95};
 
    // penalty control parameters
    bool penalty_ratio;
    bool constant_rate_penalty;
    bool percent_rate_penalty;
-   real rate_penalty;
-   real rate_penalty_ratio;
-   real const_penalty;
+   RealT rate_penalty;
+   RealT rate_penalty_ratio;
+   RealT const_penalty;
    bool enable_timestep_vote;
 };
 
@@ -133,12 +133,12 @@ public:
    *
    */
    void setupContactMeshHex( int numElemsX1, int numElemsY1, int numElemsZ1, 
-                             real xMin1, real yMin1, real zMin1,
-                             real xMax1, real yMax1, real zMax1,
+                             RealT xMin1, RealT yMin1, RealT zMin1,
+                             RealT xMax1, RealT yMax1, RealT zMax1,
                              int numElemsX2, int numElemsY2, int numElemsZ2,
-                             real xMin2, real yMin2, real zMin2, 
-                             real xMax2, real yMax2, real zMax2,
-                             real thetaMortar, real thetaNonmortar );
+                             RealT xMin2, RealT yMin2, RealT zMin2, 
+                             RealT xMax2, RealT yMax2, RealT zMax2,
+                             RealT thetaMortar, RealT thetaNonmortar );
 
   /*!
    * \brief setups of a 3D contact tet mesh consisting of two blocks
@@ -166,12 +166,12 @@ public:
    *
    */
    void setupContactMeshTet( int numElemsX1, int numElemsY1, int numElemsZ1, 
-                             real xMin1, real yMin1, real zMin1,
-                             real xMax1, real yMax1, real zMax1,
+                             RealT xMin1, RealT yMin1, RealT zMin1,
+                             RealT xMax1, RealT yMax1, RealT zMax1,
                              int numElemsX2, int numElemsY2, int numElemsZ2,
-                             real xMin2, real yMin2, real zMin2, 
-                             real xMax2, real yMax2, real zMax2,
-                             real thetaMortar, real thetaNonmortar );
+                             RealT xMin2, RealT yMin2, RealT zMin2, 
+                             RealT xMax2, RealT yMax2, RealT zMax2,
+                             RealT thetaMortar, RealT thetaNonmortar );
 
   /*!
    * \brief sets up an mfem mesh object representation of the original hex or tet test mesh
@@ -203,7 +203,7 @@ public:
    */
    void setupPatchTestDirichletBCs( int meshId, int numElemsX, int numElemsY, int numElemsZ, 
                                     int nodeIdOffset, bool inHomogeneousGap, 
-                                    real inHomogeneousZVal = 0. );
+                                    RealT inHomogeneousZVal = 0. );
 
   /*!
    * \brief sets up pressure dof ids for a 3D nonmortar mesh block for PATCH TEST
@@ -229,7 +229,7 @@ public:
    * \note in the future we should handle an array of velocity values
    *
    */
-   void allocateAndSetVelocities( int meshId, real valX, real valY, real valZ=0. );
+   void allocateAndSetVelocities( int meshId, RealT valX, RealT valY, RealT valZ=0. );
 
   /*!
    * \brief allocates and sets bulk modulus arrays on mesh
@@ -239,7 +239,7 @@ public:
    * \note in the future we should handle an array of values
    *
    */
-   void allocateAndSetBulkModulus( int meshId, real val );
+   void allocateAndSetBulkModulus( int meshId, RealT val );
 
   /*!
    * \brief allocates and sets element thickness arrays on mesh
@@ -250,7 +250,7 @@ public:
    *       should handle an array of values
    *
    */
-   void allocateAndSetElementThickness( int meshId, real t );
+   void allocateAndSetElementThickness( int meshId, RealT t );
 
   /*!
    * \brief wraps element Jacobian calculations for linear elasticity
@@ -264,7 +264,7 @@ public:
    * \pre matrix A cannot have been finalized yet
    */
    void computeEquilibriumJacobian( mfem::SparseMatrix * const A, 
-                                    real const nu, real const youngs );
+                                    RealT const nu, RealT const youngs );
 
   /*!
    * \brief wraps element Jacobian calculations for linear elasticity 
@@ -324,7 +324,7 @@ public:
    * \pre v of length, dim * numTotalNodes + numPressureDofs
    *
    */
-   void getGapEvals( real * const v );
+   void getGapEvals( RealT * const v );
 
   /*!
    * \brief Modifies matrix A and rhs vector b to enforce Dirichlet BCs
@@ -347,7 +347,7 @@ public:
    /// print mesh to vtk file
    void testMeshToVtk( const std::string& dir, ///< Name of the output directory
                        int cycle,              ///< Cycle number
-                       double time             ///< Simulation time 
+                       RealT time             ///< Simulation time 
                      );
 
 public:
@@ -376,15 +376,15 @@ public:
    int *dirNodesX1;          ///< Pointer to list of mortar node ids with x-component Dirichlet BCs
    int *dirNodesY1;          ///< Pointer to list of mortar node ids with y-component Dirichlet BCs
    int *dirNodesZ1;          ///< Pointer to list of mortar node ids with z-component Dirichlet BCs
-   double *iDirValX1;        ///< Pointer to x-component Dirichlet BC values for specified mortar nodes
-   double *iDirValY1;        ///< Pointer to y-component Dirichlet BC values for specified mortar nodes
-   double *iDirValZ1;        ///< Pointer to z-component Dirichlet BC values for specified mortar nodes
+   RealT *iDirValX1;        ///< Pointer to x-component Dirichlet BC values for specified mortar nodes
+   RealT *iDirValY1;        ///< Pointer to y-component Dirichlet BC values for specified mortar nodes
+   RealT *iDirValZ1;        ///< Pointer to z-component Dirichlet BC values for specified mortar nodes
    int *dirNodesX2;          ///< Pointer to list of nonmortar node ids with x-component Dirichlet BCs
    int *dirNodesY2;          ///< Pointer to list of nonmortar node ids with y-component Dirichlet BCs
    int *dirNodesZ2;          ///< Pointer to list of nonmortar node ids with z-component Dirichlet BCs
-   double *iDirValX2;        ///< Pointer to x-component Dirichlet BC values for specified nonmortar nodes
-   double *iDirValY2;        ///< Pointer to y-component Dirichlet BC values for specified nonmortar nodes
-   double *iDirValZ2;        ///< Pointer to z-component Dirichlet BC values for specified nonmortar nodes
+   RealT *iDirValX2;        ///< Pointer to x-component Dirichlet BC values for specified nonmortar nodes
+   RealT *iDirValY2;        ///< Pointer to y-component Dirichlet BC values for specified nonmortar nodes
+   RealT *iDirValZ2;        ///< Pointer to z-component Dirichlet BC values for specified nonmortar nodes
    int *presDofs1;           ///< Pointer to mortar node ids with a pressure BC
    int *presDofs2;           ///< Pointer to nonmortar node ids with a pressure BC
 
@@ -395,43 +395,43 @@ public:
    int *elConn2;             ///< Pointer to nonmortar element connectivity 
 
    // TODO can we make these mfem grid functions?
-   double *fx1; ///< Mortar nodal forces, x-component 
-   double *fy1; ///< Mortar nodal forces, y-component 
-   double *fz1; ///< Mortar nodal forces, z-component
-   double *fx2; ///< Nonmortar nodal forces, x-component
-   double *fy2; ///< Nonmortar nodal forces, y-component
-   double *fz2; ///< Nonmortar nodal forces, z-component
-   double *vx1; ///< Mortar nodal velocities, x-component
-   double *vy1; ///< Mortar nodal velocities, y-component
-   double *vz1; ///< Mortar nodal velocities, z-component
-   double *vx2; ///< Nonmortar nodal velocities, x-component
-   double *vy2; ///< Nonmortar nodal velocities, y-component
-   double *vz2; ///< Nonmortar nodal velocities, z-component
-   double *x;   ///< Nodal coordinates, x-component
-   double *y;   ///< Nodal coordinates, y-component
-   double *z;   ///< Nodal coordinates, z-component
+   RealT *fx1; ///< Mortar nodal forces, x-component 
+   RealT *fy1; ///< Mortar nodal forces, y-component 
+   RealT *fz1; ///< Mortar nodal forces, z-component
+   RealT *fx2; ///< Nonmortar nodal forces, x-component
+   RealT *fy2; ///< Nonmortar nodal forces, y-component
+   RealT *fz2; ///< Nonmortar nodal forces, z-component
+   RealT *vx1; ///< Mortar nodal velocities, x-component
+   RealT *vy1; ///< Mortar nodal velocities, y-component
+   RealT *vz1; ///< Mortar nodal velocities, z-component
+   RealT *vx2; ///< Nonmortar nodal velocities, x-component
+   RealT *vy2; ///< Nonmortar nodal velocities, y-component
+   RealT *vz2; ///< Nonmortar nodal velocities, z-component
+   RealT *x;   ///< Nodal coordinates, x-component
+   RealT *y;   ///< Nodal coordinates, y-component
+   RealT *z;   ///< Nodal coordinates, z-component
 
    // CSR storage
    int* I;       ///< Offsets for CSR storage
    int* J;       ///< Column indices for all nonzero entries in CSR storage
-   double *vals; ///< Array of nonzero values 
+   RealT *vals; ///< Array of nonzero values 
 
-   double *gaps;      ///< Array of nodal gaps
-   double *pressures; ///< Array of nodal pressures
+   RealT *gaps;      ///< Array of nodal gaps
+   RealT *pressures; ///< Array of nodal pressures
 
-   real * mortar_bulk_mod;
-   real * mortar_element_thickness;
-   real * nonmortar_bulk_mod;
-   real * nonmortar_element_thickness;
+   RealT * mortar_bulk_mod;
+   RealT * mortar_element_thickness;
+   RealT * nonmortar_bulk_mod;
+   RealT * nonmortar_element_thickness;
 
    bool registered_velocities1 {false};
    bool registered_velocities2 {false};
    bool mesh_constructed {false};
 
   public:
-   double* getX() const {return x;}
-   double* getY() const {return y;}
-   double* getZ() const {return z;}
+   RealT* getX() const {return x;}
+   RealT* getY() const {return y;}
+   RealT* getZ() const {return z;}
    int* getMortarFaceConnectivity() const {return faceConn1;}
    int* getNonmortarFaceConnectivity()  const {return faceConn2;}
 


### PR DESCRIPTION
This PR introduces new definitions for types in Tribol.  The changes are as follows:

- Remove `tribol::integer` in favor of `int`, or other C++ fundamental types as dictated by the specific variable (e.g. `unsigned short` might make more sense for a variable that represents spatial dimension)
- Define `tribol::IndexT` as `axom::IndexType` for indexing into axom types (e.g. `axom::Array`).  Note the use of `tribol::IndexT` still needs to be checked in source files.  This will be done in future PRs.
- Rename `tribol::real` as `tribol::RealT` and ensure proper usage throughout source files.  `tribol::RealT` is defined as a `double`; if the user attempts to map it to `float` by defining `TRIBOL_USE_SINGLE_PRECISION`, an error will occur since Tribol has not been tested with single precision.
- Rename `tribol::containerArray` as `tribol::ArrayT` and define it as an `axom::Array` (with template arguments) instead of `std::vector`
- Rename `tribol::CommType` to `tribol::CommT` to be consistent with other Tribol type names

Note, this PR does not address types in redecomp or in the Fortran/C interface.