### PR TITLE
Guard PolyReorder call for overlaps with more than 2 vertices

### DIFF
--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -835,15 +835,24 @@ FaceGeomError Intersection2DPolygon( const real* const RESTRICT xA,
       PolyReorder( polyXTemp, polyYTemp, numPolyVert );
 
       // check length of segs against tolerance and collapse short segments if necessary
-      // This is where polyX and polyY get allocated.
+      // This is where polyX and polyY get allocated for any overlap that remains with 
+      // > 3 vertices
       int numFinalVert = 0; 
 
       FaceGeomError segErr = CheckPolySegs( polyXTemp, polyYTemp, numPolyVert, 
                                             lenTol, polyX, polyY, numFinalVert );
 
+      // check for an error in the segment check routine
       if (segErr != 0)
       {
          return segErr;
+      }
+ 
+      // check to see if the overlap was degenerated to have 2 or less vertices.
+      if (numFinalVert<3)
+      {
+         area = 0.0;
+         return NO_FACE_GEOM_ERROR; // punt on degenerated or collapsed overlaps
       }
 
       numPolyVert = numFinalVert;
@@ -1238,6 +1247,14 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
       {
          ++numNewPoints;
       }
+   }
+
+   // check to make sure numNewPoints > 3 for valid overlap polygons prior
+   // to memory allocation
+   if (numNewPoints < 3)
+   {
+      // return and degenerated polygon will be skipped over. 
+      return NO_FACE_GEOM_ERROR;
    }
 
    // allocate space for xnew and ynew. These are the input/output pointers 

--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -1249,7 +1249,7 @@ FaceGeomError CheckPolySegs( const real* const RESTRICT x, const real* const RES
       }
    }
 
-   // check to make sure numNewPoints > 3 for valid overlap polygons prior
+   // check to make sure numNewPoints >= 3 for valid overlap polygons prior
    // to memory allocation
    if (numNewPoints < 3)
    {


### PR DESCRIPTION
Testing showed overlaps that were degenerating (due to a bug or entirely plausible due to edge length tolerancing) to 2 or less vertices were triggering an error in a vertex reordering routine. To solve this:
- Guard the call to the vertex ordering routine and a few other lines of code with conditional for non-degenerate overlaps
- It is ok to have a degenerate overlap in many cases so this should never have triggered an error
- Use a debug log statement in the vertex ordering routine in case it is every called with <3 vertices in the polygon.