### PR TITLE
Fix Gap Used in Common-Plane Timestep Vote

### DIFF
--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -491,6 +491,7 @@ struct parameters_t
   double projection_ratio;       ///! Ratio for defining nonzero projections
   double auto_contact_pen_frac;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
   double timestep_pen_frac;      ///! Max allowable interpenetration as percent of element thickness prior to triggering timestep vote
+  double timestep_scale;         ///! Scale factor (>0) applied to the timestep vote giving users some control over the vote
 
   int vis_cycle_incr;            ///! Frequency for visualizations dumps
   VisType vis_type;              ///! Type of interface physics visualization output

--- a/src/tribol/geom/ContactPlane.hpp
+++ b/src/tribol/geom/ContactPlane.hpp
@@ -545,7 +545,8 @@ public:
    /*!
     * \brief Check whether two polygons (faces) have a positive area of overlap
     *
-    * \note Wrapper routine that calls the ALE3D polygon intersection routine
+    * \note Wrapper routine that calls the polygon intersection routine. That routine
+    *  does not return vertices, just overlap area.
     */
    void checkPolyOverlap( real* RESTRICT projLocX1, real* RESTRICT projLocY1, 
                           real* RESTRICT projLocX2, real* RESTRICT projLocY2, 

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -63,8 +63,6 @@ void ProjectPointToSegment( const real x, const real y,
  *
  * \brief Method to find the intersection area between two polygons and 
  *  the local y-coordinate of the centroid 
- * \note taken from Ben Liu's implementation of 
- *  Eric Herbold's routine in ALE3D.
  *
  * \param [in] namax number of vertices in polygon a
  * \param [in] xa array of local x coordinates of polygon a vertices

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -69,6 +69,7 @@ void set_defaults()
    parameters.projection_ratio             = 1.E-10;
    parameters.auto_contact_pen_frac        = 0.95;   // max allowable interpenetration as percent of element thickness for contact candidacy 
    parameters.timestep_pen_frac            = 3.e-1;  // max allowable interpenetration as percent of element thickness prior to triggering timestep vote (not exposed to API) 
+   parameters.timestep_scale               = 1.0;    // scale factor (>0) applied to the timestep vote
    parameters.enable_timestep_vote         = false;  // true if host-code wants to receive tribol timestep vote
    
    // Interpenetration check for auto-contact. If true, this will check a full-overlap 
@@ -213,6 +214,18 @@ void setTimestepPenFrac( double frac )
 
 } // end setTimestepPenFrac()
 
+//------------------------------------------------------------------------------
+void setTimestepScale( double scale )
+{
+   parameters_t & parameters = parameters_t::getInstance();
+   if (scale <= 0.)
+   {
+      // Don't set the timestep_scale. This will use default
+      return;
+   }
+
+   parameters.timestep_scale = scale;
+}
 //------------------------------------------------------------------------------
 void setContactAreaFrac( double frac )
 {

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -111,6 +111,17 @@ void setAutoContactPenScale( double scale );
 void setTimestepPenFrac( double frac );
 
 /*!
+ *
+ * \brief sets the timestep scale factor applied to the timestep vote 
+ *
+ * \param [in] scale the scale factor applied to the timestep vote 
+ *
+ * \pre scale > 0
+ *
+ */
+void setTimestepScale( double scale );
+
+/*!
  * \brief Sets the area fraction for inclusion of a contact overlap 
  * \param [in] frac area fraction tolerance
  *

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1443,7 +1443,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 
       real dt1 = 1.e6;  // initialize as large number
       real dt2 = 1.e6;  // initialize as large number
-      real alpha = 1.0; // multiplier on timestep estimate
+      real alpha = parameters.timestep_scale; // multiplier on timestep estimate
       bool dt1_check1 = false;
       bool dt2_check1 = false;
       bool dt1_vel_check = false;

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1306,7 +1306,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
    int numNodesPerCell1 = mesh1.m_numNodesPerCell;
    int numNodesPerCell2 = mesh2.m_numNodesPerCell;
 
-   // Loop over interface pairs and check exising gaps for pairs in 
+   // Loop over interface pairs and check existing gaps for pairs in 
    // contact, and perform velocity projection check for all contact 
    // candidates.
    IndexType numPairs = m_interfacePairs->getNumPairs();

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1393,6 +1393,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       v1_dot_n1 = dotProd( &vel_f1[0], &fn1[0], dim );
       v2_dot_n2 = dotProd( &vel_f2[0], &fn2[0], dim );
 
+      // Keep debug print statements. This routine is still in the testing phase
       //std::cout << "face 1 normal: " << fn1[0] << ", " << fn1[1] << ", " << fn1[2] << std::endl;
       //std::cout << "face 2 normal: " << fn2[0] << ", " << fn2[1] << ", " << fn2[2] << std::endl;
       //std::cout << " " << std::endl;
@@ -1419,6 +1420,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       v1_dot_n1 += tiny1;
       v2_dot_n2 += tiny2;
 
+      // Keep debug print statements. This routine is still in the testing phase
       //std::cout << "Second v1_dot_n1 calc: " << v1_dot_n1 << std::endl;
       //std::cout << "Second v2_dot_n2 calc: " << v2_dot_n2 << std::endl;
       //std::cout << "Second v1_dot_n: " << v1_dot_n << std::endl;
@@ -1509,6 +1511,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          dt1 = (dt1_check1) ? alpha * max_delta1 / v1_dot_n1 : dt1;
          dt2 = (dt2_check1) ? alpha * max_delta2 / v2_dot_n2 : dt2;
 
+         // Keep debug print statements. This routine is still in the testing phase
          //std::cout << "dt1_check1, delta1 and v1_dot_n1: " << dt1_check1 << ", " << max_delta1 << ", " << v1_dot_n1 << std::endl;
          //std::cout << "dt2_check1, delta2 and v2_dot_n2: " << dt2_check1 << ", " << max_delta2 << ", " << v2_dot_n2 << std::endl;
          //std::cout << "dt1 and dt2: " << dt1 << ", " << dt2 << std::endl;
@@ -1595,8 +1598,11 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          dt1 = (dt1_vel_check) ? alpha * max_delta1 / v1_dot_n1 : dt1;
          dt2 = (dt2_vel_check) ? alpha * max_delta2 / v2_dot_n2 : dt2; 
 
-         //std::cout << "dt1_vel_check, (proj_delta_n_1+max_delta1), v1_dot_n1: " << dt1_vel_check << ", " << proj_delta_n_1+max_delta1 << ", " << v1_dot_n1 << std::endl;
-         //std::cout << "dt2_vel_check, (proj_delta_n_2+max_delta2), v2_dot_n2: " << dt2_vel_check << ", " << proj_delta_n_2+max_delta2 << ", " << v2_dot_n2 << std::endl;
+         // Keep debug print statements. This routine is still in the testing phase
+         //std::cout << "dt1_vel_check, (proj_delta_n_1+max_delta1), v1_dot_n1: " << dt1_vel_check << ", " 
+         //          << proj_delta_n_1+max_delta1 << ", " << v1_dot_n1 << std::endl;
+         //std::cout << "dt2_vel_check, (proj_delta_n_2+max_delta2), v2_dot_n2: " << dt2_vel_check << ", " 
+         //          << proj_delta_n_2+max_delta2 << ", " << v2_dot_n2 << std::endl;
          //std::cout << "dt1 and dt2: " << dt1 << ", " << dt2 << std::endl;
 
          // update dt_temp2 only for positive dt1 and/or dt2

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1327,7 +1327,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       {
          continue;
       }
-   
+
       real x1[dim * numNodesPerCell1];
       real v1[dim * numNodesPerCell1];
       mesh1.getFaceCoords( pair.pairIndex1, &x1[0] );
@@ -1506,11 +1506,11 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          // in excess of the max allowable gap without causing timestep crashes.
          //
          // v1_dot_n1 > 0 and v2_dot_n2 > 0 for further interpen
-         dt1 = (dt1_check1) ? -alpha * max_delta1 / v1_dot_n1 : dt1;
-         dt2 = (dt2_check1) ? -alpha * max_delta2 / v2_dot_n2 : dt2;
+         dt1 = (dt1_check1) ? alpha * max_delta1 / v1_dot_n1 : dt1;
+         dt2 = (dt2_check1) ? alpha * max_delta2 / v2_dot_n2 : dt2;
 
-         //std::cout << "dt1_check1, delta1 and v1_dot_n1: " << dt1_check1 << ", " << delta1 << ", " << v1_dot_n1 << std::endl;
-         //std::cout << "dt2_check1, delta2 and v2_dot_n2: " << dt2_check1 << ", " << delta2 << ", " << v2_dot_n2 << std::endl;
+         //std::cout << "dt1_check1, delta1 and v1_dot_n1: " << dt1_check1 << ", " << max_delta1 << ", " << v1_dot_n1 << std::endl;
+         //std::cout << "dt2_check1, delta2 and v2_dot_n2: " << dt2_check1 << ", " << max_delta2 << ", " << v2_dot_n2 << std::endl;
          //std::cout << "dt1 and dt2: " << dt1 << ", " << dt2 << std::endl;
 
          // update dt_temp1 only for positive dt1 and/or dt2
@@ -1524,6 +1524,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
             dt_temp1 = axom::utilities::min(dt_temp1, 
                        axom::utilities::min(1.e6, dt2));
          }
+
 
          if (dt1 < 0. || dt2 < 0.)
          {
@@ -1589,8 +1590,10 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          // the velocity projected gap does not exceed the max allowable gap. This avoid timestep
          // crashes for velocity projected gaps slightly in excess of the max allowable and still
          // allows for a soft contact response without a timestep crash.
-         dt1 = (dt1_vel_check) ? -alpha * max_delta1 / v1_dot_n1 : dt1;
-         dt2 = (dt2_vel_check) ? -alpha * max_delta2 / v2_dot_n2 : dt2; 
+         //
+         // v1_dot_n1 > 0 and v2_dot_n2 > 0 for further interpen
+         dt1 = (dt1_vel_check) ? alpha * max_delta1 / v1_dot_n1 : dt1;
+         dt2 = (dt2_vel_check) ? alpha * max_delta2 / v2_dot_n2 : dt2; 
 
          //std::cout << "dt1_vel_check, (proj_delta_n_1+max_delta1), v1_dot_n1: " << dt1_vel_check << ", " << proj_delta_n_1+max_delta1 << ", " << v1_dot_n1 << std::endl;
          //std::cout << "dt2_vel_check, (proj_delta_n_2+max_delta2), v2_dot_n2: " << dt2_vel_check << ", " << proj_delta_n_2+max_delta2 << ", " << v2_dot_n2 << std::endl;

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1274,52 +1274,47 @@ void CouplingScheme::computeTimeStep(real &dt)
 //------------------------------------------------------------------------------
 void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 {
-   // note: the timestep vote is based on a velocity projection 
-   // and does not account for the spring stiffness in a CFL-like 
-   // timestep constraint. A constant penalty everywhere is not necessarily 
-   // tuned to the underlying material that occurs with 'element_wise'
-   // and may result in contact instabilities that this timestep vote 
-   // does not yet address. Tuning the penalty to the underlying material 
-   // stiffness implicitly scales the penalty stiffness to approximately 
-   // correspond to a host-code timestep governed by an underlying 
-   // element-wise CFL constraint. The timestep vote in this routine 
-   // catches the case where too large of a timestep results in too 
-   // much face-pair interpenetration, which may also lead to contact 
-   // instabilities.
+   // note: the timestep vote is based on a maximum allowable interpenetration
+   // approach checking current gaps and then performing a velocity projection.
+   // This timestep vote is not derived from a stability analysis and does not 
+   // account for the spring stiffness in a CFL-like timestep constraint. 
+   // The timestep vote in this routine is intended to avoid missing contact or 
+   // inadequately resolving contact by detecting 'too much' interpenetration. 
+   // To do this, the first check is a 'gap check' where the current gap is 
+   // checked against a fraction of the element-thicknesses. The second check 
+   // assumes zero gap, and then does a velocity projection followed by the 
+   // 'gap check' using this new, projected gap.
    
    MeshManager & meshManager = MeshManager::getInstance(); 
    MeshData & mesh1 = meshManager.GetMeshInstance( m_meshId1 );
    MeshData & mesh2 = meshManager.GetMeshInstance( m_meshId2 );
 
-   // issue warning that this timestep vote does not address 
-   // contact instabilities that may present themselves with the use 
-   // of a constant penalty everywhere; then, return. If constant penalty 
-   // is used then likely element thicknesses have not been registered.
-   PenaltyEnforcementOptions& pen_enfrc_options = this->m_enforcementOptions.penalty_options;
-   KinematicPenaltyCalculation kin_calc = pen_enfrc_options.kinematic_calculation;
-   if ( kin_calc == KINEMATIC_CONSTANT )
+   // check if the element thicknesses have been set. This is now
+   // regardless of exact penalty calculation type, since element
+   // thicknesses are required for auto contact even if a constant
+   // penalty is used
+   if ( !mesh1.m_elemData.m_is_element_thickness_set ||
+        !mesh2.m_elemData.m_is_element_thickness_set )
    {
-      // Tribol timestep vote only used with KINEMATIC_ELEMENT penalty
-      // because element thicknesses are supplied
       return; 
    }
 
    parameters_t & parameters = parameters_t::getInstance();
    real proj_ratio = parameters.timestep_pen_frac;
    ContactPlaneManager& cpMgr = ContactPlaneManager::getInstance();
-   //int num_sides = 2; // always 2 sides in a single coupling scheme
    int dim = this->spatialDimension();
    int numNodesPerCell1 = mesh1.m_numNodesPerCell;
    int numNodesPerCell2 = mesh2.m_numNodesPerCell;
 
-   // loop over each interface pair. Even if pair is not in contact, 
-   // we still do a velocity projection for that proximate face-pair 
-   // to see if interpenetration next cycle 'may' be too much
+   // Loop over interface pairs and check exising gaps for pairs in 
+   // contact, and perform velocity projection check for all contact 
+   // candidates.
    IndexType numPairs = m_interfacePairs->getNumPairs();
    real dt_temp1 = dt;
    real dt_temp2 = dt;
    int cpID = 0; 
-   bool max_gap_msg = false;
+   bool exceed_max_gap1 = false;
+   bool exceed_max_gap2 = false;
    bool neg_dt_gap_msg = false;
    bool neg_dt_vel_proj_msg = false;
    for (IndexType kp = 0; kp < numPairs; ++kp)
@@ -1382,9 +1377,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       // compute velocity projections:
       // compute the dot product between the face velocities 
       // at the overlap-centroid-to-face projected centroid and each
-      // face's outward unit normal AND the overlap normal. The 
-      // former is used to compute projections and the latter is 
-      // used to indicate further contact using a velocity projection
+      // face's outward unit normal AND the overlap normal. 
       real v1_dot_n, v2_dot_n, v1_dot_n1, v2_dot_n2;
       real overlapNormal[dim];
       cpMgr.getContactPlaneNormal( cpID, dim, &overlapNormal[0] );
@@ -1411,18 +1404,16 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       //std::cout << "First v1_dot_n: " << v1_dot_n << std::endl;
       //std::cout << "First v2_dot_n: " << v2_dot_n << std::endl;
 
-      // add tiny amount to velocity-cp_normal projections to avoid
-      // division by zero. Note that if these projections are close to 
-      // zero, there may stationary interactions or tangential motion. 
-      // In this case, any timestep estimate will be very large, and 
-      // not control the simulation
+      // add tiny amount to velocity projections to avoid division by zero. 
+      // Note that if these projections are close to zero, there may be 
+      // stationary interactions or tangential motion. In this case, any 
+      // timestep estimate will be very large, and not control the simulation
       real tiny = 1.e-12;
       real tiny1 = (v1_dot_n >= 0.) ? tiny : -1.*tiny;
       real tiny2 = (v2_dot_n >= 0.) ? tiny : -1.*tiny;
       v1_dot_n  += tiny1;
       v2_dot_n  += tiny2;
-      // add tiny amount to velocity-face_normal projections to avoid
-      // division by zero
+      // reset tiny velocity based on face normal projections.
       tiny1 = (v1_dot_n1 >= 0.) ? tiny : -1.*tiny;
       tiny2 = (v2_dot_n2 >= 0.) ? tiny : -1.*tiny;
       v1_dot_n1 += tiny1;
@@ -1433,12 +1424,11 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       //std::cout << "Second v1_dot_n: " << v1_dot_n << std::endl;
       //std::cout << "Second v2_dot_n: " << v2_dot_n << std::endl;
 
-      // get volume element thicknesses associated with each 
-      // face in this pair and find minimum
+      // get volume element thicknesses associated with each face in this pair
       real t1 = mesh1.m_elemData.m_thickness[pair.pairIndex1];
       real t2 = mesh2.m_elemData.m_thickness[pair.pairIndex2];
 
-      // compute the gap vector (recall gap is x1-x2 by convention)
+      // compute the existing gap vector (recall gap is x1-x2 by convention)
       real gapVec[dim];
       gapVec[0] = cpMgr.m_cXf1[cpID] - cpMgr.m_cXf2[cpID];
       gapVec[1] = cpMgr.m_cYf1[cpID] - cpMgr.m_cYf2[cpID];
@@ -1447,13 +1437,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
          gapVec[2] = cpMgr.m_cZf1[cpID] - cpMgr.m_cZf2[cpID];
       }
 
-      // compute the dot product between gap vector and the outward 
-      // unit face normals. Note: the amount of interpenetration is 
-      // going to be compared to a length/thickness parameter that 
-      // is computed in the direction of the outward unit normal, 
-      // NOT the normal of the contact plane. This is despite the 
-      // fact that the contact nodal forces are resisting contact 
-      // in the direction of the overlap normal. 
+      // compute the dot product between gap vector and the outward unit face normals. 
       real gap_f1_n1 = dotProd( &gapVec[0], &fn1[0], dim );
       real gap_f2_n2 = dotProd( &gapVec[0], &fn2[0], dim );
 
@@ -1465,10 +1449,11 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       bool dt1_vel_check = false;
       bool dt2_vel_check = false;
 
+      // maximum allowable interpenetration in the normal direction of each element
       real max_delta1 = proj_ratio * t1;
       real max_delta2 = proj_ratio * t2;
 
-      // Trigger for check 1 and 2:
+      // Separation or interpenetration trigger for check 1 and 2:
       // check if there is further interpen or separation based on the 
       // velocity projection in the direction of the common-plane normal,
       // which is in the direction of face-2 normal.
@@ -1482,43 +1467,47 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
       dt1_vel_check = (v1_dot_n < 0.) ? true : false; 
       dt2_vel_check = (v2_dot_n > 0.) ? true : false; 
 
-      ////////////////////////////////////////////////////////////////////
-      // 1. Current interpenetration gap exceeds max allowable interpen // 
-      ////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////
+      // Check 1. Current interpenetration gap exceeds max allowable interpen // 
+      //////////////////////////////////////////////////////////////////////////
 
-      // check if pair is in contact per Common Plane method. Note: this check 
-      // to see if the face-pair is in contact uses the gap computed on the 
-      // contact plane, which is in the direction of the overlap normal
-      if (cpMgr.m_inContact[cpID]) // gap < gap_tol
+      // check if face-pair is in contact (i.e. gap < gap_tol), which is determined
+      // in Common Plane ApplyNormal<>() routine
+      if (cpMgr.m_inContact[cpID])
       {
 
          // compute the difference between the 'face-gaps' and the max allowable 
-         // interpen as a function of element thickness. 
+         // interpen as a function of element thickness. Note, we have to use the 
+         // gap projected onto the outward unit face-normal to check against the
+         // max allowable gap as a factor of the thickness in the element normal
+         // direction 
          real delta1 = max_delta1 - gap_f1_n1; // >0 not exceeding max allowable
          real delta2 = max_delta2 + gap_f2_n2; // >0 not exceeding max allowable
 
-         if (delta1 < 0 || delta2 < 0)
-         {
-            max_gap_msg = true;
-         }
+         exceed_max_gap1 = (delta1 < 0.) ? true : false;
+         exceed_max_gap2 = (delta2 < 0.) ? true : false;
 
          // if velocity projection indicates further interpenetration, and the gaps
          // EXCEED max allowable, then compute time step estimates to reduce overlap
-         dt1_check1 = (dt1_vel_check) ? (delta1 < 0.) : false;
-         dt2_check1 = (dt2_vel_check) ? (delta2 < 0.) : false;
+         dt1_check1 = (dt1_vel_check) ? exceed_max_gap1 : false;
+         dt2_check1 = (dt2_vel_check) ? exceed_max_gap2 : false;
 
-         // compute dt for face 1 and 2 based on the velocity projection in the 
-         // direction of that face's outward unit normal
-         // Note, this calculation takes a fraction of the computed dt to reduce 
-         // the amount of face-displacement in a given cycle.
+         // compute dt for face 1 and 2 based on the velocity and gap projections onto 
+         // the face-normals for faces where currect gap exceeds max allowable gap.
          //
-         // if dt[i]_check[i] is true, then delta[i] is < 0. per check above. Furthermore,
-         // if the velocity projection indicates further interpenetration, the velocity 
-         // projected onto that face's outward unit normal is always positive. Thus,
-         // dt[i] should never be negative unless the face-normal is flipped based on 
-         // vertex ordering.
-         dt1 = (dt1_check1) ? -alpha * delta1 / v1_dot_n1 : dt1;
-         dt2 = (dt2_check1) ? -alpha * delta2 / v2_dot_n2 : dt2;
+         // NOTE:
+         //
+         // This calculation RESETS the current gap to be g = 0, and computes a timestep
+         // such that the velocity projection of the overlap-to-face projected overlap 
+         // centroid does not exceed the max allowable gap. 
+         //
+         // This avoid a timestep crash in the case that the current gap barely exceeds 
+         // the max allowable and also allows a soft contact response with interpen
+         // in excess of the max allowable gap without causing timestep crashes.
+         //
+         // v1_dot_n1 > 0 and v2_dot_n2 > 0 for further interpen
+         dt1 = (dt1_check1) ? -alpha * max_delta1 / v1_dot_n1 : dt1;
+         dt2 = (dt2_check1) ? -alpha * max_delta2 / v2_dot_n2 : dt2;
 
          //std::cout << "dt1_check1, delta1 and v1_dot_n1: " << dt1_check1 << ", " << delta1 << ", " << v1_dot_n1 << std::endl;
          //std::cout << "dt2_check1, delta2 and v2_dot_n2: " << dt2_check1 << ", " << delta2 << ", " << v2_dot_n2 << std::endl;
@@ -1629,7 +1618,7 @@ void CouplingScheme::computeCommonPlaneTimeStep(real &dt)
 
    // print general messages once
    // Can we output this message on root? SRW
-   SLIC_DEBUG_IF(max_gap_msg, "tribol::computeCommonPlaneTimeStep(): there are "  <<
+   SLIC_DEBUG_IF(exceed_max_gap, "tribol::computeCommonPlaneTimeStep(): there are "  <<
                  "locations where mesh overlap may be too large. "                <<
                  "Cannot provide timestep vote. Reduce timestep and/or increase " << 
                  "penalty.");

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -1007,6 +1007,8 @@ int TestMesh::tribolSetupAndUpdate( ContactMethod method,
                  this->faceConn2, this->cellType, x, y, z );
 
    enableTimestepVote(params.enable_timestep_vote);
+   setTimestepPenFrac(params.timestep_pen_frac);
+   setTimestepScale(params.timestep_scale);
 
    // register nodal forces. Note, I was getting a seg fault when 
    // registering the same pointer to a single set of force arrays 

--- a/src/tribol/utils/TestUtils.hpp
+++ b/src/tribol/utils/TestUtils.hpp
@@ -53,6 +53,8 @@ struct TestControlParameters
       , rate_penalty_ratio       (0.0)
       , const_penalty            (1.0)
       , enable_timestep_vote     (false)
+      , timestep_pen_frac        (0.30)
+      , timestep_scale           (1.0)
    {}
 
    ~TestControlParameters() 
@@ -71,6 +73,8 @@ struct TestControlParameters
    real rate_penalty_ratio;
    real const_penalty;
    bool enable_timestep_vote;
+   real timestep_pen_frac;
+   real timestep_scale;
 };
 
 /*!


### PR DESCRIPTION
- Refactors the gap used in the common plane timestep calculation to reset the existing gap to g=0
- This fix avoids timestep crashes when the existing gap, or the velocity projected gap is slightly beyond the timestep interpenetration amount (as a factor of the element thickness).
- This fix also allows for a soft contact response without a timestep crash in the presence of larger amounts of interpenetration.
- Tests and comments have been updated