### PR TITLE
Removed instance where contact case AUTO is set to NO CASE.

### DIFF
--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -1192,39 +1192,6 @@ TEST_F( CouplingSchemeTest, auto_common_plane_with_element_thickness )
    EXPECT_EQ( isInit, true );
 }
 
-TEST_F( CouplingSchemeTest, two_meshes_with_auto_case )
-{
-   tribol::CommType problem_comm = TRIBOL_COMM_WORLD;
-   tribol::initialize( 3, problem_comm );
-
-   int meshId1 = 0;
-   int meshId2 = 1;
-   int numElements = 1;
-   int csId = 0;
-   registerDummy3DMesh( meshId1, numElements );
-   registerDummy3DMesh( meshId2, numElements );
-
-   tribol::registerCouplingScheme(csId, meshId1, meshId2,
-                                  tribol::SURFACE_TO_SURFACE,
-                                  tribol::AUTO,
-                                  tribol::COMMON_PLANE,
-                                  tribol::FRICTIONLESS,
-                                  tribol::PENALTY,
-                                  tribol::BINNING_GRID );
-
-   tribol::setKinematicConstantPenalty( meshId1, 1.0 );
-   tribol::setKinematicConstantPenalty( meshId2, 1.0 );
-
-   tribol::setPenaltyOptions( csId, tribol::KINEMATIC,
-                              tribol::KINEMATIC_CONSTANT ); 
-
-   tribol::CouplingSchemeManager& csManager = tribol::CouplingSchemeManager::getInstance();
-   tribol::CouplingScheme* scheme  = csManager.getCoupling(csId);
-   bool isInit = scheme->init();
-
-   EXPECT_EQ( isInit, true );
-}
-
 int main(int argc, char* argv[])
 {
   int result = 0;

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -517,14 +517,6 @@ bool CouplingScheme::isValidCase()
       this->m_contactCase = NO_CASE;
    }
 
-   // catch incorrectly specified AUTO contact case
-   if (this->m_contactCase == AUTO &&
-       (this->m_meshId1 != this->m_meshId2))
-   {
-      this->m_couplingSchemeInfo.cs_case_info = SPECIFYING_NONE_WITH_TWO_REGISTERED_MESHES;
-      this->m_contactCase = NO_CASE;
-   }
-
    // specify auto-contact specific interpenetration check and verify 
    // element thicknesses have been registered
    parameters_t& params = parameters_t::getInstance();


### PR DESCRIPTION
There was a coupling scheme validity check that if the registered contact case is AUTO, but the mesh ids are different, than the contact case was overwritten as NO_CASE. 

This is not necessarily a bug, but we have a use case that does things a little differently. The most general case of auto contact is that I have one mesh (id = 1) that I register with Tribol, and I register a coupling scheme with mesh id=1 to be in contact with mesh id=1. That is the usual setting in which someone thinks about auto contact. 

We have a case, however, where the host code loops over contact surfaces that are specified. In this case, surface 1 may be specified to be in contact with surface 2. Then, the host code may construct two meshes with unique ids, one for surface 1 and one for surface 2. If, however, both surfaces have the SAME boundary attribute, then the two meshes that are constructed are in fact the same collection of faces with that SINGLE boundary attribute. This is the case where the check that this PR removes  was not doing the right thing. 

In principle, nothing should happen in Tribol if in fact a host code specifies two different mesh ids that actually have two unique sets of faces, and specifies that the contact case is AUTO. The coupling scheme will still process faces in one mesh against faces on the other mesh.