### PR TITLE
Reset null mesh value with each CouplingScheme validity check

### DIFF
--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -389,6 +389,9 @@ bool CouplingScheme::isValidCouplingScheme()
    MeshData & mesh1 = meshManager.GetMeshInstance( this->m_meshId1 );
    MeshData & mesh2 = meshManager.GetMeshInstance( this->m_meshId2 );
 
+   // set boolean for null meshes
+   this->m_nullMeshes = mesh1.m_numCells <= 0 || mesh2.m_numCells <= 0;
+
    // check for invalid mesh topology matches in a coupling scheme
    if (mesh1.m_elementType != mesh2.m_elementType)
    {
@@ -402,13 +405,6 @@ bool CouplingScheme::isValidCouplingScheme()
    if (!mesh1.m_isValid || !mesh2.m_isValid)
    {
       return false;
-   }
-   
-   // set boolean for null meshes
-   if ( mesh1.m_numCells <= 0 || mesh2.m_numCells <= 0 )
-   {
-      this->m_nullMeshes = true;
-      valid = true; // a null-mesh coupling scheme should still be valid
    }
 
    // check valid contact mode. Not all modes have an implementation


### PR DESCRIPTION
@zatkins-work found an issue with Tribol not resetting the null meshes each time a `CouplingScheme` is checked for validity.  Currently, the variable `CouplingScheme::m_nullMeshes` is true if any of the meshes have ever been null.  After the fix, the value of `CouplingScheme::m_nullMeshes` will only be true if either of the meshes is currently null.

Thanks for the fix @zatkins-work!