### PR TITLE
Fixed Bug in Adjancent Face Check in Geom Filter

### DIFF
--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -517,7 +517,7 @@ struct parameters_t
   bool enable_timestep_vote;     ///! True if host-code desires the timestep vote to be calculated and returned
 
   double auto_contact_len_scale_factor; ///! Sacle factor applied to element thickness for auto contact length scale
-  bool auto_contact_check;              ///! True for auto contact enabled checks (e.g. geometry specific checks etc.)
+  bool auto_contact_check;              ///! True if auto-contact checks should be enabled
 
 private:
 

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -517,7 +517,7 @@ struct parameters_t
   bool enable_timestep_vote;     ///! True if host-code desires the timestep vote to be calculated and returned
 
   double auto_contact_len_scale_factor; ///! Sacle factor applied to element thickness for auto contact length scale
-  bool auto_interpen_check;             ///! True if the auto-contact interpenetration check is used for full-overlap pairs
+  bool auto_contact_check;              ///! True for auto contact enabled checks (e.g. geometry specific checks etc.)
 
 private:
 

--- a/src/tribol/geom/ContactPlane.cpp
+++ b/src/tribol/geom/ContactPlane.cpp
@@ -308,7 +308,7 @@ bool ExceedsMaxAutoInterpen( const MeshData& meshDat1, const MeshData& meshDat2,
                              const int faceId1, const int faceId2, const real gap )
 {
    parameters_t& params = parameters_t::getInstance();
-   if (params.auto_interpen_check)
+   if (params.auto_contact_check)
    {
       real max_interpen = -1. * params.auto_contact_pen_frac * 
                           axom::utilities::min( meshDat1.m_elemData.m_thickness[ faceId1 ],

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -78,7 +78,7 @@ void set_defaults()
    // interpenetration kinematic gap is more than the smallest thickness of the 
    // constituent face elements, then we don't consider the face-pair a contact candidate.
    // Note, auto-contact will require registration of element thicknesses.
-   parameters.auto_interpen_check           = false; // true if the auto-contact interpenetration check is used for interpenetrating face-pairs.
+   parameters.auto_contact_check           = false; // true if the auto-contact specific checks will be enabled 
 
 }
 

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -519,9 +519,10 @@ bool CouplingScheme::isValidCase()
       {
          case AUTO:
          {
-            // specify auto-contact specific interpenetration check and verify 
-            // element thicknesses have been registered
-            params.auto_interpen_check = true;
+            // enable auto-contact specific checks through boolean, and check to 
+            // make sure element thicknesses have been registered for auto-contact 
+            // length scale calculations
+            params.auto_contact_check = true;
 
             MeshManager & meshManager = MeshManager::getInstance(); 
             MeshData & mesh1 = meshManager.GetMeshInstance( this->m_meshId1 );
@@ -538,13 +539,13 @@ bool CouplingScheme::isValidCase()
          case TIED_FULL:
          {
             // uncomment when there is an implementation
-            //params.auto_interpen_check = false;
+            //params.auto_contact_check = false;
             this->m_couplingSchemeErrors.cs_case_error = NO_CASE_IMPLEMENTATION;
             isValid = false;
             break;
          }
          default:
-            params.auto_interpen_check = false;
+            params.auto_contact_check = false;
       } // end switch on case
    } // end if check on common-plane
 

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -50,28 +50,36 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
    // get instance of mesh manager
    MeshManager & meshManager = MeshManager::getInstance();
 
+   // get instance of parameters
+   parameters_t & parameters = parameters_t::getInstance();
+
    // get instance of mesh data
    MeshData& mesh1 = meshManager.GetMeshInstance(meshId1);
    MeshData& mesh2 = meshManager.GetMeshInstance(meshId2);
    int dim = mesh1.m_dim;
 
-   /// CHECK #2: Check to make sure faces don't share a common
+   /// CHECK #2: Auto-contact precludes faces that share a common
    ///           node(s). We want to preclude two adjacent faces from interacting 
    //            due to problematic configurations, such as corners where the
    //            configuration and opposing normals appear to be in contact, but 
-   //            are not. This will preclude two adjacent faces from being in self-contact,
-   //            but self-contact should be adequately resolved beyond this local face-pair
-   //            check.
-   for (int i=0; i<mesh1.m_numNodesPerCell; ++i)
+   //            are not.
+   //
+   //            Note: non-auto-contact coupling schemes should typically be amongst
+   //                  topologically disconnected surfaces unless it is known apriori that
+   //                  face-pairs with shared nodes can in fact contact.
+   if (parameters.auto_contact_check)
    {
-      int node1 = mesh1.getFaceNodeId(faceId1, i);
-      for (int j=0; j<mesh2.m_numNodesPerCell; ++j)
+      for (int i=0; i<mesh1.m_numNodesPerCell; ++i)
       {
-         int node2 = mesh2.getFaceNodeId(faceId2, j);
-         if (node1 == node2)
+         int node1 = mesh1.getFaceNodeId(faceId1, i);
+         for (int j=0; j<mesh2.m_numNodesPerCell; ++j)
          {
-           iPair.isContactCandidate = false;
-           return iPair.isContactCandidate;
+            int node2 = mesh2.getFaceNodeId(faceId2, j);
+            if (node1 == node2)
+            {
+              iPair.isContactCandidate = false;
+              return iPair.isContactCandidate;
+            }
          }
       }
    }

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -56,21 +56,22 @@ bool geomFilter( InterfacePair & iPair, ContactMode const mode )
    int dim = mesh1.m_dim;
 
    /// CHECK #2: Check to make sure faces don't share a common
-   ///           node for the case where meshId1 = meshId2.
-   ///           We want to preclude two adjacent faces from interacting.
-   if (meshId1 == meshId2)
+   ///           node(s). We want to preclude two adjacent faces from interacting 
+   //            due to problematic configurations, such as corners where the
+   //            configuration and opposing normals appear to be in contact, but 
+   //            are not. This will preclude two adjacent faces from being in self-contact,
+   //            but self-contact should be adequately resolved beyond this local face-pair
+   //            check.
+   for (int i=0; i<mesh1.m_numNodesPerCell; ++i)
    {
-      for (int i=0; i<mesh1.m_numNodesPerCell; ++i)
+      int node1 = mesh1.getFaceNodeId(faceId1, i);
+      for (int j=0; j<mesh2.m_numNodesPerCell; ++j)
       {
-         int node1 = mesh1.getFaceNodeId(faceId1, i);
-         for (int j=0; j<mesh2.m_numNodesPerCell; ++j)
+         int node2 = mesh2.getFaceNodeId(faceId2, j);
+         if (node1 == node2)
          {
-            int node2 = mesh2.getFaceNodeId(faceId2, j);
-            if (node1 == node2)
-            {
-              iPair.isContactCandidate = false;
-              return iPair.isContactCandidate;
-            }
+           iPair.isContactCandidate = false;
+           return iPair.isContactCandidate;
          }
       }
    }


### PR DESCRIPTION
- Adjacent faces were precluded from contact ONLY for matching mesh ids, which presents issues at sharp edges or corners where the configuration and opposing normals make the faces appear to be in contact.
- This removes the conditional on the mesh ids, which doesn't mean anything anymore, and simply precludes contact between adjacent faces. This removes adjacent faces at corners from being included in contact (which is wrong). 
- The consequence is that two adjacent faces can't be in self contact, but self-contact should be resolved beyond such a local face-pair anyway.