### PR TITLE
add macos spack config

### DIFF
--- a/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
+++ b/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
@@ -1,0 +1,59 @@
+spack:
+  # add package specs to the `specs` list
+  view: true
+  concretizer:
+    unify: true
+  packages:
+    all:
+      compiler: [clang, gcc]
+      providers:
+        blas: [netlib-lapack]
+        lapack: [netlib-lapack]
+        mpi: [openmpi]
+    mpi:
+      buildable: false
+    openmpi:
+      buildable: false
+      externals:
+      - spec: openmpi@5.0.6
+        prefix: /opt/homebrew
+    netlib-lapack:
+      buildable: false
+      externals:
+      - spec: netlib-lapack@3.12.0
+        prefix: /opt/homebrew/opt/lapack
+    cmake:
+      version: [3.31.1]
+      buildable: false
+      externals:
+      - spec: cmake@3.31.1
+        prefix: /opt/homebrew
+    hdf5:
+      version: [1.14.5]
+      buildable: false
+      externals:
+      - spec: hdf5@1.14.5
+        prefix: /opt/homebrew
+    lua:
+      version: [5.4.7]
+      buildable: false
+      externals:
+      - spec: lua@5.4.7
+        prefix: /opt/homebrew
+
+ # The "::" removes all found/known compilers from Spack except for these.
+  compilers::
+  - compiler:
+      spec: clang@=19.1.4
+      paths:
+        cc: /opt/homebrew/opt/llvm/bin/clang
+        cxx: /opt/homebrew/opt/llvm/bin/clang++
+        f77: /opt/homebrew/bin/gfortran-14
+        fc: /opt/homebrew/bin/gfortran-14
+      flags: {}
+      operating_system: sequoia
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths:
+      - /opt/homebrew/lib/gcc/14

--- a/src/tribol/common/Containers.hpp
+++ b/src/tribol/common/Containers.hpp
@@ -45,11 +45,11 @@ protected:
     }
   }
   TRIBOL_HOST_DEVICE DeviceArrayData(DeviceArrayData&& other)
-  : size_ {other.size},
+  : size_ {other.size_},
     data_ {other.data_}
   {
     // reset other
-    other.size = 0;
+    other.size_ = 0;
     other.data_ = nullptr;
   }
 

--- a/src/tribol/integ/Integration.cpp
+++ b/src/tribol/integ/Integration.cpp
@@ -96,7 +96,7 @@ TRIBOL_HOST_DEVICE void EvalWeakFormIntegral< COMMON_PLANE, SINGLE_POINT >
                               projX2[elem.dim*i+2] );
 
          SLIC_DEBUG("face 2 projected vertex " << i << ": " << elem.m_mesh2->getPosition()[0][nodeId2] << ", " << elem.m_mesh2->getPosition()[1][nodeId2] <<
-                      elem.m_mesh2->getPosition[2][nodeId2]);
+                      elem.m_mesh2->getPosition()[2][nodeId2]);
       }
    } 
    else


### PR DESCRIPTION
Adds a spack config for Mac OS Sequoia and fixes a couple of small errors caught by the compiler.