### PR TITLE
enable setting number of redecomp ranks

### DIFF
--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -15,12 +15,12 @@
 
 namespace redecomp {
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, PartitionType method, int num_ranks )
-    : RedecompMesh( parent, DefaultGhostLength( parent ), method, num_ranks )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, PartitionType method, int n_ranks )
+    : RedecompMesh( parent, DefaultGhostLength( parent ), method, n_ranks )
 {
 }
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method, int num_ranks )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method, int n_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
   // build partitioner
@@ -54,24 +54,24 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, Pa
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
-  if ( num_ranks == 0 ) {
+  if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
     // additional factor of 10 targets about 10 pairs/rank
-    num_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+    n_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
   }
   // p2r = parent to redecomp
-  auto p2r_elems_ = BuildP2RElementList( *partitioner, num_ranks, ghost_length );
+  p2r_elems_ = BuildP2RElementList( *partitioner, n_ranks, ghost_length );
   BuildRedecomp();
 }
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int num_ranks )
-    : RedecompMesh( parent, DefaultGhostLength( parent ), std::move( partitioner ), num_ranks )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int n_ranks )
+    : RedecompMesh( parent, DefaultGhostLength( parent ), std::move( partitioner ), n_ranks )
 {
 }
 
 RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
-                            std::unique_ptr<const Partitioner> partitioner, int num_ranks )
+                            std::unique_ptr<const Partitioner> partitioner, int n_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
   // check partitioner
@@ -81,8 +81,7 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
       SLIC_ERROR_ROOT_IF( partitioner2d == nullptr, "Partitioner must be Partitioner2D." );
       auto partition_elems2d = dynamic_cast<const PartitionElements2D*>( partitioner2d->getPartitionEntity() );
       SLIC_ERROR_ROOT_IF( partition_elems2d == nullptr,
-                          "Redecomp requires the PartitionEntity "
-                          "to be PartitionElements." );
+                          "Redecomp requires the PartitionEntity to be PartitionElements." );
       break;
     }
     case 3: {
@@ -90,22 +89,21 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
       SLIC_ERROR_ROOT_IF( partitioner3d == nullptr, "Partitioner must be Partitioner3D." );
       auto partition_elems3d = dynamic_cast<const PartitionElements3D*>( partitioner3d->getPartitionEntity() );
       SLIC_ERROR_ROOT_IF( partition_elems3d == nullptr,
-                          "Redecomp requires the PartitionEntity "
-                          "to be PartitionElements." );
+                          "Redecomp requires the PartitionEntity to be PartitionElements." );
       break;
     }
     default:
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
-  if ( num_ranks == 0 ) {
+  if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
     // additional factor of 10 targets about 10 pairs/rank
-    num_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+    n_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
   }
   // p2r = parent to redecomp
-  p2r_elems_ = BuildP2RElementList( *partitioner, num_ranks, ghost_length );
+  p2r_elems_ = BuildP2RElementList( *partitioner, n_ranks, ghost_length );
   BuildRedecomp();
 }
 

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -54,11 +54,15 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, Pa
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
+  SLIC_ERROR_ROOT_IF( n_ranks < 0, "Number of ranks must be non-negative." );
+  SLIC_ERROR_ROOT_IF( n_ranks > parent.GetNRanks(),
+                      "Number of ranks must be less than or equal to the number of MPI ranks." );
   auto parent_n_els = static_cast<int>( parent.GetGlobalNE() );
   if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
-    // additional factor of 10 targets about 10 pairs/rank
+    // additional factor of 10 targets about 10 pairs/rank on a conforming mesh (and more than 10 on a non-conforming
+    // mesh)
     n_ranks = std::max( std::min( parent.GetNRanks(), ( parent_n_els + 1 ) / 2 / 10 ), 1 );
   }
   SLIC_INFO_ROOT( axom::fmt::format( "Repartitioning {} elements onto {} ranks...", parent_n_els, n_ranks ) );
@@ -98,11 +102,15 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
+  SLIC_ERROR_ROOT_IF( n_ranks < 0, "Number of ranks must be non-negative." );
+  SLIC_ERROR_ROOT_IF( n_ranks > parent.GetNRanks(),
+                      "Number of ranks must be less than or equal to the number of MPI ranks." );
   auto parent_n_els = static_cast<int>( parent.GetGlobalNE() );
   if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
-    // additional factor of 10 targets about 10 pairs/rank
+    // additional factor of 10 targets about 10 pairs/rank on a conforming mesh (and more than 10 on a non-conforming
+    // mesh)
     n_ranks = std::max( std::min( parent.GetNRanks(), ( parent_n_els + 1 ) / 2 / 10 ), 1 );
   }
   SLIC_INFO_ROOT( axom::fmt::format( "Repartitioning {} elements onto {} ranks...", parent_n_els, n_ranks ) );

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -54,12 +54,14 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, Pa
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
+  auto parent_n_els = static_cast<int>( parent.GetGlobalNE() );
   if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
     // additional factor of 10 targets about 10 pairs/rank
-    n_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+    n_ranks = std::max( std::min( parent.GetNRanks(), ( parent_n_els + 1 ) / 2 / 10 ), 1 );
   }
+  SLIC_INFO_ROOT( axom::fmt::format( "Repartitioning {} elements onto {} ranks...", parent_n_els, n_ranks ) );
   // p2r = parent to redecomp
   p2r_elems_ = BuildP2RElementList( *partitioner, n_ranks, ghost_length );
   BuildRedecomp();
@@ -96,12 +98,14 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
+  auto parent_n_els = static_cast<int>( parent.GetGlobalNE() );
   if ( n_ranks == 0 ) {
     // preclude degenerate case where num elements/2 < num ranks
     // factor of 2 on num elements are due to elements being paired for contact
     // additional factor of 10 targets about 10 pairs/rank
-    n_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+    n_ranks = std::max( std::min( parent.GetNRanks(), ( parent_n_els + 1 ) / 2 / 10 ), 1 );
   }
+  SLIC_INFO_ROOT( axom::fmt::format( "Repartitioning {} elements onto {} ranks...", parent_n_els, n_ranks ) );
   // p2r = parent to redecomp
   p2r_elems_ = BuildP2RElementList( *partitioner, n_ranks, ghost_length );
   BuildRedecomp();

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -15,12 +15,12 @@
 
 namespace redecomp {
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, PartitionType method )
-    : RedecompMesh( parent, DefaultGhostLength( parent ), method )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, PartitionType method, int num_ranks )
+    : RedecompMesh( parent, DefaultGhostLength( parent ), method, num_ranks )
 {
 }
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method, int num_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
   // build partitioner
@@ -54,20 +54,24 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, Pa
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
-  // preclude degenerate case where num elements/2 < num ranks
-  // factor of 2 on num elements are due to elements being paired for contact
-  auto n_parts = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 );
-  p2r_elems_ = BuildP2RElementList( *partitioner, n_parts, ghost_length );
+  if ( num_ranks == 0 ) {
+    // preclude degenerate case where num elements/2 < num ranks
+    // factor of 2 on num elements are due to elements being paired for contact
+    // additional factor of 10 targets about 10 pairs/rank
+    num_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+  }
+  // p2r = parent to redecomp
+  auto p2r_elems_ = BuildP2RElementList( *partitioner, num_ranks, ghost_length );
   BuildRedecomp();
 }
 
-RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner )
-    : RedecompMesh( parent, DefaultGhostLength( parent ), std::move( partitioner ) )
+RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int num_ranks )
+    : RedecompMesh( parent, DefaultGhostLength( parent ), std::move( partitioner ), num_ranks )
 {
 }
 
 RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
-                            std::unique_ptr<const Partitioner> partitioner )
+                            std::unique_ptr<const Partitioner> partitioner, int num_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
   // check partitioner
@@ -94,10 +98,14 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
       SLIC_ERROR_ROOT( "Only 2D and 3D meshes are supported." );
   }
 
-  // preclude degenerate case where num elements < num ranks
-  auto n_parts = std::min( parent.GetNRanks(), static_cast<int>( parent.GetGlobalNE() ) );
+  if ( num_ranks == 0 ) {
+    // preclude degenerate case where num elements/2 < num ranks
+    // factor of 2 on num elements are due to elements being paired for contact
+    // additional factor of 10 targets about 10 pairs/rank
+    num_ranks = std::min( parent.GetNRanks(), ( static_cast<int>( parent.GetGlobalNE() ) + 1 ) / 2 / 10 );
+  }
   // p2r = parent to redecomp
-  p2r_elems_ = BuildP2RElementList( *partitioner, n_parts, ghost_length );
+  p2r_elems_ = BuildP2RElementList( *partitioner, num_ranks, ghost_length );
   BuildRedecomp();
 }
 

--- a/src/redecomp/RedecompMesh.hpp
+++ b/src/redecomp/RedecompMesh.hpp
@@ -42,25 +42,29 @@ class RedecompMesh : public mfem::Mesh {
   /**
    * @brief Construct a new RedecompMesh object
    *
-   * @note This constructor builds the Partitioner object based on the method
-   * passed. If no method is passed, a RCB Partitioner is constructed.
+   * @note This constructor builds the Partitioner object based on the method passed. If no method is passed, a RCB
+   * Partitioner is constructed.
    *
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param method The method of redecomposition (optional)
+   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, PartitionType method = RCB );
+  RedecompMesh( const mfem::ParMesh& parent, PartitionType method = RCB, int num_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
    *
-   * @note This constructor builds the Partitioner object based on the method
-   * passed. If no method is passed, a RCB Partitioner is constructed.
+   * @note This constructor builds the Partitioner object based on the method passed. If no method is passed, a RCB
+   * Partitioner is constructed.
    *
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param ghost_length Size of layer of un-owned ghost elements to include around the edge of the on-rank domain
    * @param method The method of redecomposition (optional)
+   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method = RCB );
+  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method = RCB, int num_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
@@ -71,8 +75,10 @@ class RedecompMesh : public mfem::Mesh {
    *
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param partitioner Partitioning object used to define redecomposition
+   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner );
+  RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int num_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
@@ -84,8 +90,11 @@ class RedecompMesh : public mfem::Mesh {
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param ghost_length Size of layer of un-owned ghost elements to include around the edge of the on-rank domain
    * @param partitioner Partitioning object used to define redecomposition
+   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, std::unique_ptr<const Partitioner> partitioner );
+  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, std::unique_ptr<const Partitioner> partitioner,
+                int num_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object

--- a/src/redecomp/RedecompMesh.hpp
+++ b/src/redecomp/RedecompMesh.hpp
@@ -47,10 +47,10 @@ class RedecompMesh : public mfem::Mesh {
    *
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param method The method of redecomposition (optional)
-   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * @param n_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
    * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, PartitionType method = RCB, int num_ranks = 0 );
+  RedecompMesh( const mfem::ParMesh& parent, PartitionType method = RCB, int n_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
@@ -61,10 +61,10 @@ class RedecompMesh : public mfem::Mesh {
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param ghost_length Size of layer of un-owned ghost elements to include around the edge of the on-rank domain
    * @param method The method of redecomposition (optional)
-   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * @param n_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
    * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method = RCB, int num_ranks = 0 );
+  RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method = RCB, int n_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
@@ -75,10 +75,10 @@ class RedecompMesh : public mfem::Mesh {
    *
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param partitioner Partitioning object used to define redecomposition
-   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * @param n_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
    * automatically determined.
    */
-  RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int num_ranks = 0 );
+  RedecompMesh( const mfem::ParMesh& parent, std::unique_ptr<const Partitioner> partitioner, int n_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object
@@ -90,11 +90,11 @@ class RedecompMesh : public mfem::Mesh {
    * @param parent The mfem::ParMesh that will be redecomposed
    * @param ghost_length Size of layer of un-owned ghost elements to include around the edge of the on-rank domain
    * @param partitioner Partitioning object used to define redecomposition
-   * @param num_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
+   * @param n_ranks Sets number of MPI ranks to build RedecompMesh on (default = 0). Set this to zero to have this
    * automatically determined.
    */
   RedecompMesh( const mfem::ParMesh& parent, double ghost_length, std::unique_ptr<const Partitioner> partitioner,
-                int num_ranks = 0 );
+                int n_ranks = 0 );
 
   /**
    * @brief Construct a new RedecompMesh object

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -230,7 +230,7 @@ class CartesianProduct : public SearchBase {
 #ifdef TRIBOL_USE_RAJA
                   RAJA::atomicAdd<RAJA::auto_atomic>( pCount, static_cast<int>( isProximate[i] ) );
 #else
-        if (isProximate[i]) { ++(*pCount); }
+                  if (isProximate[i]) { ++(*pCount); }
 #endif
                 } );
 


### PR DESCRIPTION
This PR makes two small changes

- Allows the user to specify how many ranks the redecomp mesh should be created on
- Targets about 10 element pairs/rank as a new minimum default