### PR TITLE
Add proximity scale for binning

### DIFF
--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -463,13 +463,14 @@ struct EnforcementOptions {
 struct Parameters {
   CommT problem_comm = TRIBOL_COMM_WORLD;  ///! MPI communicator for the problem
 
-  RealT binning_proximity_scale = 4.0;  ///! Approximate element length multiplier for including pairs in coarse binning
-  RealT overlap_area_frac = 1.0e-8;     ///! Ratio of overlap area to largest face area for contact inclusion
-  RealT gap_tol_ratio = 1.0e-12;        ///! Ratio for determining tolerance for active contact gaps
-  RealT gap_separation_ratio = 0.75;    ///! Ratio for determining allowable separation in geometric filtering
-  RealT gap_tied_tol = 0.1;             ///! Ratio for determining max separation tied contact can support
-  RealT len_collapse_ratio = 1.0e-8;    ///! Ratio of face length providing topology collapse length tolerance
-  RealT projection_ratio = 1.0e-10;     ///! Ratio for defining nonzero projections
+  RealT binning_proximity_scale =
+      4.0;                           ///! Element length multiplier for coarse binning and proximity detection inclusion
+  RealT overlap_area_frac = 1.0e-8;  ///! Ratio of overlap area to largest face area for contact inclusion
+  RealT gap_tol_ratio = 1.0e-12;     ///! Ratio for determining tolerance for active contact gaps
+  RealT gap_separation_ratio = 0.75;  ///! Ratio for determining allowable separation in geometric filtering
+  RealT gap_tied_tol = 0.1;           ///! Ratio for determining max separation tied contact can support
+  RealT len_collapse_ratio = 1.0e-8;  ///! Ratio of face length providing topology collapse length tolerance
+  RealT projection_ratio = 1.0e-10;   ///! Ratio for defining nonzero projections
   RealT auto_contact_pen_frac =
       0.95;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
   RealT timestep_pen_frac =

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -463,12 +463,13 @@ struct EnforcementOptions {
 struct Parameters {
   CommT problem_comm = TRIBOL_COMM_WORLD;  ///! MPI communicator for the problem
 
-  RealT overlap_area_frac = 1.0e-8;   ///! Ratio of overlap area to largest face area for contact inclusion
-  RealT gap_tol_ratio = 1.0e-12;      ///! Ratio for determining tolerance for active contact gaps
-  RealT gap_separation_ratio = 0.75;  ///! Ratio for determining allowable separation in geometric filtering
-  RealT gap_tied_tol = 0.1;           ///! Ratio for determining max separation tied contact can support
-  RealT len_collapse_ratio = 1.0e-8;  ///! Ratio of face length providing topology collapse length tolerance
-  RealT projection_ratio = 1.0e-10;   ///! Ratio for defining nonzero projections
+  RealT binning_proximity_scale = 4.0;  ///! Approximate element length multiplier for including pairs in coarse binning
+  RealT overlap_area_frac = 1.0e-8;     ///! Ratio of overlap area to largest face area for contact inclusion
+  RealT gap_tol_ratio = 1.0e-12;        ///! Ratio for determining tolerance for active contact gaps
+  RealT gap_separation_ratio = 0.75;    ///! Ratio for determining allowable separation in geometric filtering
+  RealT gap_tied_tol = 0.1;             ///! Ratio for determining max separation tied contact can support
+  RealT len_collapse_ratio = 1.0e-8;    ///! Ratio of face length providing topology collapse length tolerance
+  RealT projection_ratio = 1.0e-10;     ///! Ratio for defining nonzero projections
   RealT auto_contact_pen_frac =
       0.95;  ///! Max allowable interpenetration as percent of element thickness for contact candidacy
   RealT timestep_pen_frac =

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -318,6 +318,19 @@ void setLoggingLevel( IndexT cs_id, LoggingLevel log_level )
 }  // end setLoggingLevel()
 
 //------------------------------------------------------------------------------
+void setBinningProximityScale( IndexT cs_id, RealT binning_proximity_scale )
+{
+  // get access to coupling scheme
+  auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
+
+  SLIC_ERROR_ROOT_IF( !cs, "tribol::setBinningProximityScale(): call tribol::registerCouplingScheme() "
+                               << "prior to calling this routine." );
+
+  cs->getParameters().binning_proximity_scale = binning_proximity_scale;
+
+}  // end setBinningProximityScale()
+
+//------------------------------------------------------------------------------
 void enableTimestepVote( IndexT cs_id, const bool enable )
 {
   auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
@@ -751,7 +764,8 @@ void setInterfacePairs( IndexT cs_id, IndexT numPairs, IndexT const* const pairI
     // to interface pair manager. Note, further computational geometry
     // filtering will be performed on each face-pair indendifying
     // contact candidates.
-    if ( geomFilter( pairIndex1[i], pairIndex2[i], mesh1, mesh2, mode, cs->getParameters().auto_contact_check ) ) {
+    if ( geomFilter( pairIndex1[i], pairIndex2[i], mesh1, mesh2, mode, cs->getParameters().auto_contact_check,
+                     cs->getParameters().binning_proximity_scale ) ) {
       pairs.emplace_back( pairIndex1[i], pairIndex2[i], true );
     }
   }

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -325,6 +325,11 @@ void setBinningProximityScale( IndexT cs_id, RealT binning_proximity_scale )
 
   SLIC_ERROR_ROOT_IF( !cs, "tribol::setBinningProximityScale(): call tribol::registerCouplingScheme() "
                                << "prior to calling this routine." );
+  if ( binning_proximity_scale < 2.0 ) {
+    binning_proximity_scale = 2.0;
+    SLIC_WARNING_ROOT(
+        "Setting binning proximity to less than 2.0 can lead to missed contact pairs.  Resetting to 2.0." );
+  }
 
   cs->getParameters().binning_proximity_scale = binning_proximity_scale;
 

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -197,6 +197,14 @@ void setOutputDirectory( IndexT cs_id, const std::string& dir );
 void setLoggingLevel( IndexT cs_id, LoggingLevel log_level );
 
 /*!
+ * @brief Optionally set the binning proximity scale; an element length multiplier for including pairs in coarse binning
+ *
+ * @param cs_id coupling scheme id
+ * @param binning_proximity_scale proximity scale
+ */
+void setBinningProximityScale( IndexT cs_id, RealT binning_proximity_scale );
+
+/*!
  * \brief Enable the contact timestep vote
  *
  * \param [in] cs_id coupling scheme id

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -100,9 +100,7 @@ TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, cons
     RealT distY = mesh2.getElementCentroids()[1][element_id2] - mesh1.getElementCentroids()[1][element_id1];
     RealT distZ = mesh2.getElementCentroids()[2][element_id2] - mesh1.getElementCentroids()[2][element_id1];
 
-    // scale the magnitude of the computed distance by 1% to include nearly coincident nodes/edges for 3D
-    // polygons that are nearly coplanar; otherwise, we may miss this configuration
-    RealT distMag = 1.01 * magnitude( distX, distY, distZ );
+    RealT distMag = magnitude( distX, distY, distZ );
 
     if ( distMag > ( distMax ) ) {
       return false;
@@ -113,9 +111,7 @@ TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, cons
     RealT e1 = 0.5 * mesh1.getElementAreas()[element_id1];
     RealT e2 = 0.5 * mesh2.getElementAreas()[element_id2];
 
-    // set maximum offset of edge centroids for inclusion. Scale by 1% to make
-    // sure we include nearly proximate faces for co-planar faces
-    RealT distMax = 1.01 * binning_proximity_scale * ( e1 + e2 );
+    RealT distMax = binning_proximity_scale * ( e1 + e2 );
 
     // check if the contact mode is conforming, in which case the
     // edges are supposed to be aligned

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -27,7 +27,8 @@ namespace tribol {
  *  Perform geometry/proximity checks 1-4
  */
 TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, const MeshData::Viewer& mesh1,
-                                    const MeshData::Viewer& mesh2, ContactMode mode, bool auto_contact_check )
+                                    const MeshData::Viewer& mesh2, ContactMode mode, bool auto_contact_check,
+                                    RealT binning_proximity_scale )
 {
   /// CHECK #1: Check to make sure the two face ids are not the same
   ///           and the two mesh ids are not the same.
@@ -84,7 +85,7 @@ TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, cons
     RealT r2 = mesh2.getFaceRadius()[element_id2];
 
     // set maximum offset of face centroids for inclusion
-    RealT distMax = r1 + r2;  // default is sum of face radii
+    RealT distMax = binning_proximity_scale * ( r1 + r2 );  // default is sum of face radii
 
     // check if the contact mode is conforming, in which case the
     // faces are supposed to be aligned
@@ -114,7 +115,7 @@ TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, cons
 
     // set maximum offset of edge centroids for inclusion. Scale by 1% to make
     // sure we include nearly proximate faces for co-planar faces
-    RealT distMax = 1.01 * ( e1 + e2 );
+    RealT distMax = 1.01 * binning_proximity_scale * ( e1 + e2 );
 
     // check if the contact mode is conforming, in which case the
     // edges are supposed to be aligned
@@ -213,11 +214,12 @@ class CartesianProduct : public SearchBase {
     ContactMode cmode = m_coupling_scheme->getContactMode();
 
     bool auto_contact_check = m_coupling_scheme->getParameters().auto_contact_check;
+    auto binning_proximity_scale = m_coupling_scheme->getParameters().binning_proximity_scale;
 
     // count how many pairs are proximate
     forAllExec( m_coupling_scheme->getExecutionMode(), maxNumPairs,
-                [mesh1NumElems, mesh2NumElems, is_symm, isProximate, mesh1, mesh2, cmode, pCount,
-                 auto_contact_check] TRIBOL_HOST_DEVICE( IndexT i ) {
+                [mesh1NumElems, mesh2NumElems, is_symm, isProximate, mesh1, mesh2, cmode, pCount, auto_contact_check,
+                 binning_proximity_scale] TRIBOL_HOST_DEVICE( IndexT i ) {
                   IndexT fromIdx = i / mesh2NumElems;
                   IndexT toIdx = i % mesh2NumElems;
                   if ( is_symm ) {
@@ -226,7 +228,8 @@ class CartesianProduct : public SearchBase {
                     fromIdx = row;
                     toIdx = i - offset;
                   }
-                  isProximate[i] = geomFilter( fromIdx, toIdx, mesh1, mesh2, cmode, auto_contact_check );
+                  isProximate[i] =
+                      geomFilter( fromIdx, toIdx, mesh1, mesh2, cmode, auto_contact_check, binning_proximity_scale );
 #ifdef TRIBOL_USE_RAJA
                   RAJA::atomicAdd<RAJA::auto_atomic>( pCount, static_cast<int>( isProximate[i] ) );
 #else
@@ -326,6 +329,7 @@ class GridSearch : public SearchBase {
     const RealT bboxTolerance = 1e-6;
 
     m_coupling_scheme->getInterfacePairs().clear();
+    auto binning_proximity_scale = m_coupling_scheme->getParameters().binning_proximity_scale;
 
     // if either mesh is empty, don't initialize because...
     // 1) there won't be any pairs
@@ -345,16 +349,13 @@ class GridSearch : public SearchBase {
     // Find an appropriate resolution for the spatial index grid
     //
     // (Note KW) This implementation is a bit ad-hoc
-    // * Inflate bounding boxes by 33% of longest dimension
-    //   to avoid zero-width dimensions
-    // * Find the average extents (range) of the boxes
-    //   Assumption is that elements are roughly the same size
-    // * Grid resolution for each dimension is overall box width
-    //   divided by half the average element width
+    // * Inflate bounding boxes by proximity scale * longest dimension to avoid zero-width dimensions
+    // * Find the average extents (range) of the boxes Assumption is that elements are roughly the same size
+    // * Grid resolution for each dimension is overall box width divided by half the average element width
     SpaceVec ranges;
     for ( int i = 0; i < m_mesh1.numberOfElements(); ++i ) {
       auto& bbox = m_meshBBoxes1[i];
-      inflateBBox( bbox );
+      inflateBBox( bbox, binning_proximity_scale );
 
       ranges += bbox.range();
 
@@ -410,13 +411,14 @@ class GridSearch : public SearchBase {
     const auto mesh1 = m_coupling_scheme->getMesh1().getView();
     const auto mesh2 = m_coupling_scheme->getMesh2().getView();
     auto& contactPairs = m_coupling_scheme->getInterfacePairs();
+    auto binning_proximity_scale = m_coupling_scheme->getParameters().binning_proximity_scale;
 
     // Find matches in first mesh (with index 'fromIdx')
     // with candidate elements in second mesh (with index 'toIdx')
-    int k = 0;
+    // int k = 0;  // Debug only
     for ( int toIdx = 0; toIdx < m_mesh2.numberOfElements(); ++toIdx ) {
       SpatialBoundingBox bbox = elementBoundingBox( m_mesh2, toIdx );
-      inflateBBox( bbox );
+      inflateBBox( bbox, binning_proximity_scale );
 
       // Query the mesh
       auto candidateBits = m_grid.getCandidates( bbox );
@@ -434,12 +436,13 @@ class GridSearch : public SearchBase {
 
         // Preliminary geometry/proximity checks, SRW
         bool contact = geomFilter( fromIdx, toIdx, mesh1, mesh2, m_coupling_scheme->getContactMode(),
-                                   m_coupling_scheme->getParameters().auto_contact_check );
+                                   m_coupling_scheme->getParameters().auto_contact_check,
+                                   m_coupling_scheme->getParameters().binning_proximity_scale );
 
         if ( contact ) {
           contactPairs.emplace_back( fromIdx, toIdx, true );
           // SLIC_INFO("Interface pair " << k << " = " << toIdx << ", " << fromIdx);  // Debug only
-          ++k;
+          // ++k;  // Debug only
         }
       }
     }  // end of loop over candidates in second mesh
@@ -465,12 +468,10 @@ class GridSearch : public SearchBase {
   /*!
    * Expands bounding box by 33% of longest dimension's range
    */
-  void inflateBBox( SpatialBoundingBox& bbox )
+  void inflateBBox( SpatialBoundingBox& bbox, RealT binning_proximity_scale )
   {
-    constexpr double sc = 1. / 3.;
-
     int d = bbox.getLongestDimension();
-    const RealT expansionFac = sc * bbox.range()[d];
+    const RealT expansionFac = binning_proximity_scale * bbox.range()[d];
     bbox.expand( expansionFac );
   }
 
@@ -565,13 +566,15 @@ class BvhSearch : public SearchBase {
     const auto mesh2 = m_coupling_scheme->getMesh2().getView();
     auto cmode = m_coupling_scheme->getContactMode();
     bool auto_contact_check = m_coupling_scheme->getParameters().auto_contact_check;
+    auto binning_proximity_scale = m_coupling_scheme->getParameters().binning_proximity_scale;
     // count the number of filtered proximate pairs
     forAllExec( m_coupling_scheme->getExecutionMode(), m_candidates.size(),
                 [mesh1, mesh2, offsets_view, counts_view, candidates_view, filtered_candidates, cmode,
-                 auto_contact_check] TRIBOL_HOST_DEVICE( IndexT i ) {
+                 auto_contact_check, binning_proximity_scale] TRIBOL_HOST_DEVICE( IndexT i ) {
                   auto mesh1_elem = algorithm::binarySearch( offsets_view, counts_view, i );
                   auto mesh2_elem = candidates_view[i];
-                  if ( geomFilter( mesh1_elem, mesh2_elem, mesh1, mesh2, cmode, auto_contact_check ) ) {
+                  if ( geomFilter( mesh1_elem, mesh2_elem, mesh1, mesh2, cmode, auto_contact_check,
+                                   binning_proximity_scale ) ) {
 #ifdef TRIBOL_USE_RAJA
                     RAJA::atomicInc<AtomicPolicy>( filtered_candidates.data() );
 #else

--- a/src/tribol/search/InterfacePairFinder.hpp
+++ b/src/tribol/search/InterfacePairFinder.hpp
@@ -26,10 +26,12 @@ class SearchBase;
  * \param [in] mesh2 mesh view for 2nd element in pair
  * \param [in] mode ContactMode
  * \param [in] auto_contact_check Is auto-contact assumed?
+ * \param [in] binning_proximity_scale Scaling applied to max element radius distance check
  *
  */
 TRIBOL_HOST_DEVICE bool geomFilter( IndexT element_id1, IndexT element_id2, const MeshData::Viewer& mesh1,
-                                    const MeshData::Viewer& mesh2, ContactMode mode, bool auto_contact_check );
+                                    const MeshData::Viewer& mesh2, ContactMode mode, bool auto_contact_check,
+                                    RealT binning_proximity_scale );
 
 /*!
  * \class InterfacePairFinder


### PR DESCRIPTION
Adds a proximity scaling for binning.  Sets the default at 4.0 with a minimum of 2.0 (enforced through the API call `setBinningProximityScale()`).