### PR TITLE
Get rid of braced initializer for `mfem::Vector` and `mfem::Array<T>`

### DIFF
--- a/.gitlab/build_ruby.yml
+++ b/.gitlab/build_ruby.yml
@@ -9,7 +9,7 @@
 # This is the shared configuration of jobs for ruby
 .on_ruby:
   variables:
-    ALLOC_OPTIONS: "--res=ci --exclusive=user --deadline=now+1hour"
+    ALLOC_OPTIONS: "--reservation=ci --exclusive=user --deadline=now+1hour"
     ALLOC_COMMAND: "salloc ${ALLOC_OPTIONS} -N ${ALLOC_NODES} -t ${ALLOC_TIME}"
   tags:
     - shell

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -95,8 +95,10 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
       DEPENDS_ON ${redecomp_test_depends} ${tribol_device_depends}
       FOLDER redecomp/tests )
-
-    foreach ( nranks RANGE 1 3 )
+    
+    # NOTE: just do 2 ranks for now until we make the tests smaller
+    #foreach ( nranks RANGE 1 3 )
+    foreach ( nranks RANGE 2 2 )
       blt_add_test( NAME ${test_name}_${nranks}rank
                     COMMAND ${test_name}_test
                     NUM_MPI_TASKS ${nranks} )
@@ -133,7 +135,9 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
       DEPENDS_ON ${combined_test_depends} ${tribol_device_depends}
       FOLDER tribol/tests )
 
-    foreach ( nranks RANGE 1 3 )
+    # NOTE: just do 2 ranks for now until we make the tests smaller
+    #foreach ( nranks RANGE 1 3 )
+    foreach ( nranks RANGE 2 2 )
       blt_add_test( NAME ${test_name}_${nranks}rank
                     COMMAND ${test_name}_test
                     NUM_MPI_TASKS ${nranks} )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,110 +5,110 @@
 
 #------------------------------------------------------------------------------
 
-#------------------------------------------------------------------------------
-# Add single source tests
-#------------------------------------------------------------------------------
-set( tribol_tests
-     tribol_check_tpl.cpp
-     tribol_common_plane_penalty.cpp
-     tribol_common_plane_gap_rate.cpp
-     tribol_common_plane_gpu.cpp
-     tribol_comp_geom.cpp
-     tribol_coupling_scheme.cpp
-     tribol_coupling_scheme_manager.cpp
-     tribol_enforcement_options.cpp
-     tribol_execution_modes.cpp
-     tribol_hex_mesh.cpp
-     tribol_inv_iso.cpp
-     tribol_iso_integ.cpp
-     tribol_math.cpp
-     tribol_mortar_data_geom.cpp
-     tribol_mortar_data_weights.cpp
-     tribol_mortar_force.cpp
-     tribol_mortar_gap.cpp
-     tribol_mortar_jacobian.cpp
-     tribol_mortar_lm_patch_test.cpp
-     tribol_mortar_sparse_weights.cpp
-     tribol_mortar_wts.cpp
-     tribol_nodal_nrmls.cpp
-     tribol_quad_integ.cpp
-     tribol_tet_mesh.cpp
-     tribol_timestep_vote.cpp
-     tribol_twb_integ.cpp
-     )
+# #------------------------------------------------------------------------------
+# # Add single source tests
+# #------------------------------------------------------------------------------
+# set( tribol_tests
+#      tribol_check_tpl.cpp
+#      tribol_common_plane_penalty.cpp
+#      tribol_common_plane_gap_rate.cpp
+#      tribol_common_plane_gpu.cpp
+#      tribol_comp_geom.cpp
+#      tribol_coupling_scheme.cpp
+#      tribol_coupling_scheme_manager.cpp
+#      tribol_enforcement_options.cpp
+#      tribol_execution_modes.cpp
+#      tribol_hex_mesh.cpp
+#      tribol_inv_iso.cpp
+#      tribol_iso_integ.cpp
+#      tribol_math.cpp
+#      tribol_mortar_data_geom.cpp
+#      tribol_mortar_data_weights.cpp
+#      tribol_mortar_force.cpp
+#      tribol_mortar_gap.cpp
+#      tribol_mortar_jacobian.cpp
+#      tribol_mortar_lm_patch_test.cpp
+#      tribol_mortar_sparse_weights.cpp
+#      tribol_mortar_wts.cpp
+#      tribol_nodal_nrmls.cpp
+#      tribol_quad_integ.cpp
+#      tribol_tet_mesh.cpp
+#      tribol_timestep_vote.cpp
+#      tribol_twb_integ.cpp
+#      )
 
-set(test_depends tribol gtest)
+# set(test_depends tribol gtest)
 
-foreach( test ${tribol_tests} )
+# foreach( test ${tribol_tests} )
 
-  get_filename_component( test_name ${test} NAME_WE )
+#   get_filename_component( test_name ${test} NAME_WE )
 
-  blt_add_executable(
-    NAME ${test_name}_test
-    SOURCES ${test}
-    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-    DEPENDS_ON ${test_depends} ${tribol_device_depends}
-    FOLDER tribol/tests )
+#   blt_add_executable(
+#     NAME ${test_name}_test
+#     SOURCES ${test}
+#     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+#     DEPENDS_ON ${test_depends} ${tribol_device_depends}
+#     FOLDER tribol/tests )
 
-  blt_add_test( NAME ${test_name}
-                COMMAND ${test_name}_test )
+#   blt_add_test( NAME ${test_name}
+#                 COMMAND ${test_name}_test )
 
-  if (ENABLE_CUDA)
-    set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
-  endif()
+#   if (ENABLE_CUDA)
+#     set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+#   endif()
 
-  if (ENABLE_HIP)
-    target_compile_options(${test_name}_test PRIVATE -fgpu-rdc)
-    target_compile_options(${test_name}_test PRIVATE
-        $<$<CONFIG:Debug>:
-            -ggdb
-        >
-    )
-    target_link_options(${test_name}_test PRIVATE -fgpu-rdc)
-    target_link_options(${test_name}_test PRIVATE --hip-link)
-  endif()
+#   if (ENABLE_HIP)
+#     target_compile_options(${test_name}_test PRIVATE -fgpu-rdc)
+#     target_compile_options(${test_name}_test PRIVATE
+#         $<$<CONFIG:Debug>:
+#             -ggdb
+#         >
+#     )
+#     target_link_options(${test_name}_test PRIVATE -fgpu-rdc)
+#     target_link_options(${test_name}_test PRIVATE --hip-link)
+#   endif()
 
-endforeach()
+# endforeach()
 
-#------------------------------------------------------------------------------
-# Add redecomp tests
-#------------------------------------------------------------------------------
-if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
+# #------------------------------------------------------------------------------
+# # Add redecomp tests
+# #------------------------------------------------------------------------------
+# if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
 
-  set( redecomp_tests
-      redecomp_transfer.cpp
-      redecomp_multitransfer.cpp
-      redecomp_massmatrix.cpp
-      redecomp_rectmatrix.cpp
-      redecomp_sparsematrix.cpp
-      )
+#   set( redecomp_tests
+#       redecomp_transfer.cpp
+#       redecomp_multitransfer.cpp
+#       redecomp_massmatrix.cpp
+#       redecomp_rectmatrix.cpp
+#       redecomp_sparsematrix.cpp
+#       )
 
-  set(redecomp_test_depends tribol gtest)
+#   set(redecomp_test_depends tribol gtest)
 
-  foreach( test ${redecomp_tests} )
+#   foreach( test ${redecomp_tests} )
 
-    get_filename_component( test_name ${test} NAME_WE )
+#     get_filename_component( test_name ${test} NAME_WE )
 
-    blt_add_executable(
-      NAME ${test_name}_test
-      SOURCES ${test}
-      OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-      DEPENDS_ON ${redecomp_test_depends} ${tribol_device_depends}
-      FOLDER redecomp/tests )
+#     blt_add_executable(
+#       NAME ${test_name}_test
+#       SOURCES ${test}
+#       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+#       DEPENDS_ON ${redecomp_test_depends} ${tribol_device_depends}
+#       FOLDER redecomp/tests )
 
-    foreach ( nranks RANGE 1 3 )
-      blt_add_test( NAME ${test_name}_${nranks}rank
-                    COMMAND ${test_name}_test
-                    NUM_MPI_TASKS ${nranks} )
-    endforeach()
+#     foreach ( nranks RANGE 1 3 )
+#       blt_add_test( NAME ${test_name}_${nranks}rank
+#                     COMMAND ${test_name}_test
+#                     NUM_MPI_TASKS ${nranks} )
+#     endforeach()
 
-    if (ENABLE_CUDA)
-      set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
-    endif()
+#     if (ENABLE_CUDA)
+#       set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+#     endif()
 
-  endforeach()
+#   endforeach()
 
-endif()
+# endif()
 
 #------------------------------------------------------------------------------
 # Add tribol + redecomp tests
@@ -116,7 +116,7 @@ endif()
 if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
 
   set( combined_tests
-      tribol_mfem_common_plane.cpp
+      #tribol_mfem_common_plane.cpp
       tribol_mfem_mortar_lm.cpp
       )
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,110 +5,110 @@
 
 #------------------------------------------------------------------------------
 
-# #------------------------------------------------------------------------------
-# # Add single source tests
-# #------------------------------------------------------------------------------
-# set( tribol_tests
-#      tribol_check_tpl.cpp
-#      tribol_common_plane_penalty.cpp
-#      tribol_common_plane_gap_rate.cpp
-#      tribol_common_plane_gpu.cpp
-#      tribol_comp_geom.cpp
-#      tribol_coupling_scheme.cpp
-#      tribol_coupling_scheme_manager.cpp
-#      tribol_enforcement_options.cpp
-#      tribol_execution_modes.cpp
-#      tribol_hex_mesh.cpp
-#      tribol_inv_iso.cpp
-#      tribol_iso_integ.cpp
-#      tribol_math.cpp
-#      tribol_mortar_data_geom.cpp
-#      tribol_mortar_data_weights.cpp
-#      tribol_mortar_force.cpp
-#      tribol_mortar_gap.cpp
-#      tribol_mortar_jacobian.cpp
-#      tribol_mortar_lm_patch_test.cpp
-#      tribol_mortar_sparse_weights.cpp
-#      tribol_mortar_wts.cpp
-#      tribol_nodal_nrmls.cpp
-#      tribol_quad_integ.cpp
-#      tribol_tet_mesh.cpp
-#      tribol_timestep_vote.cpp
-#      tribol_twb_integ.cpp
-#      )
+#------------------------------------------------------------------------------
+# Add single source tests
+#------------------------------------------------------------------------------
+set( tribol_tests
+     tribol_check_tpl.cpp
+     tribol_common_plane_penalty.cpp
+     tribol_common_plane_gap_rate.cpp
+     tribol_common_plane_gpu.cpp
+     tribol_comp_geom.cpp
+     tribol_coupling_scheme.cpp
+     tribol_coupling_scheme_manager.cpp
+     tribol_enforcement_options.cpp
+     tribol_execution_modes.cpp
+     tribol_hex_mesh.cpp
+     tribol_inv_iso.cpp
+     tribol_iso_integ.cpp
+     tribol_math.cpp
+     tribol_mortar_data_geom.cpp
+     tribol_mortar_data_weights.cpp
+     tribol_mortar_force.cpp
+     tribol_mortar_gap.cpp
+     tribol_mortar_jacobian.cpp
+     tribol_mortar_lm_patch_test.cpp
+     tribol_mortar_sparse_weights.cpp
+     tribol_mortar_wts.cpp
+     tribol_nodal_nrmls.cpp
+     tribol_quad_integ.cpp
+     tribol_tet_mesh.cpp
+     tribol_timestep_vote.cpp
+     tribol_twb_integ.cpp
+     )
 
-# set(test_depends tribol gtest)
+set(test_depends tribol gtest)
 
-# foreach( test ${tribol_tests} )
+foreach( test ${tribol_tests} )
 
-#   get_filename_component( test_name ${test} NAME_WE )
+  get_filename_component( test_name ${test} NAME_WE )
 
-#   blt_add_executable(
-#     NAME ${test_name}_test
-#     SOURCES ${test}
-#     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-#     DEPENDS_ON ${test_depends} ${tribol_device_depends}
-#     FOLDER tribol/tests )
+  blt_add_executable(
+    NAME ${test_name}_test
+    SOURCES ${test}
+    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+    DEPENDS_ON ${test_depends} ${tribol_device_depends}
+    FOLDER tribol/tests )
 
-#   blt_add_test( NAME ${test_name}
-#                 COMMAND ${test_name}_test )
+  blt_add_test( NAME ${test_name}
+                COMMAND ${test_name}_test )
 
-#   if (ENABLE_CUDA)
-#     set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
-#   endif()
+  if (ENABLE_CUDA)
+    set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+  endif()
 
-#   if (ENABLE_HIP)
-#     target_compile_options(${test_name}_test PRIVATE -fgpu-rdc)
-#     target_compile_options(${test_name}_test PRIVATE
-#         $<$<CONFIG:Debug>:
-#             -ggdb
-#         >
-#     )
-#     target_link_options(${test_name}_test PRIVATE -fgpu-rdc)
-#     target_link_options(${test_name}_test PRIVATE --hip-link)
-#   endif()
+  if (ENABLE_HIP)
+    target_compile_options(${test_name}_test PRIVATE -fgpu-rdc)
+    target_compile_options(${test_name}_test PRIVATE
+        $<$<CONFIG:Debug>:
+            -ggdb
+        >
+    )
+    target_link_options(${test_name}_test PRIVATE -fgpu-rdc)
+    target_link_options(${test_name}_test PRIVATE --hip-link)
+  endif()
 
-# endforeach()
+endforeach()
 
-# #------------------------------------------------------------------------------
-# # Add redecomp tests
-# #------------------------------------------------------------------------------
-# if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
+#------------------------------------------------------------------------------
+# Add redecomp tests
+#------------------------------------------------------------------------------
+if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
 
-#   set( redecomp_tests
-#       redecomp_transfer.cpp
-#       redecomp_multitransfer.cpp
-#       redecomp_massmatrix.cpp
-#       redecomp_rectmatrix.cpp
-#       redecomp_sparsematrix.cpp
-#       )
+  set( redecomp_tests
+      redecomp_transfer.cpp
+      redecomp_multitransfer.cpp
+      redecomp_massmatrix.cpp
+      redecomp_rectmatrix.cpp
+      redecomp_sparsematrix.cpp
+      )
 
-#   set(redecomp_test_depends tribol gtest)
+  set(redecomp_test_depends tribol gtest)
 
-#   foreach( test ${redecomp_tests} )
+  foreach( test ${redecomp_tests} )
 
-#     get_filename_component( test_name ${test} NAME_WE )
+    get_filename_component( test_name ${test} NAME_WE )
 
-#     blt_add_executable(
-#       NAME ${test_name}_test
-#       SOURCES ${test}
-#       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-#       DEPENDS_ON ${redecomp_test_depends} ${tribol_device_depends}
-#       FOLDER redecomp/tests )
+    blt_add_executable(
+      NAME ${test_name}_test
+      SOURCES ${test}
+      OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+      DEPENDS_ON ${redecomp_test_depends} ${tribol_device_depends}
+      FOLDER redecomp/tests )
 
-#     foreach ( nranks RANGE 1 3 )
-#       blt_add_test( NAME ${test_name}_${nranks}rank
-#                     COMMAND ${test_name}_test
-#                     NUM_MPI_TASKS ${nranks} )
-#     endforeach()
+    foreach ( nranks RANGE 1 3 )
+      blt_add_test( NAME ${test_name}_${nranks}rank
+                    COMMAND ${test_name}_test
+                    NUM_MPI_TASKS ${nranks} )
+    endforeach()
 
-#     if (ENABLE_CUDA)
-#       set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
-#     endif()
+    if (ENABLE_CUDA)
+      set_target_properties(${test_name}_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+    endif()
 
-#   endforeach()
+  endforeach()
 
-# endif()
+endif()
 
 #------------------------------------------------------------------------------
 # Add tribol + redecomp tests
@@ -116,7 +116,7 @@
 if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
 
   set( combined_tests
-      #tribol_mfem_common_plane.cpp
+      tribol_mfem_common_plane.cpp
       tribol_mfem_mortar_lm.cpp
       )
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -99,7 +99,7 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
     foreach ( nranks RANGE 1 3 )
       blt_add_test( NAME ${test_name}_${nranks}rank
                     COMMAND ${test_name}_test
-                    NUM_MPI_RANKS ${nranks} )
+                    NUM_MPI_TASKS ${nranks} )
     endforeach()
 
     if (ENABLE_CUDA)
@@ -136,7 +136,7 @@ if ( BUILD_REDECOMP AND TRIBOL_USE_MPI )
     foreach ( nranks RANGE 1 3 )
       blt_add_test( NAME ${test_name}_${nranks}rank
                     COMMAND ${test_name}_test
-                    NUM_MPI_RANKS ${nranks} )
+                    NUM_MPI_TASKS ${nranks} )
     endforeach()
 
     if (ENABLE_CUDA)

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -661,7 +661,7 @@ const MfemSubmeshData::UpdateData& MfemSubmeshData::GetUpdateData() const
 
 MfemJacobianData::MfemJacobianData( const MfemMeshData& parent_data, const MfemSubmeshData& submesh_data,
                                     ContactMethod contact_method )
-    : parent_data_{ parent_data }, submesh_data_{ submesh_data }, block_offsets_{ 3 }
+    : parent_data_{ parent_data }, submesh_data_{ submesh_data }, block_offsets_( 3 )
 {
   SLIC_ERROR_ROOT_IF( parent_data.GetParentCoords().ParFESpace()->FEColl()->GetOrder() > 1,
                       "Higher order meshes not yet supported for Jacobian matrices." );

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -609,7 +609,7 @@ void MfemMeshData::UpdateData::SetElementData()
     num_verts_per_elem_ = mfem::Geometry::NumVerts[element_type];
   } else {
     // just put something here so Tribol will not give a warning for zero element meshes
-    elem_type_ = LINEAR_EDGE;
+    elem_type_ = LINEAR_QUAD;
     num_verts_per_elem_ = 2;
   }
 }

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -608,7 +608,8 @@ void MfemMeshData::UpdateData::SetElementData()
 
     num_verts_per_elem_ = mfem::Geometry::NumVerts[element_type];
   } else {
-    // just put something here so Tribol will not give a warning for zero element meshes
+    // just put something here so Tribol will not give a warning for zero element meshes.  use a 2d element so arrays
+    // are sized for 3d (max supported dimension) in case they are accessed later on.
     elem_type_ = LINEAR_QUAD;
     num_verts_per_elem_ = 2;
   }

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -1703,7 +1703,7 @@ void TestMesh::testMeshToVtk( const std::string& dir, int cycle, RealT time )
 
 namespace mfem_ext {
 
-CentralDiffSolver::CentralDiffSolver( const mfem::Array<int>& bc_vdofs_ ) : bc_vdofs{ bc_vdofs_ }, first_step{ true } {}
+CentralDiffSolver::CentralDiffSolver( const mfem::Array<int>& bc_vdofs_ ) : bc_vdofs( bc_vdofs_ ), first_step{ true } {}
 
 void CentralDiffSolver::Step( mfem::Vector& x, mfem::Vector& dxdt, double& t, double& dt )
 {
@@ -1746,13 +1746,13 @@ void CentralDiffSolver::SetHomogeneousBC( mfem::Vector& dxdt ) const
 #ifdef TRIBOL_USE_MPI
 ExplicitMechanics::ExplicitMechanics( mfem::ParFiniteElementSpace& fespace, mfem::Coefficient& rho,
                                       mfem::Coefficient& lambda, mfem::Coefficient& mu )
-    : f_ext{ &fespace }, elasticity{ &fespace }, inv_lumped_mass{ fespace.GetVSize() }
+    : f_ext{ &fespace }, elasticity{ &fespace }, inv_lumped_mass( fespace.GetVSize() )
 {
   // create inverse lumped mass matrix; store as a vector
   mfem::ParBilinearForm mass{ &fespace };
   mass.AddDomainIntegrator( new mfem::VectorMassIntegrator( rho ) );
   mass.Assemble();
-  mfem::Vector ones{ fespace.GetVSize() };
+  mfem::Vector ones( fespace.GetVSize() );
   ones = 1.0;
   mass.SpMat().Mult( ones, inv_lumped_mass );
   mfem::Vector mass_true( fespace.GetTrueVSize() );
@@ -1771,10 +1771,10 @@ ExplicitMechanics::ExplicitMechanics( mfem::ParFiniteElementSpace& fespace, mfem
 void ExplicitMechanics::Mult( const mfem::Vector& u, const mfem::Vector& AXOM_UNUSED_PARAM( dudt ),
                               mfem::Vector& a ) const
 {
-  mfem::Vector f{ u.Size() };
+  mfem::Vector f( u.Size() );
   f = 0.0;
 
-  mfem::Vector f_int{ f.Size() };
+  mfem::Vector f_int( f.Size() );
   elasticity.Mult( u, f_int );
   f.Add( -1.0, f_int );
 
@@ -1783,7 +1783,7 @@ void ExplicitMechanics::Mult( const mfem::Vector& u, const mfem::Vector& AXOM_UN
   // sum forces over ranks
   auto& fespace = *elasticity.ParFESpace();
   const Operator& P = *fespace.GetProlongationMatrix();
-  mfem::Vector f_true{ fespace.GetTrueVSize() };
+  mfem::Vector f_true( fespace.GetTrueVSize() );
   P.MultTranspose( f, f_true );
   P.Mult( f_true, f );
 


### PR DESCRIPTION
A `std::initializer_list` constructor was recently added to `mfem::Vector`, so code like `mfem::Array<int> blah {100};` now creates a `mfem::Array<int>` of size 1 with `blah[0] = 100`, instead of an uninitialized `mfem::Array<int>` of size 100.

This PR updates the places in the code where this is an issue.  Note, the verification of changes is through running tests and there may be other places where the code still needs to be updated.