### PR TITLE
Fix headers and source files in Tribol CMake

### DIFF
--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -13,72 +13,75 @@ set(tribol_headers
 
     common/ArrayTypes.hpp
     common/BasicTypes.hpp
+    common/Containers.hpp
+    common/Enzyme.hpp
     common/ExecModel.hpp
     common/LoopExec.hpp
     common/Parameters.hpp
-
-    interface/mfem_tribol.hpp
-    interface/simple_tribol.hpp
-    interface/tribol.hpp
-
-    integ/Integration.hpp
-    integ/FE.hpp
-
-    mesh/InterfacePairs.hpp
-    mesh/MethodCouplingData.hpp 
-    mesh/CouplingScheme.hpp
-    mesh/MeshData.hpp
-    mesh/MfemData.hpp
 
     geom/ContactPlane.hpp
     geom/ElementNormal.hpp
     geom/GeomUtilities.hpp
     geom/NodalNormal.hpp
 
+    integ/FE.hpp
+    integ/Integration.hpp
+
+    interface/mfem_tribol.hpp
+    interface/simple_tribol.hpp
+    interface/tribol.hpp
+
+    mesh/CouplingScheme.hpp
+    mesh/InterfacePairs.hpp
+    mesh/MeshData.hpp
+    mesh/MethodCouplingData.hpp
+    mesh/MfemData.hpp
+
+    physics/AlignedMortar.hpp
+    physics/CommonPlane.hpp
+    physics/Mortar.hpp
+    physics/Physics.hpp
+
+    search/InterfacePairFinder.hpp
+
+    utils/Algorithm.hpp
     utils/ContactPlaneOutput.hpp
     utils/DataManager.hpp
     utils/Math.hpp
     utils/TestUtils.hpp
-
-    search/InterfacePairFinder.hpp
-
-    physics/Physics.hpp
-    physics/CommonPlane.hpp
-    physics/AlignedMortar.hpp
-    physics/Mortar.hpp
     )
 
 ## list of sources
 set(tribol_sources
-
-    interface/mfem_tribol.cpp
-    interface/simple_tribol.cpp
-    interface/tribol.cpp
-
-    integ/Integration.cpp
-    integ/FE.cpp
-
-    mesh/InterfacePairs.cpp
-    mesh/MethodCouplingData.cpp
-    mesh/CouplingScheme.cpp
-    mesh/MeshData.cpp
-    mesh/MfemData.cpp
      
     geom/ContactPlane.cpp
     geom/ElementNormal.cpp
     geom/GeomUtilities.cpp
     geom/NodalNormal.cpp
 
-    utils/ContactPlaneOutput.cpp
-    utils/Math.cpp
-    utils/TestUtils.cpp
+    integ/FE.cpp
+    integ/Integration.cpp
+
+    interface/mfem_tribol.cpp
+    interface/simple_tribol.cpp
+    interface/tribol.cpp
+
+    mesh/CouplingScheme.cpp
+    mesh/InterfacePairs.cpp
+    mesh/MeshData.cpp
+    mesh/MethodCouplingData.cpp
+    mesh/MfemData.cpp
+
+    physics/AlignedMortar.cpp
+    physics/CommonPlane.cpp
+    physics/Mortar.cpp
+    physics/Physics.cpp
      
     search/InterfacePairFinder.cpp
 
-    physics/Physics.cpp
-    physics/CommonPlane.cpp
-    physics/AlignedMortar.cpp
-    physics/Mortar.cpp
+    utils/ContactPlaneOutput.cpp
+    utils/Math.cpp
+    utils/TestUtils.cpp
     )
 
 if (ENABLE_FORTRAN)


### PR DESCRIPTION
This PR
- adds missing header and source files in `tribol_headers` and `tribol_sources`
- reorders header and source files in alpha order

Thanks @thartland for identifying this!