### PR TITLE
Less output with RCB

### DIFF
--- a/src/redecomp/partition/RCB.cpp
+++ b/src/redecomp/partition/RCB.cpp
@@ -192,7 +192,7 @@ BisecTree<RCBInfo<NDIMS>> RCB<NDIMS>::BuildProblemTree( int n_parts,
 
         if ( axis_ok ) break;
       }
-      // none of the axes worked.  issue a warning but continue.
+      // none of the axes worked.  issue a debug statement but continue.
       SLIC_DEBUG_ROOT_IF( !axis_ok,
                           axom::fmt::format( "RCB domain decomposition unsuccessful.\n"
                                              "  Max out of balance tolerance: {}\n"

--- a/src/redecomp/partition/RCB.cpp
+++ b/src/redecomp/partition/RCB.cpp
@@ -193,13 +193,13 @@ BisecTree<RCBInfo<NDIMS>> RCB<NDIMS>::BuildProblemTree( int n_parts,
         if ( axis_ok ) break;
       }
       // none of the axes worked.  issue a warning but continue.
-      SLIC_WARNING_ROOT_IF(
-          !axis_ok, axom::fmt::format( "RCB domain decomposition unsuccessful.\n"
-                                       "  Max out of balance tolerance: {}\n"
-                                       "  Total entities to split: {}\n"
-                                       "  Proportion of entities on left of cut: {}\n"
-                                       "  Desired proportion of entites on left of cut: {}\n",
-                                       node_max_out_of_balance, total_node_ents, left_prop, actual_left_prop ) );
+      SLIC_DEBUG_ROOT_IF( !axis_ok,
+                          axom::fmt::format( "RCB domain decomposition unsuccessful.\n"
+                                             "  Max out of balance tolerance: {}\n"
+                                             "  Total entities to split: {}\n"
+                                             "  Proportion of entities on left of cut: {}\n"
+                                             "  Desired proportion of entites on left of cut: {}\n",
+                                             node_max_out_of_balance, total_node_ents, actual_left_prop, left_prop ) );
     }
   }
 

--- a/src/redecomp/partition/RCB.hpp
+++ b/src/redecomp/partition/RCB.hpp
@@ -73,7 +73,7 @@ class RCB : public PartitionMethod<NDIMS> {
    * @param max_out_of_balance Allowable deviation from desired fraction of entities on each partition
    * @param n_try_new_axis Number of attempted cuts with no change in entity counts before trying a new axis
    */
-  RCB( const MPI_Comm& comm, double max_out_of_balance = 0.1, int n_try_new_axis = 5 );
+  RCB( const MPI_Comm& comm, double max_out_of_balance = 0.1, int n_try_new_axis = 10 );
 
   /**
    * @brief Build entity partitioning using recursive coordinate bisection


### PR DESCRIPTION
This PR
- Fixes a small bug in the RCB failure message
- Changes the message from a warning to a debug statement
- Increases the number of bisections before giving up on the decomposition.  A more robust fix would be to resize the bounding box on the actual entity coordinates in the tree's node, but this can be implemented later.