### PR TITLE
Allow wider range of rate percent penalties

### DIFF
--- a/src/tests/tribol_enforcement_options.cpp
+++ b/src/tests/tribol_enforcement_options.cpp
@@ -276,7 +276,7 @@ TEST_F( EnforcementOptionsTest, penalty_kinematic_constant_rate_percent_error_2 
   tribol::setKinematicConstantPenalty( 1, penalty );
 
   // incorrectly set the rate_percent value outside of acceptable bounds
-  RealT rate_percent = 1.2;
+  RealT rate_percent = -0.01;
   tribol::setRatePercentPenalty( 0, rate_percent );
   tribol::setRatePercentPenalty( 1, rate_percent );
 

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -160,10 +160,9 @@ bool MeshElemData::isValidRatePenalty( PenaltyEnforcementOptions& pen_options )
         SLIC_WARNING( "MeshElemData::isValidRatePenalty(): "
                       << "percent rate penalty data not set." );
         return false;
-      } else if ( this->m_rate_percent_stiffness < pen_options.tiny_penalty ||
-                  this->m_rate_percent_stiffness > ( 1. - pen_options.tiny_penalty ) ) {
+      } else if ( this->m_rate_percent_stiffness < 0.0 ) {
         SLIC_WARNING( "MeshElemData::isValidRatePenalty(): "
-                      << "rate percent penalty not in (0,1)." );
+                      << "rate percent penalty less than 0." );
         return false;
       }
       break;


### PR DESCRIPTION
Relax the requirements on percent rate penalties to be between $[0, \infty)$.