### PR TITLE
Add support for tet meshes in mortar

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,8 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 - Created interfaces for nodal normal and element normal calculations, to simplify addition of new normal computation
   techniques.
 - Introduced `TRIBOL_DEBUG` compiler definition for guarding code that should only be compiled in debug builds
+- Support for linear triangle meshes in Tribol's SINGLE_MORTAR method (exact Jacobians through Enzyme or approximate
+  Jacobians)
 
 
 ### Changed

--- a/src/examples/mfem_mortar_lm_patch.cpp
+++ b/src/examples/mfem_mortar_lm_patch.cpp
@@ -45,15 +45,6 @@
 
 #include <set>
 
-// Tribol includes
-#include "tribol/config.hpp"
-#include "tribol/common/Parameters.hpp"
-#include "tribol/interface/tribol.hpp"
-#include "tribol/interface/mfem_tribol.hpp"
-
-// Redecomp includes
-#include "redecomp/redecomp.hpp"
-
 #ifdef TRIBOL_USE_UMPIRE
 // Umpire includes
 #include "umpire/ResourceManager.hpp"
@@ -65,6 +56,18 @@
 // Axom includes
 #include "axom/CLI11.hpp"
 #include "axom/slic.hpp"
+
+// Redecomp includes
+#include "redecomp/redecomp.hpp"
+
+// Shared includes
+#include "shared/mesh/MeshBuilder.hpp"
+
+// Tribol includes
+#include "tribol/config.hpp"
+#include "tribol/common/Parameters.hpp"
+#include "tribol/interface/tribol.hpp"
+#include "tribol/interface/mfem_tribol.hpp"
 
 int main( int argc, char** argv )
 {
@@ -92,6 +95,8 @@ int main( int argc, char** argv )
   double lambda = 50.0;
   // Lame parameter mu (shear modulus)
   double mu = 50.0;
+  // Should we mesh with tet elements?
+  bool use_tets = false;
 
   // parse command line options
   axom::CLI::App app{ "mfem_mortar_lm_patch" };
@@ -102,16 +107,16 @@ int main( int argc, char** argv )
   //   ->capture_default_str();
   app.add_option( "-l,--lambda", lambda, "Lame parameter lambda." )->capture_default_str();
   app.add_option( "-m,--mu", mu, "Lame parameter mu (shear modulus)." )->capture_default_str();
+  app.add_option( "-t,--use-tets", use_tets, "Should we use tetrahedral elements?" )->capture_default_str();
   CLI11_PARSE( app, argc, argv );
 
   SLIC_INFO_ROOT( "Running mfem_mortar_lm_patch with the following options:" );
-  SLIC_INFO_ROOT( axom::fmt::format( "refine: {0}", ref_levels ) );
-  SLIC_INFO_ROOT( axom::fmt::format( "lambda: {0}", lambda ) );
-  SLIC_INFO_ROOT( axom::fmt::format( "mu:     {0}\n", mu ) );
+  SLIC_INFO_ROOT( axom::fmt::format( "refine:   {0}", ref_levels ) );
+  SLIC_INFO_ROOT( axom::fmt::format( "lambda:   {0}", lambda ) );
+  SLIC_INFO_ROOT( axom::fmt::format( "mu:       {0}", mu ) );
+  SLIC_INFO_ROOT( axom::fmt::format( "use_tets: {0}\n", use_tets ) );
 
   // fixed options
-  // location of mesh file. TRIBOL_REPO_DIR is defined in tribol/config.hpp
-  std::string mesh_file = TRIBOL_REPO_DIR "/data/two_hex_overlap.mesh";
   // boundary element attributes of mortar surface, the z = 1 plane of the first
   // block
   auto mortar_attrs = std::set<int>( { 4 } );
@@ -134,38 +139,33 @@ int main( int argc, char** argv )
   // Optionally, the mfem::ParMesh can be refined further on each rank by
   // setting par_ref_levels >= 1, though this is disabled below.
   timer.start();
-  std::unique_ptr<mfem::ParMesh> pmesh{ nullptr };
-  {
-    // read serial mesh
-    auto mesh = std::make_unique<mfem::Mesh>( mesh_file.c_str(), 1, 1 );
-
-    // refine serial mesh
-    if ( ref_levels > 0 ) {
-      for ( int i{ 0 }; i < ref_levels; ++i ) {
-        mesh->UniformRefinement();
-      }
-    }
-
-    // create parallel mesh from serial
-    pmesh = std::make_unique<mfem::ParMesh>( MPI_COMM_WORLD, *mesh );
-    mesh.reset( nullptr );
-
-    // further refinement of parallel mesh
-    {
-      // set this to >= 1 to refine the mesh on each rank further
-      int par_ref_levels = 0;
-      for ( int i{ 0 }; i < par_ref_levels; ++i ) {
-        pmesh->UniformRefinement();
-      }
-    }
-  }
+  // build mesh of 2 cubes
+  int nel_per_dir = std::pow( 2, ref_levels );
+  auto elem_type = use_tets ? mfem::Element::TETRAHEDRON : mfem::Element::HEXAHEDRON;
+  // clang-format off
+  mfem::ParMesh mesh = shared::ParMeshBuilder(MPI_COMM_WORLD, shared::MeshBuilder::Unify({
+    shared::MeshBuilder::CubeMesh(nel_per_dir, nel_per_dir, nel_per_dir, elem_type)
+      .updateBdrAttrib(3, 7)
+      .updateBdrAttrib(1, 3)
+      .updateBdrAttrib(4, 7)
+      .updateBdrAttrib(5, 1)
+      .updateBdrAttrib(6, 4),
+    shared::MeshBuilder::CubeMesh(nel_per_dir, nel_per_dir, nel_per_dir, elem_type)
+      .translate({0.0, 0.0, 0.99})
+      .updateBdrAttrib(1, 8)
+      .updateBdrAttrib(3, 7)
+      .updateBdrAttrib(4, 7)
+      .updateBdrAttrib(5, 1)
+      .updateBdrAttrib(8, 5)
+  }));
+  // clang-format on
   timer.stop();
   SLIC_INFO_ROOT( axom::fmt::format( "Time to create parallel mesh: {0:f}ms", timer.elapsedTimeInMilliSec() ) );
 
   // Set up an MFEM data collection for output. We output data in Paraview and
   // VisIt formats.
-  auto paraview_datacoll = mfem::ParaViewDataCollection( "mortar_patch_pv", pmesh.get() );
-  auto visit_datacoll = mfem::VisItDataCollection( "mortar_patch_vi", pmesh.get() );
+  auto paraview_datacoll = mfem::ParaViewDataCollection( "mortar_patch_pv", &mesh );
+  auto visit_datacoll = mfem::VisItDataCollection( "mortar_patch_vi", &mesh );
 
   // This block of code creates position and displacement grid functions (and
   // associated finite element collections and finite element spaces) on the
@@ -174,9 +174,9 @@ int main( int argc, char** argv )
   // functions are registered with the data collections for output.
   timer.start();
   // Finite element collection (shared between all grid functions).
-  auto fe_coll = mfem::H1_FECollection( order, pmesh->SpaceDimension() );
+  auto fe_coll = mfem::H1_FECollection( order, mesh.SpaceDimension() );
   // Finite element space (shared between all grid functions).
-  auto par_fe_space = mfem::ParFiniteElementSpace( pmesh.get(), &fe_coll, pmesh->SpaceDimension() );
+  auto par_fe_space = mfem::ParFiniteElementSpace( &mesh, &fe_coll, mesh.SpaceDimension() );
   // Create coordinate grid function
   auto coords = mfem::ParGridFunction( &par_fe_space );
   // Set coordinate grid function based on nodal locations. In MFEM, nodal
@@ -184,7 +184,7 @@ int main( int argc, char** argv )
   // MFEM meshes, nodal locations can be stored in a grid function or through
   // the vertex coordinates. For consistency, we will create a nodal grid
   // function even for linear meshes.
-  pmesh->SetNodalGridFunction( &coords, false );
+  mesh.SetNodalGridFunction( &coords, false );
   paraview_datacoll.RegisterField( "pos", &coords );
   visit_datacoll.RegisterField( "pos", &coords );
 
@@ -208,7 +208,7 @@ int main( int argc, char** argv )
     // are in the list.
     mfem::Array<int> ess_vdof_marker;
     // Convert x-fixed boundary attributes into markers
-    mfem::Array<int> ess_bdr( pmesh->bdr_attributes.Max() );
+    mfem::Array<int> ess_bdr( mesh.bdr_attributes.Max() );
     ess_bdr = 0;
     for ( auto xfixed_attr : xfixed_attrs ) {
       ess_bdr[xfixed_attr - 1] = 1;
@@ -281,7 +281,7 @@ int main( int argc, char** argv )
   int coupling_scheme_id = 0;
   int mesh1_id = 0;
   int mesh2_id = 1;
-  tribol::registerMfemCouplingScheme( coupling_scheme_id, mesh1_id, mesh2_id, *pmesh, coords, mortar_attrs,
+  tribol::registerMfemCouplingScheme( coupling_scheme_id, mesh1_id, mesh2_id, mesh, coords, mortar_attrs,
                                       nonmortar_attrs, tribol::SURFACE_TO_SURFACE, tribol::NO_SLIDING,
                                       tribol::SINGLE_MORTAR, tribol::FRICTIONLESS, tribol::LAGRANGE_MULTIPLIER,
                                       tribol::BINNING_GRID );

--- a/src/shared/mesh/MeshBuilder.cpp
+++ b/src/shared/mesh/MeshBuilder.cpp
@@ -22,9 +22,9 @@ MeshBuilder MeshBuilder::SquareMesh( int n_x_els, int n_y_els )
   return mfem::Mesh::MakeCartesian2D( n_x_els, n_y_els, mfem::Element::QUADRILATERAL );
 }
 
-MeshBuilder MeshBuilder::CubeMesh( int n_x_els, int n_y_els, int n_z_els )
+MeshBuilder MeshBuilder::CubeMesh( int n_x_els, int n_y_els, int n_z_els, mfem::Element::Type elem_type )
 {
-  return mfem::Mesh::MakeCartesian3D( n_x_els, n_y_els, n_z_els, mfem::Element::HEXAHEDRON );
+  return mfem::Mesh::MakeCartesian3D( n_x_els, n_y_els, n_z_els, elem_type );
 }
 
 MeshBuilder MeshBuilder::HypercubeMesh( int dim, int n_els )

--- a/src/shared/mesh/MeshBuilder.hpp
+++ b/src/shared/mesh/MeshBuilder.hpp
@@ -55,9 +55,11 @@ class MeshBuilder {
    * @param n_x_els Number of elements in the x direction (>0).
    * @param n_y_els Number of elements in the y direction (>0).
    * @param n_z_els Number of elements in the z direction (>0).
+   * @param elem_type The type of elements to use in the mesh (default is HEXAHEDRON).
    * @return A new MeshBuilder object representing the cube mesh.
    */
-  static MeshBuilder CubeMesh( int n_x_els, int n_y_els, int n_z_els );
+  static MeshBuilder CubeMesh( int n_x_els, int n_y_els, int n_z_els,
+                               mfem::Element::Type elem_type = mfem::Element::HEXAHEDRON );
 
   /**
    * @brief Creates a hypercube mesh occupying the unit hypercube, [0, 1]^dim.

--- a/src/tests/tribol_enzyme_element_mortar.cpp
+++ b/src/tests/tribol_enzyme_element_mortar.cpp
@@ -394,59 +394,42 @@ class EnzymeElementMortarTest : public testing::Test {
    */
   void SimplifiedJacobianCheck( double* x1, double* x2, double* n1, double* p1, int num_nodes = 4 )
   {
-    constexpr int num_disp_dofs = 12;
-    double f1[num_disp_dofs];  // Array to store forces for the first face
-    double f2[num_disp_dofs];  // Array to store forces for the second face
-    constexpr int num_pres_dofs = 4;
-    double g1[num_pres_dofs];  // Array to store gap for the first face
+    constexpr int max_num_disp_dofs = 12;
+    constexpr int max_num_pres_dofs = 4;
 
-    double df1dx1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the coordinates
-                                                   // of the first face
-    double df1dx2[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the coordinates
-                                                   // of the second face
-    double df1dn1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the normal of the
-                                                   // first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
-      df1dx1[i] = 0.0;
-      df1dx2[i] = 0.0;
-      df1dn1[i] = 0.0;
-    }
-    double df1dp1[num_disp_dofs * num_pres_dofs];  // Derivative of the force on the first face w.r.t. the pressure of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_pres_dofs; ++i ) {
-      df1dp1[i] = 0.0;
-    }
-    double dg1dx1[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the coordinates of
-                                                   // the first face
-    double dg1dx2[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the coordinates of
-                                                   // the second face
-    double dg1dn1[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the normal of the
-                                                   // first face
-    for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
-      dg1dx1[i] = 0.0;
-      dg1dx2[i] = 0.0;
-      dg1dn1[i] = 0.0;
-    }
-    double df2dx1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the coordinates
-                                                   // of the first face
-    double df2dx2[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the coordinates
-                                                   // of the second face
-    double df2dn1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the normal of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
-      df2dx1[i] = 0.0;
-      df2dx2[i] = 0.0;
-      df2dn1[i] = 0.0;
-    }
-    double df2dp1[num_disp_dofs * num_pres_dofs];  // Derivative of the force on the second face w.r.t. the pressure of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_pres_dofs; ++i ) {
-      df2dp1[i] = 0.0;
-    }
+    // Array to store forces for the first face
+    double f1[max_num_disp_dofs] = { 0.0 };
+    // Array to store forces for the second face
+    double f2[max_num_disp_dofs] = { 0.0 };
+    // Array to store gap for the first face
+    double g1[max_num_pres_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the coordinates of the first face
+    double df1dx1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the coordinates of the second face
+    double df1dx2[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the normal of the first face
+    double df1dn1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the pressure of the first face
+    double df1dp1[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the coordinates of the first face
+    double dg1dx1[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the coordinates of the second face
+    double dg1dx2[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the normal of the first face
+    double dg1dn1[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the coordinates of the first face
+    double df2dx1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the coordinates of the second face
+    double df2dx2[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the normal of the first face
+    double df2dn1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the pressure of the first face
+    double df2dp1[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
 
     ComputeMortarJacobianEnzyme( x1, n1, p1, f1, df1dx1, df1dx2, df1dn1, df1dp1, g1, dg1dx1, dg1dx2, dg1dn1, num_nodes,
                                  x2, f2, df2dx1, df2dx2, df2dn1, df2dp1, num_nodes );
 
+    // NOTE: This will still work for triangles since the unused nodes are ignored.
     int conn[4] = { 0, 1, 2, 3 };
     tribol::InterfaceElementType interface_element_type = tribol::InterfaceElementType::LINEAR_QUAD;
     if ( num_nodes == 3 ) {
@@ -466,20 +449,14 @@ class EnzymeElementMortarTest : public testing::Test {
                             ContactMethod::SINGLE_MORTAR, ContactModel::FRICTIONLESS,
                             EnforcementMethod::LAGRANGE_MULTIPLIER, BinningMethod::BINNING_GRID,
                             ExecutionMode::Sequential );
-    double f1t[num_disp_dofs];  // Array to store non-Enzyme forces for the first face
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      f1t[i] = 0.0;
-    }
+    // Array to store non-Enzyme forces for the first face
+    double f1t[max_num_disp_dofs] = { 0.0 };
     registerNodalResponse( mesh_id1, f1t, f1t + num_nodes, f1t + 2 * num_nodes );
-    double f2t[num_disp_dofs];  // Array to store non-Enzyme forces for the second face
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      f2t[i] = 0.0;
-    }
+    // Array to store non-Enzyme forces for the second face
+    double f2t[max_num_disp_dofs] = { 0.0 };
     registerNodalResponse( mesh_id2, f2t, f2t + num_nodes, f2t + 2 * num_nodes );
-    double g1t[num_pres_dofs];  // Array to store non-Enzyme gap for the first face
-    for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
-      g1t[i] = 0.0;
-    }
+    // Array to store non-Enzyme gap for the first face
+    double g1t[max_num_pres_dofs] = { 0.0 };
     registerMortarGaps( mesh_id1, g1t );
     registerMortarPressures( mesh_id1, p1 );
     setLagrangeMultiplierOptions( cs_id, ImplicitEvalMode::MORTAR_RESIDUAL_JACOBIAN, SparseMode::MFEM_ELEMENT_DENSE );
@@ -496,11 +473,14 @@ class EnzymeElementMortarTest : public testing::Test {
                               &col_elem_idx, &jacobians );
 
     double max_diff{ 0.0 };
+    constexpr int dim = 3;
+    int num_disp_dofs = num_nodes * dim;
+    int num_pres_dofs = num_nodes;
 
     std::cout << "df1/dp -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
-      for ( int j{ 0 }; j < num_nodes; ++j ) {
-        int idx_e = num_nodes * i + j;
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
+        int idx_e = num_pres_dofs * i + j;
         auto diff = std::abs( df1dp1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -515,9 +495,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &jacobians );
 
     std::cout << "df2/dp -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
-      for ( int j{ 0 }; j < num_nodes; ++j ) {
-        int idx_e = num_nodes * i + j;
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
+        int idx_e = num_pres_dofs * i + j;
         auto diff = std::abs( df2dp1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -532,9 +512,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &col_elem_idx, &jacobians );
 
     std::cout << "dg/dx1 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
-      for ( int j{ 0 }; j < num_nodes; ++j ) {
-        int idx_e = num_nodes * i + j;
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
+        int idx_e = num_pres_dofs * i + j;
         auto diff = std::abs( dg1dx1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -549,9 +529,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &jacobians );
 
     std::cout << "dg/dx2 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
-      for ( int j{ 0 }; j < num_nodes; ++j ) {
-        int idx_e = num_nodes * i + j;
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
+        int idx_e = num_pres_dofs * i + j;
         auto diff = std::abs( dg1dx2[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -565,7 +545,7 @@ class EnzymeElementMortarTest : public testing::Test {
     std::cout << "max_diff for approximate Jacobian comparison test: " << max_diff << std::endl;
 
     std::cout << "g -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_nodes; ++i ) {
+    for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
       auto diff = std::abs( g1[i] - g1t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << g1[i] << "  Tribol: " << g1t[i] << std::endl;
@@ -574,7 +554,7 @@ class EnzymeElementMortarTest : public testing::Test {
     }
 
     std::cout << "f1 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
       auto diff = std::abs( f1[i] - f1t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << f1[i] << "  Tribol: " << f1t[i] << std::endl;
@@ -583,7 +563,7 @@ class EnzymeElementMortarTest : public testing::Test {
     }
 
     std::cout << "f2 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
       auto diff = std::abs( f2[i] - f2t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << f2[i] << "  Tribol: " << f2t[i] << std::endl;

--- a/src/tests/tribol_enzyme_element_mortar.cpp
+++ b/src/tests/tribol_enzyme_element_mortar.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 
+#include "tribol/common/Parameters.hpp"
 #include "tribol/config.hpp"
 
 #include "gtest/gtest.h"
@@ -48,88 +49,66 @@ class EnzymeElementMortarTest : public testing::Test {
    * @param x2_stencil Stencil coordinate directions of the second face
    */
   void FDCheck( double* x1, double* x2, double* n1, double* p1, const double* x1_stencil = nullptr,
-                const double* x2_stencil = nullptr )
+                const double* x2_stencil = nullptr, int num_nodes = 4, double check_scale = 1.0 )
   {
-    constexpr int num_disp_dofs = 12;
+    constexpr int max_num_disp_dofs = 12;
+    constexpr int max_num_pres_dofs = 4;
 
-    double f1[num_disp_dofs];  // Array to store forces for the first face
-    double f2[num_disp_dofs];  // Array to store forces for the second face
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      f1[i] = 0.0;
-      f2[i] = 0.0;
-    }
-    constexpr int num_pres_dofs = 4;
-    double g1[num_pres_dofs];  // Array to store gap for the first face
-    for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
-      g1[i] = 0.0;
-    }
+    // Array to store forces for the first face
+    double f1[max_num_disp_dofs] = { 0.0 };
+    // Array to store forces for the second face
+    double f2[max_num_disp_dofs] = { 0.0 };
+    // Array to store gap for the first face
+    double g1[max_num_pres_dofs] = { 0.0 };
 
-    double df1dx1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the coordinates
-                                                   // of the first face
-    double df1dx2[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the coordinates
-                                                   // of the second face
-    double df1dn1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the first face w.r.t. the normal of the
-                                                   // first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
-      df1dx1[i] = 0.0;
-      df1dx2[i] = 0.0;
-      df1dn1[i] = 0.0;
-    }
-    double df1dp1[num_disp_dofs * num_pres_dofs];  // Derivative of the force on the first face w.r.t. the pressure of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_pres_dofs; ++i ) {
-      df1dp1[i] = 0.0;
-    }
-    double dg1dx1[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the coordinates of
-                                                   // the first face
-    double dg1dx2[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the coordinates of
-                                                   // the second face
-    double dg1dn1[num_pres_dofs * num_disp_dofs];  // Derivative of the gap on the first face w.r.t. the normal of the
-                                                   // first face
-    for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
-      dg1dx1[i] = 0.0;
-      dg1dx2[i] = 0.0;
-      dg1dn1[i] = 0.0;
-    }
-    double df2dx1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the coordinates
-                                                   // of the first face
-    double df2dx2[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the coordinates
-                                                   // of the second face
-    double df2dn1[num_disp_dofs * num_disp_dofs];  // Derivative of the force on the second face w.r.t. the normal of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
-      df2dx1[i] = 0.0;
-      df2dx2[i] = 0.0;
-      df2dn1[i] = 0.0;
-    }
-    double df2dp1[num_disp_dofs * num_pres_dofs];  // Derivative of the force on the second face w.r.t. the pressure of
-                                                   // the first face
-    for ( int i{ 0 }; i < num_disp_dofs * num_pres_dofs; ++i ) {
-      df2dp1[i] = 0.0;
-    }
+    // Derivative of the force on the first face w.r.t. the coordinates of the first face
+    double df1dx1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the coordinates of the second face
+    double df1dx2[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the normal of the first face
+    double df1dn1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the first face w.r.t. the pressure of the first face
+    double df1dp1[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the coordinates of the first face
+    double dg1dx1[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the coordinates of the second face
+    double dg1dx2[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the gap on the first face w.r.t. the normal of the first face
+    double dg1dn1[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the coordinates of the first face
+    double df2dx1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the coordinates of the second face
+    double df2dx2[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the normal of the first face
+    double df2dn1[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Derivative of the force on the second face w.r.t. the pressure of the first face
+    double df2dp1[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
 
-    constexpr int num_nodes = 4;
     tribol::ComputeMortarJacobianEnzyme( x1, n1, p1, f1, df1dx1, df1dx2, df1dn1, df1dp1, g1, dg1dx1, dg1dx2, dg1dn1,
                                          num_nodes, x2, f2, df2dx1, df2dx2, df2dn1, df2dp1, num_nodes );
 
-    double df1dx1_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the first face
-                                                      // w.r.t. the coordinates of the first face
-    double df2dx1_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the second face
-                                                      // w.r.t. the coordinates of the first face
-    double df1dx2_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the first face
-                                                      // w.r.t. the coordinates of the second face
-    double df2dx2_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the second face
-                                                      // w.r.t. the coordinates of the second face
-    double df1dn1_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the first face
-                                                      // w.r.t. the normal of the first face
-    double df2dn1_fd[num_disp_dofs * num_disp_dofs];  // Finite difference derivative of the force on the second face
-                                                      // w.r.t. the normal of the first face
-    double dg1dx1_fd[num_disp_dofs * num_pres_dofs];  // Finite difference derivative of the gap on the first face
-                                                      // w.r.t. the coordinates of the first face
-    double dg1dx2_fd[num_disp_dofs * num_pres_dofs];  // Finite difference derivative of the gap on the first face
-                                                      // w.r.t. the coordinates of the second face
-    double dg1dn1_fd[num_disp_dofs * num_pres_dofs];  // Finite difference derivative of the gap on the first face
-                                                      // w.r.t. the normal of the first face
+    // Finite difference derivative of the force on the first face w.r.t. the coordinates of the first face
+    double df1dx1_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the second face w.r.t. the coordinates of the first face
+    double df2dx1_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the first face w.r.t. the coordinates of the second face
+    double df1dx2_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the second face w.r.t. the coordinates of the second face
+    double df2dx2_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the first face w.r.t. the normal of the first face
+    double df1dn1_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the second face w.r.t. the normal of the first face
+    double df2dn1_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the gap on the first face w.r.t. the coordinates of the first face
+    double dg1dx1_fd[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
+    // Finite difference derivative of the gap on the first face w.r.t. the coordinates of the second face
+    double dg1dx2_fd[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
+    // Finite difference derivative of the gap on the first face w.r.t. the normal of the first face
+    double dg1dn1_fd[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
+
+    int num_disp_dofs = num_nodes * 3;  // Number of displacement degrees of freedom
+    int num_pres_dofs = num_nodes;      // Number of pressure degrees of freedom
+
     for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
       for ( int j{ 0 }; j < num_disp_dofs; ++j ) {
         df1dx1_fd[i * num_disp_dofs + j] = -f1[j];
@@ -145,10 +124,12 @@ class EnzymeElementMortarTest : public testing::Test {
         dg1dn1_fd[i * num_pres_dofs + j] = -g1[j];
       }
     }
-    double df1dp1_fd[num_pres_dofs * num_disp_dofs];  // Finite difference derivative of the force on the first face
-                                                      // w.r.t. the pressure of the first face
-    double df2dp1_fd[num_pres_dofs * num_disp_dofs];  // Finite difference derivative of the force on the second face
-                                                      // w.r.t. the pressure of the first face
+
+    // Finite difference derivative of the force on the first face w.r.t. the pressure of the first face
+    double df1dp1_fd[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+    // Finite difference derivative of the force on the second face w.r.t. the pressure of the first face
+    double df2dp1_fd[max_num_pres_dofs * max_num_disp_dofs] = { 0.0 };
+
     for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
       for ( int j{ 0 }; j < num_disp_dofs; ++j ) {
         df1dp1_fd[i * num_disp_dofs + j] = -f1[j];
@@ -255,148 +236,149 @@ class EnzymeElementMortarTest : public testing::Test {
     }
 
     double max_diff{ 0.0 };
+    double max_error{ check_scale * delta_ };
 
     std::cout << " df1/dx1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df1dx1[i] - df1dx1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df1dx1[i]
                   << "   FD: " << df1dx1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df1dx1[i], df1dx1_fd[i], delta_ );
+      EXPECT_NEAR( df1dx1[i], df1dx1_fd[i], max_error );
     }
 
     std::cout << " df2/dx1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df2dx1[i] - df2dx1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df2dx1[i]
                   << "   FD: " << df2dx1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df2dx1[i], df2dx1_fd[i], delta_ );
+      EXPECT_NEAR( df2dx1[i], df2dx1_fd[i], max_error );
     }
 
     std::cout << " dg1/dx1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( dg1dx1[i] - dg1dx1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_pres_dofs;
         auto col = i / num_pres_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << dg1dx1[i]
                   << "   FD: " << dg1dx1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( dg1dx1[i], dg1dx1_fd[i], delta_ );
+      EXPECT_NEAR( dg1dx1[i], dg1dx1_fd[i], max_error );
     }
 
     std::cout << " df1/dx2 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df1dx2[i] - df1dx2_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df1dx2[i]
                   << "   FD: " << df1dx2_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df1dx2[i], df1dx2_fd[i], delta_ );
+      EXPECT_NEAR( df1dx2[i], df1dx2_fd[i], max_error );
     }
 
     std::cout << " df2/dx2 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df2dx2[i] - df2dx2_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df2dx2[i]
                   << "   FD: " << df2dx2_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df2dx2[i], df2dx2_fd[i], delta_ );
+      EXPECT_NEAR( df2dx2[i], df2dx2_fd[i], max_error );
     }
 
     std::cout << " dg1/dx2 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( dg1dx2[i] - dg1dx2_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_pres_dofs;
         auto col = i / num_pres_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << dg1dx2[i]
                   << "   FD: " << dg1dx2_fd[i] << std::endl;
       }
-      EXPECT_NEAR( dg1dx2[i], dg1dx2_fd[i], delta_ );
+      EXPECT_NEAR( dg1dx2[i], dg1dx2_fd[i], max_error );
     }
 
     std::cout << " df1/dn1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df1dn1[i] - df1dn1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df1dn1[i]
                   << "   FD: " << df1dn1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df1dn1[i], df1dn1_fd[i], delta_ );
+      EXPECT_NEAR( df1dn1[i], df1dn1_fd[i], max_error );
     }
 
     std::cout << " df2/dn1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_disp_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df2dn1[i] - df2dn1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df2dn1[i]
                   << "   FD: " << df2dn1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df2dn1[i], df2dn1_fd[i], delta_ );
+      EXPECT_NEAR( df2dn1[i], df2dn1_fd[i], max_error );
     }
 
     std::cout << " dg1/dn1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( dg1dn1[i] - dg1dn1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
-        auto row = i % 4;
-        auto col = i / 4;
+      if ( diff > max_error ) {
+        auto row = i % num_pres_dofs;
+        auto col = i / num_pres_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << dg1dn1[i]
                   << "   FD: " << dg1dn1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( dg1dn1[i], dg1dn1_fd[i], delta_ );
+      EXPECT_NEAR( dg1dn1[i], dg1dn1_fd[i], max_error );
     }
 
     std::cout << " df1/dp1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df1dp1[i] - df1dp1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df1dp1[i]
                   << "   FD: " << df1dp1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df1dp1[i], df1dp1_fd[i], delta_ );
+      EXPECT_NEAR( df1dp1[i], df1dp1_fd[i], max_error );
     }
 
     std::cout << " df2/dp1 -------------------------------------- " << std::endl;
     for ( int i{ 0 }; i < num_pres_dofs * num_disp_dofs; ++i ) {
       auto diff = std::abs( df2dp1[i] - df2dp1_fd[i] );
       max_diff = std::max( max_diff, diff );
-      if ( diff > delta_ ) {
+      if ( diff > max_error ) {
         auto row = i % num_disp_dofs;
         auto col = i / num_disp_dofs;
         std::cout << "  (" << row << ", " << col << ") : Diff: " << diff << "   Enzyme: " << df2dp1[i]
                   << "   FD: " << df2dp1_fd[i] << std::endl;
       }
-      EXPECT_NEAR( df2dp1[i], df2dp1_fd[i], delta_ );
+      EXPECT_NEAR( df2dp1[i], df2dp1_fd[i], max_error );
     }
 
     std::cout << "max_diff for finite difference test: " << max_diff << std::endl;
@@ -410,7 +392,7 @@ class EnzymeElementMortarTest : public testing::Test {
    * @param n1 Normal of the first face
    * @param p1 Pressure of the first face
    */
-  void SimplifiedJacobianCheck( double* x1, double* x2, double* n1, double* p1 )
+  void SimplifiedJacobianCheck( double* x1, double* x2, double* n1, double* p1, int num_nodes = 4 )
   {
     constexpr int num_disp_dofs = 12;
     double f1[num_disp_dofs];  // Array to store forces for the first face
@@ -462,19 +444,22 @@ class EnzymeElementMortarTest : public testing::Test {
       df2dp1[i] = 0.0;
     }
 
-    constexpr int num_nodes = 4;
     ComputeMortarJacobianEnzyme( x1, n1, p1, f1, df1dx1, df1dx2, df1dn1, df1dp1, g1, dg1dx1, dg1dx2, dg1dn1, num_nodes,
                                  x2, f2, df2dx1, df2dx2, df2dn1, df2dp1, num_nodes );
 
     int conn[4] = { 0, 1, 2, 3 };
+    tribol::InterfaceElementType interface_element_type = tribol::InterfaceElementType::LINEAR_QUAD;
+    if ( num_nodes == 3 ) {
+      interface_element_type = tribol::InterfaceElementType::LINEAR_TRIANGLE;
+    }
     constexpr int num_elems = 1;
 
     constexpr int mesh_id1 = 0;
-    registerMesh( mesh_id1, num_elems, num_nodes, conn, InterfaceElementType::LINEAR_QUAD, x1, x1 + num_nodes,
-                  x1 + 2 * num_nodes, MemorySpace::Host );
+    registerMesh( mesh_id1, num_elems, num_nodes, conn, interface_element_type, x1, x1 + num_nodes, x1 + 2 * num_nodes,
+                  MemorySpace::Host );
     constexpr int mesh_id2 = 1;
-    registerMesh( mesh_id2, num_elems, num_nodes, conn, InterfaceElementType::LINEAR_QUAD, x2, x2 + num_nodes,
-                  x2 + 2 * num_nodes, MemorySpace::Host );
+    registerMesh( mesh_id2, num_elems, num_nodes, conn, interface_element_type, x2, x2 + num_nodes, x2 + 2 * num_nodes,
+                  MemorySpace::Host );
     constexpr int cs_id = 0;
     // mortar then nonmortar surfaces
     registerCouplingScheme( cs_id, mesh_id2, mesh_id1, ContactMode::SURFACE_TO_SURFACE, ContactCase::NO_CASE,
@@ -513,9 +498,9 @@ class EnzymeElementMortarTest : public testing::Test {
     double max_diff{ 0.0 };
 
     std::cout << "df1/dp -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
-        int idx_e = num_pres_dofs * i + j;
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+      for ( int j{ 0 }; j < num_nodes; ++j ) {
+        int idx_e = num_nodes * i + j;
         auto diff = std::abs( df1dp1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -530,9 +515,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &jacobians );
 
     std::cout << "df2/dp -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
-        int idx_e = num_pres_dofs * i + j;
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+      for ( int j{ 0 }; j < num_nodes; ++j ) {
+        int idx_e = num_nodes * i + j;
         auto diff = std::abs( df2dp1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -547,9 +532,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &col_elem_idx, &jacobians );
 
     std::cout << "dg/dx1 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
-        int idx_e = num_pres_dofs * i + j;
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+      for ( int j{ 0 }; j < num_nodes; ++j ) {
+        int idx_e = num_nodes * i + j;
         auto diff = std::abs( dg1dx1[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -564,9 +549,9 @@ class EnzymeElementMortarTest : public testing::Test {
                               &jacobians );
 
     std::cout << "dg/dx2 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
-      for ( int j{ 0 }; j < num_pres_dofs; ++j ) {
-        int idx_e = num_pres_dofs * i + j;
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
+      for ( int j{ 0 }; j < num_nodes; ++j ) {
+        int idx_e = num_nodes * i + j;
         auto diff = std::abs( dg1dx2[idx_e] - ( *jacobians )[0].Data()[idx_e] );
         max_diff = std::max( max_diff, diff );
         if ( diff > approx_j_err_ ) {
@@ -580,7 +565,7 @@ class EnzymeElementMortarTest : public testing::Test {
     std::cout << "max_diff for approximate Jacobian comparison test: " << max_diff << std::endl;
 
     std::cout << "g -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
+    for ( int i{ 0 }; i < num_nodes; ++i ) {
       auto diff = std::abs( g1[i] - g1t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << g1[i] << "  Tribol: " << g1t[i] << std::endl;
@@ -589,7 +574,7 @@ class EnzymeElementMortarTest : public testing::Test {
     }
 
     std::cout << "f1 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
       auto diff = std::abs( f1[i] - f1t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << f1[i] << "  Tribol: " << f1t[i] << std::endl;
@@ -598,7 +583,7 @@ class EnzymeElementMortarTest : public testing::Test {
     }
 
     std::cout << "f2 -------------------------------------- " << std::endl;
-    for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
+    for ( int i{ 0 }; i < 3 * num_nodes; ++i ) {
       auto diff = std::abs( f2[i] - f2t[i] );
       if ( diff > tribol_vs_enzyme_err_ ) {
         std::cout << "[" << i << "] Enzyme: " << f2[i] << "  Tribol: " << f2t[i] << std::endl;
@@ -637,13 +622,43 @@ TEST_F( EnzymeElementMortarTest, ExactOverlapZeroGap )
   SimplifiedJacobianCheck( x1, x2, n1, p1 );
 }
 
+TEST_F( EnzymeElementMortarTest, ShiftedXYNonmortarElementZeroGapTri )
+{
+  // clang-format off
+  // {x0, x1, x2,
+  //  y0, y1, y2,
+  //  z0, z1, z2}
+  constexpr double offset = 0.01;
+  double x1[9] = { 0.0 + 2.0 * offset, 1.0 + 2.0 * offset, 1.0 + 2.0 * offset,
+                   0.0 + offset,       0.0 + offset,       1.0 + offset,
+                   0.0,                0.0,                0.0 };
+  double x2[9] = { 0.0, 1.0, 1.0,
+                   0.0, 1.0, 0.0,
+                   0.0, 0.0, 0.0 };
+  double n1[9] = { 0.0, 0.0, 0.0,
+                   0.0, 0.0, 0.0,
+                   1.0, 1.0, 1.0 };
+  double p1[4] = { 1.0, 1.0, 1.0 };
+  double x1_stencil[12] = {  1.0, -1.0, -1.0,
+                             1.0,  1.0, -1.0,
+                            -1.0, -1.0, -1.0 };
+  double x2_stencil[12] = { -1.0,  1.0,  1.0,
+                            -1.0,  1.0, -1.0,
+                            -1.0, -1.0, -1.0 };
+  // clang-format on
+
+  FDCheck( x1, x2, n1, p1, x1_stencil, x2_stencil, 3, 2.0 );
+  // the simplified Tribol jacobian should match here.  verify that it does
+  SimplifiedJacobianCheck( x1, x2, n1, p1, 3 );
+}
+
 TEST_F( EnzymeElementMortarTest, SlightlySmallerNonmortarElementMinorInterpenetration )
 {
   // slightly smaller
   double dx = 4.0 * delta_;
   // clang-format off
-  // {x0, x1, x2, x3, 
-  //  y0, y1, y2, y3, 
+  // {x0, x1, x2, x3,
+  //  y0, y1, y2, y3,
   //  z0, z1, z2, z3}
   double x1[12] = { 0.0+dx, 1.0-dx, 1.0-dx, 0.0+dx,
                     0.0+dx, 0.0+dx, 1.0-dx, 1.0-dx,
@@ -668,8 +683,8 @@ TEST_F( EnzymeElementMortarTest, ShiftedXNonmortarElementMinorInterpenetration )
   double offset = 0.3;
   double dx = 4.0 * delta_;
   // clang-format off
-  // {x0, x1, x2, x3, 
-  //  y0, y1, y2, y3, 
+  // {x0, x1, x2, x3,
+  //  y0, y1, y2, y3,
   //  z0, z1, z2, z3}
   double x1[12] = { 0.0+dx+offset, 1.0-dx+offset, 1.0-dx+offset, 0.0+dx+offset,
                     0.0+dx,        0.0+dx,        1.0-dx,        1.0-dx,
@@ -692,8 +707,8 @@ TEST_F( EnzymeElementMortarTest, ShiftedXYNonmortarElementMinorInterpenetration 
   double offset = 0.3;
   double dx = 4.0 * delta_;
   // clang-format off
-  // {x0, x1, x2, x3, 
-  //  y0, y1, y2, y3, 
+  // {x0, x1, x2, x3,
+  //  y0, y1, y2, y3,
   //  z0, z1, z2, z3}
   double x1[12] = { 0.0+dx+offset, 1.0-dx+offset, 1.0-dx+offset, 0.0+dx+offset,
                     0.0+dx+offset, 0.0+dx+offset, 1.0-dx+offset, 1.0-dx+offset,
@@ -716,8 +731,8 @@ TEST_F( EnzymeElementMortarTest, ShiftedXYNonmortarElementMinorInterpenetrationV
   // slightly offset
   double dx = 10.0 * delta_;
   // clang-format off
-  // {x0, x1, x2, x3, 
-  //  y0, y1, y2, y3, 
+  // {x0, x1, x2, x3,
+  //  y0, y1, y2, y3,
   //  z0, z1, z2, z3}
   double x1[12] = { 0.0+dx, 0.0+dx, 1.0+dx, 1.0+dx,
                     0.0+dx, 1.0+dx, 1.0+dx, 0.0+dx,

--- a/src/tests/tribol_inv_iso.cpp
+++ b/src/tests/tribol_inv_iso.cpp
@@ -95,7 +95,8 @@ class InvIsoTest : public ::testing::Test {
   }
 
   /**
-   * @brief Run a test on a triangular element.
+   * @brief Given a coordinate point xi in the reference triangle, compute the corresponding physical coordinate. Then
+   * verify InvIso maps the coordinate back to xi.
    *
    * @param x0 The zero-th coordinate of the triangle (3D, CCW ordering).
    * @param x1 The first coordinate of the triangle (3D, CCW ordering).
@@ -233,6 +234,19 @@ TEST_F( InvIsoTest, affine_test_point )
   EXPECT_EQ( convrg, true );
 }
 
+/*
+       x2
+       /\
+      /  \
+     /    \
+    /      \
+   /        \
+  x0---------x1
+
+  x0 = (0.0, 0.0, 0.0)
+  x1 = (1.0, 0.0, 0.0)
+  x2 = (0.5, 1.0, 0.0)
+*/
 TEST_F( InvIsoTest, basic_tri_test )
 {
   RealT x0[3] = { 0.0, 0.0, 0.0 };
@@ -253,11 +267,12 @@ TEST_F( InvIsoTest, basic_tri_test )
   }
 }
 
+// tests a narrower triangle that is out of the xy plane
 TEST_F( InvIsoTest, narrow_offaxis_tri_test )
 {
   RealT x0[3] = { 0.2, -0.2, 0.5 };
   RealT x1[3] = { 1.0, 0.0, 0.5 };
-  RealT x2[3] = { 0.5, 0.1, 0.5 };
+  RealT x2[3] = { 0.5, 0.1, 0.0 };
   // clang-format off
   RealT xi[14] = { 0.25, 0.25,
                   0.0, 0.0,

--- a/src/tests/tribol_inv_iso.cpp
+++ b/src/tests/tribol_inv_iso.cpp
@@ -94,6 +94,31 @@ class InvIsoTest : public ::testing::Test {
     }
   }
 
+  /**
+   * @brief Run a test on a triangular element.
+   *
+   * @param x0 The zero-th coordinate of the triangle (3D, CCW ordering).
+   * @param x1 The first coordinate of the triangle (3D, CCW ordering).
+   * @param x2 The second coordinate of the triangle (3D, CCW ordering).
+   * @param xi The point to test (xi \in [0, 1], eta \in [0, 1 - xi]).
+   */
+  void RunTriTest( const tribol::RealT* x0, const tribol::RealT* x1, const tribol::RealT* x2, const tribol::RealT* xi )
+  {
+    tribol::RealT x[3] = { 0.0, 0.0, 0.0 };
+    tribol::RealT phi[3] = { 0.0, 0.0, 0.0 };
+    tribol::LinIsoTriShapeFunc( xi, phi );
+    for ( int i{ 0 }; i < 3; ++i ) {
+      x[i] += phi[0] * x0[i] + phi[1] * x1[i] + phi[2] * x2[i];
+    }
+    tribol::RealT xi_inviso[2] = { 0.0, 0.0 };
+    tribol::RealT xA[3] = { x0[0], x1[0], x2[0] };
+    tribol::RealT yA[3] = { x0[1], x1[1], x2[1] };
+    tribol::RealT zA[3] = { x0[2], x1[2], x2[2] };
+    tribol::InvIso( x, xA, yA, zA, 3, xi_inviso );
+    EXPECT_NEAR( xi_inviso[0], xi[0], 1.e-12 );
+    EXPECT_NEAR( xi_inviso[1], xi[1], 1.e-12 );
+  }
+
  protected:
   RealT* x{ nullptr };
   RealT* y{ nullptr };
@@ -206,6 +231,46 @@ TEST_F( InvIsoTest, affine_test_point )
   bool convrg = this->InvMap( point, 1.e-6 );
 
   EXPECT_EQ( convrg, true );
+}
+
+TEST_F( InvIsoTest, basic_tri_test )
+{
+  RealT x0[3] = { 0.0, 0.0, 0.0 };
+  RealT x1[3] = { 1.0, 0.0, 0.0 };
+  RealT x2[3] = { 0.5, 1.0, 0.0 };
+  // clang-format off
+  RealT xi[14] = { 0.25, 0.25,
+                  0.0, 0.0,
+                  1.0, 0.0,
+                  0.0, 1.0,
+                  0.5, 0.5,
+                  0.33333, 0.33333,
+                  0.12352634, 0.2345422 };
+  // clang-format on
+
+  for ( int i{ 0 }; i < 7; ++i ) {
+    this->RunTriTest( x0, x1, x2, xi + 2 * i );
+  }
+}
+
+TEST_F( InvIsoTest, narrow_offaxis_tri_test )
+{
+  RealT x0[3] = { 0.2, -0.2, 0.5 };
+  RealT x1[3] = { 1.0, 0.0, 0.5 };
+  RealT x2[3] = { 0.5, 0.1, 0.5 };
+  // clang-format off
+  RealT xi[14] = { 0.25, 0.25,
+                  0.0, 0.0,
+                  1.0, 0.0,
+                  0.0, 1.0,
+                  0.5, 0.5,
+                  0.33333, 0.33333,
+                  0.12352634, 0.2345422 };
+  // clang-format on
+
+  for ( int i{ 0 }; i < 7; ++i ) {
+    this->RunTriTest( x0, x1, x2, xi + 2 * i );
+  }
 }
 
 int main( int argc, char* argv[] )

--- a/src/tests/tribol_mfem_mortar_lm.cpp
+++ b/src/tests/tribol_mfem_mortar_lm.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (MIT)
 
-#include <mfem/mesh/element.hpp>
 #include <set>
 
 #include <gtest/gtest.h>

--- a/src/tests/tribol_mfem_mortar_lm.cpp
+++ b/src/tests/tribol_mfem_mortar_lm.cpp
@@ -3,18 +3,10 @@
 //
 // SPDX-License-Identifier: (MIT)
 
+#include <mfem/mesh/element.hpp>
 #include <set>
 
 #include <gtest/gtest.h>
-
-// Tribol includes
-#include "tribol/config.hpp"
-#include "tribol/common/Parameters.hpp"
-#include "tribol/interface/tribol.hpp"
-#include "tribol/interface/mfem_tribol.hpp"
-
-// Redecomp includes
-#include "redecomp/redecomp.hpp"
 
 #ifdef TRIBOL_USE_UMPIRE
 // Umpire includes
@@ -28,24 +20,34 @@
 #include "axom/CLI11.hpp"
 #include "axom/slic.hpp"
 
+// Shared includes
+#include "shared/mesh/MeshBuilder.hpp"
+
+// Redecomp includes
+#include "redecomp/redecomp.hpp"
+
+// Tribol includes
+#include "tribol/config.hpp"
+#include "tribol/common/Parameters.hpp"
+#include "tribol/interface/tribol.hpp"
+#include "tribol/interface/mfem_tribol.hpp"
+
 /**
  * @brief This tests the Tribol MFEM interface running a contact patch test.
  *
  */
-class MfemMortarTest : public testing::TestWithParam<int> {
+class MfemMortarTest : public testing::TestWithParam<std::tuple<int, mfem::Element::Type>> {
  protected:
   tribol::RealT max_disp_;
   void SetUp() override
   {
     // number of times to uniformly refine the serial mesh before constructing the
     // parallel mesh
-    int ref_levels = GetParam();
+    int ref_levels = std::get<0>( GetParam() );
     // polynomial order of the finite element discretization
     int order = 1;
 
     // fixed options
-    // location of mesh file. TRIBOL_REPO_DIR is defined in tribol/config.hpp
-    std::string mesh_file = TRIBOL_REPO_DIR "/data/two_hex_overlap.mesh";
     // boundary element attributes of mortar surface
     auto mortar_attrs = std::set<int>( { 4 } );
     // boundary element attributes of nonmortar surface
@@ -57,40 +59,34 @@ class MfemMortarTest : public testing::TestWithParam<int> {
     // boundary element attributes of z-fixed surfaces (3: surface at z = 0, 6: surface at z = 1.99)
     auto zfixed_attrs = std::set<int>( { 3, 6 } );
 
-    // read mesh
-    std::unique_ptr<mfem::ParMesh> pmesh{ nullptr };
-    {
-      // read serial mesh
-      auto mesh = std::make_unique<mfem::Mesh>( mesh_file.c_str(), 1, 1 );
-
-      // refine serial mesh
-      if ( ref_levels > 0 ) {
-        for ( int i{ 0 }; i < ref_levels; ++i ) {
-          mesh->UniformRefinement();
-        }
-      }
-
-      // create parallel mesh from serial
-      pmesh = std::make_unique<mfem::ParMesh>( MPI_COMM_WORLD, *mesh );
-      mesh.reset( nullptr );
-
-      // further refinement of parallel mesh
-      {
-        int par_ref_levels = 0;
-        for ( int i{ 0 }; i < par_ref_levels; ++i ) {
-          pmesh->UniformRefinement();
-        }
-      }
-    }
+    // build mesh of 2 cubes
+    int nel_per_dir = std::pow( 2, ref_levels );
+    // clang-format off
+    mfem::ParMesh mesh = shared::ParMeshBuilder(MPI_COMM_WORLD, shared::MeshBuilder::Unify({
+      shared::MeshBuilder::CubeMesh(nel_per_dir, nel_per_dir, nel_per_dir, std::get<1>(GetParam()))
+        .updateBdrAttrib(3, 7)
+        .updateBdrAttrib(1, 3)
+        .updateBdrAttrib(4, 7)
+        .updateBdrAttrib(5, 1)
+        .updateBdrAttrib(6, 4),
+      shared::MeshBuilder::CubeMesh(nel_per_dir, nel_per_dir, nel_per_dir, std::get<1>(GetParam()))
+        .translate({0.0, 0.0, 0.99})
+        .updateBdrAttrib(1, 8)
+        .updateBdrAttrib(3, 7)
+        .updateBdrAttrib(4, 7)
+        .updateBdrAttrib(5, 1)
+        .updateBdrAttrib(8, 5)
+    }));
+    // clang-format on
 
     // grid function for higher-order nodes
-    auto fe_coll = mfem::H1_FECollection( order, pmesh->SpaceDimension() );
-    auto par_fe_space = mfem::ParFiniteElementSpace( pmesh.get(), &fe_coll, pmesh->SpaceDimension() );
+    auto fe_coll = mfem::H1_FECollection( order, mesh.SpaceDimension() );
+    auto par_fe_space = mfem::ParFiniteElementSpace( &mesh, &fe_coll, mesh.SpaceDimension() );
     auto coords = mfem::ParGridFunction( &par_fe_space );
     if ( order > 1 ) {
-      pmesh->SetNodalGridFunction( &coords, false );
+      mesh.SetNodalGridFunction( &coords, false );
     } else {
-      pmesh->GetNodes( coords );
+      mesh.GetNodes( coords );
     }
 
     // grid function for displacement
@@ -101,7 +97,7 @@ class MfemMortarTest : public testing::TestWithParam<int> {
     mfem::Array<int> ess_tdof_list;
     {
       mfem::Array<int> ess_vdof_marker;
-      mfem::Array<int> ess_bdr( pmesh->bdr_attributes.Max() );
+      mfem::Array<int> ess_bdr( mesh.bdr_attributes.Max() );
       ess_bdr = 0;
       for ( auto xfixed_attr : xfixed_attrs ) {
         ess_bdr[xfixed_attr - 1] = 1;
@@ -144,7 +140,7 @@ class MfemMortarTest : public testing::TestWithParam<int> {
     int coupling_scheme_id = 0;
     int mesh1_id = 0;
     int mesh2_id = 1;
-    tribol::registerMfemCouplingScheme( coupling_scheme_id, mesh1_id, mesh2_id, *pmesh, coords, mortar_attrs,
+    tribol::registerMfemCouplingScheme( coupling_scheme_id, mesh1_id, mesh2_id, mesh, coords, mortar_attrs,
                                         nonmortar_attrs, tribol::SURFACE_TO_SURFACE, tribol::NO_SLIDING,
                                         tribol::SINGLE_MORTAR, tribol::FRICTIONLESS, tribol::LAGRANGE_MULTIPLIER,
                                         tribol::BINNING_GRID );
@@ -206,7 +202,9 @@ TEST_P( MfemMortarTest, mass_matrix_transfer )
   MPI_Barrier( MPI_COMM_WORLD );
 }
 
-INSTANTIATE_TEST_SUITE_P( tribol, MfemMortarTest, testing::Values( 2 ) );
+INSTANTIATE_TEST_SUITE_P( tribol, MfemMortarTest,
+                          testing::Values( std::make_tuple( 2, mfem::Element::Type::HEXAHEDRON ),
+                                           std::make_tuple( 2, mfem::Element::Type::TETRAHEDRON ) ) );
 
 //------------------------------------------------------------------------------
 #include "axom/slic/core/SimpleLogger.hpp"

--- a/src/tribol/geom/ElementNormal.cpp
+++ b/src/tribol/geom/ElementNormal.cpp
@@ -7,6 +7,8 @@
 
 #include <cmath>
 
+#include "axom/slic.hpp"
+
 #include "tribol/utils/Math.hpp"
 
 namespace tribol {
@@ -62,8 +64,8 @@ TRIBOL_HOST_DEVICE bool PalletAvgNormal::Compute( const RealT* x, const RealT* c
   return face_ok;
 }
 
-TRIBOL_HOST_DEVICE bool QuadCentroidNormal::Compute( const RealT* x, const RealT* c, RealT* n, int num_nodes,
-                                                     RealT& area ) const
+TRIBOL_HOST_DEVICE bool ElementCentroidNormal::Compute( const RealT* x, const RealT* c, RealT* n, int num_nodes,
+                                                        RealT& area ) const
 {
   area = 0.0;
   // get vector n (normal of elem1) = de1 x de2, where de1 and de2 are tangent vectors evaluated at the
@@ -84,6 +86,8 @@ TRIBOL_HOST_DEVICE bool QuadCentroidNormal::Compute( const RealT* x, const RealT
     de2[0] = x[2] - x[0];
     de2[1] = x[5] - x[3];
     de2[2] = x[8] - x[6];
+  } else {
+    SLIC_ERROR( "ElementCentroidNormal::Compute() only 3- and 4-node elements are supported." );
   }
   n[0] = de1[1] * de2[2] - de1[2] * de2[1];
   n[1] = de1[2] * de2[0] - de1[0] * de2[2];

--- a/src/tribol/geom/ElementNormal.cpp
+++ b/src/tribol/geom/ElementNormal.cpp
@@ -68,13 +68,23 @@ TRIBOL_HOST_DEVICE bool QuadCentroidNormal::Compute( const RealT* x, const RealT
   area = 0.0;
   // get vector n (normal of elem1) = de1 x de2, where de1 and de2 are tangent vectors evaluated at the
   // element centroid
-  // NOTE: this limits this routine to quads
-  RealT de1[3] = { -0.25 * x[0] + 0.25 * x[1] + 0.25 * x[2] - 0.25 * x[3],
-                   -0.25 * x[4] + 0.25 * x[5] + 0.25 * x[6] - 0.25 * x[7],
-                   -0.25 * x[8] + 0.25 * x[9] + 0.25 * x[10] - 0.25 * x[11] };
-  RealT de2[3] = { -0.25 * x[0] - 0.25 * x[1] + 0.25 * x[2] + 0.25 * x[3],
-                   -0.25 * x[4] - 0.25 * x[5] + 0.25 * x[6] + 0.25 * x[7],
-                   -0.25 * x[8] - 0.25 * x[9] + 0.25 * x[10] + 0.25 * x[11] };
+  RealT de1[3] = { 0.0, 0.0, 0.0 };
+  RealT de2[3] = { 0.0, 0.0, 0.0 };
+  if ( num_nodes == 4 ) {
+    de1[0] = -0.25 * x[0] + 0.25 * x[1] + 0.25 * x[2] - 0.25 * x[3];
+    de1[1] = -0.25 * x[4] + 0.25 * x[5] + 0.25 * x[6] - 0.25 * x[7];
+    de1[2] = -0.25 * x[8] + 0.25 * x[9] + 0.25 * x[10] - 0.25 * x[11];
+    de2[0] = -0.25 * x[0] - 0.25 * x[1] + 0.25 * x[2] + 0.25 * x[3];
+    de2[1] = -0.25 * x[4] - 0.25 * x[5] + 0.25 * x[6] + 0.25 * x[7];
+    de2[2] = -0.25 * x[8] - 0.25 * x[9] + 0.25 * x[10] + 0.25 * x[11];
+  } else if ( num_nodes == 3 ) {
+    de1[0] = x[1] - x[0];
+    de1[1] = x[4] - x[3];
+    de1[2] = x[7] - x[6];
+    de2[0] = x[2] - x[0];
+    de2[1] = x[5] - x[3];
+    de2[2] = x[8] - x[6];
+  }
   n[0] = de1[1] * de2[2] - de1[2] * de2[1];
   n[1] = de1[2] * de2[0] - de1[0] * de2[2];
   n[2] = de1[0] * de2[1] - de1[1] * de2[0];

--- a/src/tribol/geom/ElementNormal.cpp
+++ b/src/tribol/geom/ElementNormal.cpp
@@ -87,7 +87,10 @@ TRIBOL_HOST_DEVICE bool ElementCentroidNormal::Compute( const RealT* x, const Re
     de2[1] = x[5] - x[3];
     de2[2] = x[8] - x[6];
   } else {
+// TODO: switch to TRIBOL_DEVICE_CODE when PR 147 merges
+#ifdef TRIBOL_USE_HOST
     SLIC_ERROR( "ElementCentroidNormal::Compute() only 3- and 4-node elements are supported." );
+#endif
   }
   n[0] = de1[1] * de2[2] - de1[2] * de2[1];
   n[1] = de1[2] * de2[0] - de1[0] * de2[2];

--- a/src/tribol/geom/ElementNormal.hpp
+++ b/src/tribol/geom/ElementNormal.hpp
@@ -56,9 +56,9 @@ class PalletAvgNormal : public ElementNormal {
 };
 
 /**
- * @brief Computes element normal at the origin of the isoparametric element
+ * @brief Computes element normal at the origin of the isoparametric element (triangle or quadrilateral)
  */
-class QuadCentroidNormal : public ElementNormal {
+class ElementCentroidNormal : public ElementNormal {
  public:
   /**
    * @brief Computes element normal at the origin of the isoparametric element
@@ -66,7 +66,7 @@ class QuadCentroidNormal : public ElementNormal {
    * @param [in] x Nodal coordinates for the element (stored by nodes, i.e. [x0, x1, x2, y0, y1, y2, z0, z1, z2])
    * @param [in] c Centroid for the element (length = spatial dimension)
    * @param [out] n Unit vector in the normal direction (length = spatial dimension)
-   * @param [in] num_nodes Number of nodes in the element
+   * @param [in] num_nodes Number of nodes in the element (either 3 or 4)
    * @param [out] area Area of the element
    * @return Is face data OK?  true = yes; false = no
    */

--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -612,7 +612,9 @@ TRIBOL_HOST_DEVICE FaceGeomError Intersection2DPolygon( const RealT* xA, const R
 
   // check A in B
   for ( int i = 0; i < numVertexA; ++i ) {
-    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB ) ) {
+    // NOTE (EBC): if a point is less than lenTol away from being inside, then include it as interior (since the edge
+    // should be collapsed anyway)
+    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB, lenTol ) ) {
       // interior A in B
       interiorVAId[i] = i;
       ++numVAI;
@@ -643,7 +645,9 @@ TRIBOL_HOST_DEVICE FaceGeomError Intersection2DPolygon( const RealT* xA, const R
 
   // check B in A
   for ( int i = 0; i < numVertexB; ++i ) {
-    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA ) ) {
+    // NOTE (EBC): if a point is less than lenTol away from being inside, then include it as interior (since the edge
+    // should be collapsed anyway)
+    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA, lenTol ) ) {
       // interior B in A
       interiorVBId[i] = i;
       ++numVBI;
@@ -965,7 +969,8 @@ TRIBOL_HOST_DEVICE bool CheckPolyOrientation( const RealT* const x, const RealT*
 
 //------------------------------------------------------------------------------
 TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, const RealT* const xPoly,
-                                       const RealT* const yPoly, const RealT xC, const RealT yC, const int numPolyVert )
+                                       const RealT* const yPoly, const RealT xC, const RealT yC, const int numPolyVert,
+                                       RealT tol )
 {
 #if defined( TRIBOL_USE_HOST ) && !defined( TRIBOL_USE_ENZYME )
   SLIC_ERROR_IF( numPolyVert < 3, "Point2DInFace: number of face vertices is less than 3" );
@@ -975,7 +980,7 @@ TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, c
 
   // if face is triangle (numPolyVert), call Point2DInTri once
   if ( numPolyVert == 3 ) {
-    return Point2DInTri( xPoint, yPoint, xPoly, yPoly );
+    return Point2DInTri( xPoint, yPoint, xPoly, yPoly, tol );
   }
 
   // loop over triangles and determine if point is inside
@@ -996,7 +1001,9 @@ TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, c
     yTri[2] = yC;
 
     // call Point2DInTri for each triangle
-    tri = Point2DInTri( xPoint, yPoint, xTri, yTri );
+    // NOTE (EBC): we should probably "round" the corners around the tolerance so there aren't weird spikes in the
+    // inclusion polygon
+    tri = Point2DInTri( xPoint, yPoint, xTri, yTri, tol );
 
     if ( tri ) {
       return true;
@@ -1007,7 +1014,8 @@ TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, c
 }  // end Point2DInFace()
 
 //------------------------------------------------------------------------------
-TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const RealT* const xTri, const RealT* const yTri )
+TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const RealT* const xTri, const RealT* const yTri,
+                                      RealT tol )
 {
   bool inside = false;
 
@@ -1036,11 +1044,9 @@ TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const Real
   RealT u = invDet * ( e22 * p1e1 - e12 * p1e2 );
   RealT v = invDet * ( e11 * p1e2 - e12 * p1e1 );
 
-  // u or v may be negative, but numerically zero. Address this
-  u = ( std::abs( u ) < 1.e-12 ) ? 0.0 : u;
-  v = ( std::abs( v ) < 1.e-12 ) ? 0.0 : v;
-
-  if ( ( u >= 0 ) && ( v >= 0 ) && ( u + v <= 1 ) ) {
+  // check if point is inside the triangle within a tolerance
+  // NOTE: the sqrt(2.0) is to keep the length consistent on the incline
+  if ( ( u >= -tol ) && ( v >= -tol ) && ( u + v <= 1 + tol * std::sqrt( 2.0 ) ) ) {
     inside = true;
   }
 

--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -612,9 +612,7 @@ TRIBOL_HOST_DEVICE FaceGeomError Intersection2DPolygon( const RealT* xA, const R
 
   // check A in B
   for ( int i = 0; i < numVertexA; ++i ) {
-    // NOTE (EBC): if a point is less than lenTol away from being inside, then include it as interior (since the edge
-    // should be collapsed anyway)
-    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB, lenTol ) ) {
+    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB ) ) {
       // interior A in B
       interiorVAId[i] = i;
       ++numVAI;
@@ -645,9 +643,7 @@ TRIBOL_HOST_DEVICE FaceGeomError Intersection2DPolygon( const RealT* xA, const R
 
   // check B in A
   for ( int i = 0; i < numVertexB; ++i ) {
-    // NOTE (EBC): if a point is less than lenTol away from being inside, then include it as interior (since the edge
-    // should be collapsed anyway)
-    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA, lenTol ) ) {
+    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA ) ) {
       // interior B in A
       interiorVBId[i] = i;
       ++numVBI;
@@ -722,7 +718,7 @@ TRIBOL_HOST_DEVICE FaceGeomError Intersection2DPolygon( const RealT* xA, const R
   dupl = false;
 
   // loop over segment-segment intersections to find the rest of the
-  // intersecting vertices. This is O(n^2), but segments defined by two
+  // intersection vertices. This is O(n^2), but segments defined by two
   // nodes interior to the other polygon will be skipped. This will catch
   // outlier cases.
   int interId = 0;
@@ -1046,7 +1042,7 @@ TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const Real
 
   // check if point is inside the triangle within a tolerance
   // NOTE: the sqrt(2.0) is to keep the length consistent on the incline
-  if ( ( u >= -tol ) && ( v >= -tol ) && ( u + v <= 1 + tol * std::sqrt( 2.0 ) ) ) {
+  if ( ( u >= -tol ) && ( v >= -tol ) && ( u + v <= 1.0 + tol * std::sqrt( 2.0 ) ) ) {
     inside = true;
   }
 

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -385,6 +385,7 @@ TRIBOL_HOST_DEVICE bool CheckPolyOrientation( const RealT* const x, const RealT*
  * \param [in] xC local x coordinate of vertex averaged centroid
  * \param [in] yC local y coordinate of vertex averaged centroid
  * \param [in] numPolyVert number of polygon vertices
+ * \param [in] tol "fuzz" length: how far outside the face a point can be to still be considered inside
  *
  * \return true if the point is in the face, false otherwise.
  *
@@ -399,8 +400,8 @@ TRIBOL_HOST_DEVICE bool CheckPolyOrientation( const RealT* const x, const RealT*
  *  point lies in either of those two triangles.
  */
 TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, const RealT* const xPoly,
-                                       const RealT* const yPoly, const RealT xC, const RealT yC,
-                                       const int numPolyVert );
+                                       const RealT* const yPoly, const RealT xC, const RealT yC, const int numPolyVert,
+                                       RealT tol = 1.0e-12 );
 
 /*!
  *
@@ -410,6 +411,7 @@ TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, c
  * \param [in] yp local y coordinate of point
  * \param [in] xTri array of local x coordinates of triangle
  * \param [in] yTri array of local y coordinates of triangle
+ * \param [in] tol "fuzz" length: how far outside the triangle a point can be to still be considered inside
  *
  * \return true if the point is inside the triangle, false otherwise
  *
@@ -419,8 +421,8 @@ TRIBOL_HOST_DEVICE bool Point2DInFace( const RealT xPoint, const RealT yPoint, c
  *  determines if those coordinates are inside or out
  *  (http://blackpawn.com/texts/pointinpoly/default.html);
  */
-TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const RealT* const xTri,
-                                      const RealT* const yTri );
+TRIBOL_HOST_DEVICE bool Point2DInTri( const RealT xp, const RealT yp, const RealT* const xTri, const RealT* const yTri,
+                                      RealT tol = 1.0e-12 );
 
 /*!
  * \brief computes the area of a polygon

--- a/src/tribol/geom/NodalNormal.cpp
+++ b/src/tribol/geom/NodalNormal.cpp
@@ -130,7 +130,7 @@ void EdgeAvgNodalNormal::Compute( MeshData& mesh, MethodData* jacobian_data )
     }
     if ( jacobian_data != nullptr ) {
       StackArray<DeviceArray2D<RealT>, 9> blockJ( 3 );
-      blockJ( 0, 0 ) = DeviceArray2D<RealT>( 12, 12 );
+      blockJ( 0, 0 ) = DeviceArray2D<RealT>( num_nodes_per_elem * 3, num_nodes_per_elem * 3 );
       blockJ( 0, 0 ).fill( 0.0 );
       ElementEdgeAvgNodalNormalJacobian( x, xref, n, blockJ( 0, 0 ).data(), num_nodes_per_elem );
       jacobian_data->storeElemBlockJ( { e }, blockJ );

--- a/src/tribol/integ/FE.cpp
+++ b/src/tribol/integ/FE.cpp
@@ -209,132 +209,153 @@ TRIBOL_HOST_DEVICE void WachspressBasis( const RealT* const x, const RealT pX, c
 //------------------------------------------------------------------------------
 void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const RealT* zA, const int numNodes, RealT xi[2] )
 {
-#if !defined( TRIBOL_USE_ENZYME )
-  SLIC_ERROR_IF( numNodes != 4, "InvIso: routine only for 4 node quads." );
-#endif
+  if ( numNodes == 4 ) {
+    bool convrg = false;
+    int kmax = 15;
+    RealT xtol = 1.E-12;
 
-  bool convrg = false;
-  int kmax = 15;
-  RealT xtol = 1.E-12;
+    RealT x_sol[2] = { 0., 0. };
 
-  RealT x_sol[2] = { 0., 0. };
+    // derivatives of the Jacobian wrt (xi,eta)
+    RealT djde_11 = 0.;
+    RealT djde_x_12 = 0.25 * ( xA[0] - xA[1] + xA[2] - xA[3] );
+    RealT djde_y_12 = 0.25 * ( yA[0] - yA[1] + yA[2] - yA[3] );
+    RealT djde_z_12 = 0.25 * ( zA[0] - zA[1] + zA[2] - zA[3] );
+    RealT djde_22 = 0.;
 
-  // derivatives of the Jacobian wrt (xi,eta)
-  RealT djde_11 = 0.;
-  RealT djde_x_12 = 0.25 * ( xA[0] - xA[1] + xA[2] - xA[3] );
-  RealT djde_y_12 = 0.25 * ( yA[0] - yA[1] + yA[2] - yA[3] );
-  RealT djde_z_12 = 0.25 * ( zA[0] - zA[1] + zA[2] - zA[3] );
-  RealT djde_22 = 0.;
+    // loop over newton iterations
+    for ( int k = 0; k < kmax; ++k ) {
+      // evaluate Jacobian
+      RealT j_x_1 = 0.25 * ( xA[0] * ( 1. + x_sol[1] ) - xA[1] * ( 1. + x_sol[1] ) - xA[2] * ( 1. - x_sol[1] ) +
+                             xA[3] * ( 1. - x_sol[1] ) );
 
-  // loop over newton iterations
-  for ( int k = 0; k < kmax; ++k ) {
-    // evaluate Jacobian
-    RealT j_x_1 = 0.25 * ( xA[0] * ( 1. + x_sol[1] ) - xA[1] * ( 1. + x_sol[1] ) - xA[2] * ( 1. - x_sol[1] ) +
-                           xA[3] * ( 1. - x_sol[1] ) );
+      RealT j_y_1 = 0.25 * ( yA[0] * ( 1. + x_sol[1] ) - yA[1] * ( 1. + x_sol[1] ) - yA[2] * ( 1. - x_sol[1] ) +
+                             yA[3] * ( 1. - x_sol[1] ) );
 
-    RealT j_y_1 = 0.25 * ( yA[0] * ( 1. + x_sol[1] ) - yA[1] * ( 1. + x_sol[1] ) - yA[2] * ( 1. - x_sol[1] ) +
-                           yA[3] * ( 1. - x_sol[1] ) );
+      RealT j_z_1 = 0.25 * ( zA[0] * ( 1. + x_sol[1] ) - zA[1] * ( 1. + x_sol[1] ) - zA[2] * ( 1. - x_sol[1] ) +
+                             zA[3] * ( 1. - x_sol[1] ) );
 
-    RealT j_z_1 = 0.25 * ( zA[0] * ( 1. + x_sol[1] ) - zA[1] * ( 1. + x_sol[1] ) - zA[2] * ( 1. - x_sol[1] ) +
-                           zA[3] * ( 1. - x_sol[1] ) );
+      RealT j_x_2 = 0.25 * ( xA[0] * ( 1. + x_sol[0] ) + xA[1] * ( 1. - x_sol[0] ) - xA[2] * ( 1. - x_sol[0] ) -
+                             xA[3] * ( 1. + x_sol[0] ) );
 
-    RealT j_x_2 = 0.25 * ( xA[0] * ( 1. + x_sol[0] ) + xA[1] * ( 1. - x_sol[0] ) - xA[2] * ( 1. - x_sol[0] ) -
-                           xA[3] * ( 1. + x_sol[0] ) );
+      RealT j_y_2 = 0.25 * ( yA[0] * ( 1. + x_sol[0] ) + yA[1] * ( 1. - x_sol[0] ) - yA[2] * ( 1. - x_sol[0] ) -
+                             yA[3] * ( 1. + x_sol[0] ) );
 
-    RealT j_y_2 = 0.25 * ( yA[0] * ( 1. + x_sol[0] ) + yA[1] * ( 1. - x_sol[0] ) - yA[2] * ( 1. - x_sol[0] ) -
-                           yA[3] * ( 1. + x_sol[0] ) );
+      RealT j_z_2 = 0.25 * ( zA[0] * ( 1. + x_sol[0] ) + zA[1] * ( 1. - x_sol[0] ) - zA[2] * ( 1. - x_sol[0] ) -
+                             zA[3] * ( 1. + x_sol[0] ) );
 
-    RealT j_z_2 = 0.25 * ( zA[0] * ( 1. + x_sol[0] ) + zA[1] * ( 1. - x_sol[0] ) - zA[2] * ( 1. - x_sol[0] ) -
-                           zA[3] * ( 1. + x_sol[0] ) );
+      // evaluate the residual
+      RealT f_x =
+          x[0] -
+          0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * xA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * xA[1] +
+                   ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * xA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * xA[3] );
 
-    // evaluate the residual
-    RealT f_x =
-        x[0] - 0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * xA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * xA[1] +
-                        ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * xA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * xA[3] );
+      RealT f_y =
+          x[1] -
+          0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * yA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * yA[1] +
+                   ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * yA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * yA[3] );
 
-    RealT f_y =
-        x[1] - 0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * yA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * yA[1] +
-                        ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * yA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * yA[3] );
+      RealT f_z =
+          x[2] -
+          0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * zA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * zA[1] +
+                   ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * zA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * zA[3] );
 
-    RealT f_z =
-        x[2] - 0.25 * ( ( 1. + x_sol[0] ) * ( 1. + x_sol[1] ) * zA[0] + ( 1. - x_sol[0] ) * ( 1. + x_sol[1] ) * zA[1] +
-                        ( 1. - x_sol[0] ) * ( 1. - x_sol[1] ) * zA[2] + ( 1. + x_sol[0] ) * ( 1. - x_sol[1] ) * zA[3] );
+      // compute J' * J
+      RealT JTJ_11 = j_x_1 * j_x_1 + j_y_1 * j_y_1 + j_z_1 * j_z_1;
+      RealT JTJ_12 = j_x_1 * j_x_2 + j_y_1 * j_y_2 + j_z_1 * j_z_2;
+      // RealT JTJ_21 = JTJ_12;
+      RealT JTJ_22 = j_x_2 * j_x_2 + j_y_2 * j_y_2 + j_z_2 * j_z_2;
+      ;
 
-    // compute J' * J
-    RealT JTJ_11 = j_x_1 * j_x_1 + j_y_1 * j_y_1 + j_z_1 * j_z_1;
-    RealT JTJ_12 = j_x_1 * j_x_2 + j_y_1 * j_y_2 + j_z_1 * j_z_2;
-    // RealT JTJ_21 = JTJ_12;
-    RealT JTJ_22 = j_x_2 * j_x_2 + j_y_2 * j_y_2 + j_z_2 * j_z_2;
-    ;
+      // compute J' * F
+      RealT JTF_1 = j_x_1 * f_x + j_y_1 * f_y + j_z_1 * f_z;
+      RealT JTF_2 = j_x_2 * f_x + j_y_2 * f_y + j_z_2 * f_z;
 
-    // compute J' * F
-    RealT JTF_1 = j_x_1 * f_x + j_y_1 * f_y + j_z_1 * f_z;
-    RealT JTF_2 = j_x_2 * f_x + j_y_2 * f_y + j_z_2 * f_z;
+      // for first few steps don't do exact Newton.
+      RealT cm_11 = JTJ_11;  //- (djde_11 * f_x + djde_11 * f_y + djde_11 * f_z);
+      RealT cm_12 = JTJ_12;  //- (djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z);
+      RealT cm_21 = cm_12;
+      RealT cm_22 = JTJ_22;  //- (djde_22 * f_x + djde_22 * f_y + djde_22 * f_z);
 
-    // for first few steps don't do exact Newton.
-    RealT cm_11 = JTJ_11;  //- (djde_11 * f_x + djde_11 * f_y + djde_11 * f_z);
-    RealT cm_12 = JTJ_12;  //- (djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z);
-    RealT cm_21 = cm_12;
-    RealT cm_22 = JTJ_22;  //- (djde_22 * f_x + djde_22 * f_y + djde_22 * f_z);
-
-    // do exact Newton for steps beyond first few
-    if ( k > 2 )  // set to 2 per mortar method testing
-    {
-      cm_11 += -( djde_11 * f_x + djde_11 * f_y + djde_11 * f_z );
-      cm_12 += -( djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z );
-      cm_21 = cm_12;
-      cm_22 += -( djde_22 * f_x + djde_22 * f_y + djde_22 * f_z );
-    }
-
-    RealT detI = 1. / ( cm_11 * cm_22 - cm_12 * cm_21 );
-
-    RealT cmi_11 = cm_22 * detI;
-    RealT cmi_22 = cm_11 * detI;
-    RealT cmi_12 = -cm_12 * detI;
-    RealT cmi_21 = -cm_21 * detI;
-
-    RealT dxi_1 = cmi_11 * JTF_1 + cmi_12 * JTF_2;
-    RealT dxi_2 = cmi_21 * JTF_1 + cmi_22 * JTF_2;
-
-    x_sol[0] += dxi_1;
-    x_sol[1] += dxi_2;
-
-    RealT abs_dxi_1 = std::abs( dxi_1 );
-    RealT abs_dxi_2 = std::abs( dxi_2 );
-
-    if ( abs_dxi_1 <= xtol && abs_dxi_2 <= xtol ) {
-      convrg = true;
-      xi[0] = x_sol[0];
-      xi[1] = x_sol[1];
-
-      //       check to make sure point is inside isoparametric quad
-      bool in_quad = true;
-      if ( std::abs( xi[0] ) > 1. || std::abs( xi[1] ) > 1. ) {
-        if ( std::abs( xi[0] ) > 1. + 100 * xtol ||
-             std::abs( xi[1] ) > 1. + 100 * xtol )  // should have some tolerance dependent conv tol?
-        {
-          in_quad = false;
-        } else {
-          xi[0] = std::min( xi[0], 1. );
-          xi[1] = std::min( xi[1], 1. );
-          xi[0] = std::max( xi[0], -1. );
-          xi[1] = std::max( xi[1], -1. );
-        }
+      // do exact Newton for steps beyond first few
+      if ( k > 2 )  // set to 2 per mortar method testing
+      {
+        cm_11 += -( djde_11 * f_x + djde_11 * f_y + djde_11 * f_z );
+        cm_12 += -( djde_x_12 * f_x + djde_y_12 * f_y + djde_z_12 * f_z );
+        cm_21 = cm_12;
+        cm_22 += -( djde_22 * f_x + djde_22 * f_y + djde_22 * f_z );
       }
 
+      RealT detI = 1. / ( cm_11 * cm_22 - cm_12 * cm_21 );
+
+      RealT cmi_11 = cm_22 * detI;
+      RealT cmi_22 = cm_11 * detI;
+      RealT cmi_12 = -cm_12 * detI;
+      RealT cmi_21 = -cm_21 * detI;
+
+      RealT dxi_1 = cmi_11 * JTF_1 + cmi_12 * JTF_2;
+      RealT dxi_2 = cmi_21 * JTF_1 + cmi_22 * JTF_2;
+
+      x_sol[0] += dxi_1;
+      x_sol[1] += dxi_2;
+
+      RealT abs_dxi_1 = std::abs( dxi_1 );
+      RealT abs_dxi_2 = std::abs( dxi_2 );
+
+      if ( abs_dxi_1 <= xtol && abs_dxi_2 <= xtol ) {
+        convrg = true;
+        xi[0] = x_sol[0];
+        xi[1] = x_sol[1];
+
+        //       check to make sure point is inside isoparametric quad
+        bool in_quad = true;
+        if ( std::abs( xi[0] ) > 1. || std::abs( xi[1] ) > 1. ) {
+          if ( std::abs( xi[0] ) > 1. + 100 * xtol ||
+               std::abs( xi[1] ) > 1. + 100 * xtol )  // should have some tolerance dependent conv tol?
+          {
+            in_quad = false;
+          } else {
+            xi[0] = std::min( xi[0], 1. );
+            xi[1] = std::min( xi[1], 1. );
+            xi[0] = std::max( xi[0], -1. );
+            xi[1] = std::max( xi[1], -1. );
+          }
+        }
+
 #if !defined( TRIBOL_USE_ENZYME )
-      SLIC_WARNING_IF( !in_quad, "InvIso(): (xi,eta) coordinate does not lie inside isoparametric quad." );
+        SLIC_WARNING_IF( !in_quad, "InvIso(): (xi,eta) coordinate does not lie inside isoparametric quad." );
 #endif
 
-      return;
+        return;
+      }
     }
-  }
 
 #if !defined( TRIBOL_USE_ENZYME )
-  SLIC_ERROR_IF( !convrg, "InvIso: Newtons method did not converge." );
+    SLIC_ERROR_IF( !convrg, "InvIso: Newtons method did not converge." );
 #endif
 
-  return;
+    return;
+
+  } else if ( numNodes == 3 ) {
+    // use area (barycentric) coords to get xi, eta
+    RealT a[3] = { xA[1] - xA[0], yA[1] - yA[0], zA[1] - zA[0] };
+    RealT b[3] = { xA[2] - xA[0], yA[2] - yA[0], zA[2] - zA[0] };
+    RealT a_cr_b[3] = { a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0] };
+    RealT area = std::sqrt( a_cr_b[0] * a_cr_b[0] + a_cr_b[1] * a_cr_b[1] + a_cr_b[2] * a_cr_b[2] );
+    RealT c[3] = { x[0] - xA[0], x[1] - yA[0], x[2] - zA[0] };
+
+    RealT c_cr_b[3] = { c[1] * b[2] - c[2] * b[1], c[2] * b[0] - c[0] * b[2], c[0] * b[1] - c[1] * b[0] };
+    RealT xi_area = std::sqrt( c_cr_b[0] * c_cr_b[0] + c_cr_b[1] * c_cr_b[1] + c_cr_b[2] * c_cr_b[2] );
+    xi[0] = xi_area / area;
+
+    RealT a_cr_c[3] = { a[1] * c[2] - a[2] * c[1], a[2] * c[0] - a[0] * c[2], a[0] * c[1] - a[1] * c[0] };
+    RealT eta_area = std::sqrt( a_cr_c[0] * a_cr_c[0] + a_cr_c[1] * a_cr_c[1] + a_cr_c[2] * a_cr_c[2] );
+    xi[1] = eta_area / area;
+  } else {
+#if !defined( TRIBOL_USE_ENZYME )
+    SLIC_ERROR( "Invalid number of nodes: " << numNodes );
+#endif
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -551,8 +551,10 @@ bool CouplingScheme::isValidMethod()
 
   // check all methods for basic validity issues for non-null meshes
   if ( !this->m_nullMeshes ) {
-    if ( ( this->m_mesh1->getElementType() != LINEAR_EDGE && this->m_mesh1->getElementType() != LINEAR_QUAD ) ||
-         ( this->m_mesh2->getElementType() != LINEAR_EDGE && this->m_mesh2->getElementType() != LINEAR_QUAD ) ) {
+    if ( ( this->m_mesh1->getElementType() != LINEAR_EDGE && this->m_mesh1->getElementType() != LINEAR_QUAD &&
+           this->m_mesh1->getElementType() != LINEAR_TRIANGLE ) ||
+         ( this->m_mesh2->getElementType() != LINEAR_EDGE && this->m_mesh2->getElementType() != LINEAR_QUAD &&
+           this->m_mesh2->getElementType() != LINEAR_TRIANGLE ) ) {
       this->m_couplingSchemeErrors.cs_method_error = INVALID_ELEMENT_TYPE;
       return false;
     }

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1149,9 +1149,9 @@ bool CouplingScheme::init()
     // compute the face data
     // different element normals for enzyme + mortar (matching Puso and Laursen)
     if ( this->isEnzymeEnabled() && this->m_contactMethod == SINGLE_MORTAR ) {
-      this->m_mesh1->computeFaceData( this->m_exec_mode, QuadCentroidNormal() );
+      this->m_mesh1->computeFaceData( this->m_exec_mode, ElementCentroidNormal() );
       if ( this->m_mesh_id2 != this->m_mesh_id1 ) {
-        this->m_mesh2->computeFaceData( this->m_exec_mode, QuadCentroidNormal() );
+        this->m_mesh2->computeFaceData( this->m_exec_mode, ElementCentroidNormal() );
       }
     } else {
       this->m_mesh1->computeFaceData( this->m_exec_mode, PalletAvgNormal() );

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -461,7 +461,7 @@ bool MeshData::computeFaceData( ExecutionMode exec_mode, ElemNormalMethod elem_n
 }  // end MeshData::computeFaceData()
 
 template bool MeshData::computeFaceData<PalletAvgNormal>( ExecutionMode, PalletAvgNormal );
-template bool MeshData::computeFaceData<QuadCentroidNormal>( ExecutionMode, QuadCentroidNormal );
+template bool MeshData::computeFaceData<ElementCentroidNormal>( ExecutionMode, ElementCentroidNormal );
 
 //------------------------------------------------------------------------------
 RealT MeshData::computeEdgeLength( int faceId )

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -741,8 +741,6 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
       blockJ( 2, 2 ) = DeviceArray2D<RealT>( n_multipliers, n_multipliers );
       blockJ( 2, 2 ).fill( 0.0 );
 
-      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2 );
-
       // This function also computes the residual contributions
       ComputeMortarJacobianEnzyme( x1, n1, p1, f1, blockJ( 0, 0 ).data(), blockJ( 0, 1 ).data(),
                                    blockJ_n( 0, 0 ).data(), blockJ( 0, 2 ).data(), g1, blockJ( 2, 0 ).data(),

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -86,11 +86,20 @@ void ComputeMortarWeights( SurfaceContactElem& elem )
         RealT xi[2] = { 0., 0. };
 
         InvIso( xp, x1, y1, z1, elem.numFaceVert, xi );
-        LinIsoQuadShapeFunc( xi[0], xi[1], a, phiMortarA );
+        if ( elem.numFaceVert == 4 ) {
+          LinIsoQuadShapeFunc( xi[0], xi[1], a, phiMortarA );
+        } else if ( elem.numFaceVert == 3 ) {
+          LinIsoTriShapeFunc( xi[0], xi[1], a, phiMortarA );
+        }
 
         InvIso( xp, x2, y2, z2, elem.numFaceVert, xi );
-        LinIsoQuadShapeFunc( xi[0], xi[1], a, phiNonmortarA );
-        LinIsoQuadShapeFunc( xi[0], xi[1], b, phiNonmortarB );
+        if ( elem.numFaceVert == 4 ) {
+          LinIsoQuadShapeFunc( xi[0], xi[1], a, phiNonmortarA );
+          LinIsoQuadShapeFunc( xi[0], xi[1], b, phiNonmortarB );
+        } else if ( elem.numFaceVert == 3 ) {
+          LinIsoTriShapeFunc( xi[0], xi[1], a, phiNonmortarA );
+          LinIsoTriShapeFunc( xi[0], xi[1], b, phiNonmortarB );
+        }
 
         SLIC_ERROR_IF( nonmortarNonmortarId > elem.numWts || mortarNonmortarId > elem.numWts,
                        "ComputeMortarWts: integer ids for weights exceed elem.numWts" );
@@ -989,12 +998,18 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
       // NOTE: Nonstandard node numbering with InvIso and LinIsoQuadShapeFunc
       for ( int k{ 0 }; k < size1; ++k ) {
         RealT phiA;
-        // NOTE: this limits this routine to quads
-        LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
+        if ( elem.numFaceVert == 4 ) {
+          LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
+        } else if ( elem.numFaceVert == 3 ) {
+          LinIsoTriShapeFunc( xi1[0], xi1[1], k, phiA );
+        }
         for ( int l{ 0 }; l < size1; ++l ) {
           RealT phiB;
-          // NOTE: this limits this routine to quads
-          LinIsoQuadShapeFunc( xi1[0], xi1[1], l, phiB );
+          if ( elem.numFaceVert == 4 ) {
+            LinIsoQuadShapeFunc( xi1[0], xi1[1], l, phiB );
+          } else if ( elem.numFaceVert == 3 ) {
+            LinIsoTriShapeFunc( xi1[0], xi1[1], l, phiB );
+          }
           mortar_mat1[k * size1 + l] += phiA * phiB * quad_wt;
         }
       }
@@ -1002,12 +1017,18 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
       // 5. Evaluate mortar matrix (nonmortar/mortar contribs)
       for ( int k{ 0 }; k < size1; ++k ) {
         RealT phiA;
-        // NOTE: this limits this routine to quads
-        LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
+        if ( elem.numFaceVert == 4 ) {
+          LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
+        } else if ( elem.numFaceVert == 3 ) {
+          LinIsoTriShapeFunc( xi1[0], xi1[1], k, phiA );
+        }
         for ( int l{ 0 }; l < size2; ++l ) {
           RealT phiB;
-          // NOTE: this limits this routine to quads
-          LinIsoQuadShapeFunc( xi2[0], xi2[1], l, phiB );
+          if ( elem.numFaceVert == 4 ) {
+            LinIsoQuadShapeFunc( xi2[0], xi2[1], l, phiB );
+          } else if ( elem.numFaceVert == 3 ) {
+            LinIsoTriShapeFunc( xi2[0], xi2[1], l, phiB );
+          }
           mortar_mat2[k * size2 + l] += phiA * phiB * quad_wt;
         }
       }

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -715,31 +715,33 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
     if ( lm_opts.eval_mode == ImplicitEvalMode::MORTAR_RESIDUAL_JACOBIAN ||
          lm_opts.eval_mode == ImplicitEvalMode::MORTAR_JACOBIAN ) {
       StackArray<DeviceArray2D<RealT>, 9> blockJ_n( 3 );
-      constexpr int n_disp = 12;
+      int n_disp[2] = { size1 * 3, size2 * 3 };
       for ( int i{ 0 }; i < 2; ++i ) {
-        blockJ_n( i, 0 ) = DeviceArray2D<RealT>( n_disp, n_disp );
+        blockJ_n( i, 0 ) = DeviceArray2D<RealT>( n_disp[0], n_disp[0] );
         blockJ_n( i, 0 ).fill( 0.0 );
       }
-      constexpr int n_multipliers = 4;
-      blockJ_n( 2, 0 ) = DeviceArray2D<RealT>( n_multipliers, n_disp );
+      int n_multipliers = size1;
+      blockJ_n( 2, 0 ) = DeviceArray2D<RealT>( n_multipliers, n_disp[0] );
       blockJ_n( 2, 0 ).fill( 0.0 );
 
       StackArray<DeviceArray2D<RealT>, 9> blockJ( 3 );
       for ( int i{}; i < 2; ++i ) {
         for ( int j{}; j < 2; ++j ) {
-          blockJ( i, j ) = DeviceArray2D<RealT>( n_disp, n_disp );
+          blockJ( i, j ) = DeviceArray2D<RealT>( n_disp[i], n_disp[j] );
           blockJ( i, j ).fill( 0.0 );
         }
       }
       for ( int i{}; i < 2; ++i ) {
-        blockJ( i, 2 ) = DeviceArray2D<RealT>( n_disp, n_multipliers );
+        blockJ( i, 2 ) = DeviceArray2D<RealT>( n_disp[i], n_multipliers );
         blockJ( i, 2 ).fill( 0.0 );
         // transpose
-        blockJ( 2, i ) = DeviceArray2D<RealT>( n_multipliers, n_disp );
+        blockJ( 2, i ) = DeviceArray2D<RealT>( n_multipliers, n_disp[i] );
         blockJ( 2, i ).fill( 0.0 );
       }
       blockJ( 2, 2 ) = DeviceArray2D<RealT>( n_multipliers, n_multipliers );
       blockJ( 2, 2 ).fill( 0.0 );
+
+      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2 );
 
       // This function also computes the residual contributions
       ComputeMortarJacobianEnzyme( x1, n1, p1, f1, blockJ( 0, 0 ).data(), blockJ( 0, 1 ).data(),
@@ -891,9 +893,9 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
   // create a local basis; e1 is a unit vector aligned with the first edge in element 1
   // clang-format off
    RealT e1[3] = {
-      x1t[1] - x1t[0],
-      x1t[5] - x1t[4],
-      x1t[9] - x1t[8]
+      x1t[0*size1 + 1] - x1t[0*size1 + 0],
+      x1t[1*size1 + 1] - x1t[1*size1 + 0],
+      x1t[2*size1 + 1] - x1t[2*size1 + 0]
    };
   // clang-format on
   RealT e1_mag = std::sqrt( e1[0] * e1[0] + e1[1] * e1[1] + e1[2] * e1[2] );

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -835,23 +835,29 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
   }
 
   // get vector n (normal of elem1) = de1 x de2
-  // NOTE: this limits this routine to quads
   // clang-format off
-   RealT de1[3] = {
-      -0.25*x1[0] + 0.25*x1[1] + 0.25*x1[2] - 0.25*x1[3],
-      -0.25*x1[4] + 0.25*x1[5] + 0.25*x1[6] - 0.25*x1[7],
-      -0.25*x1[8] + 0.25*x1[9] + 0.25*x1[10] - 0.25*x1[11]
-   };
-   RealT de2[3] = {
-      -0.25*x1[0] - 0.25*x1[1] + 0.25*x1[2] + 0.25*x1[3],
-      -0.25*x1[4] - 0.25*x1[5] + 0.25*x1[6] + 0.25*x1[7],
-      -0.25*x1[8] - 0.25*x1[9] + 0.25*x1[10] + 0.25*x1[11]
-   };
-   RealT n[3] = {
-      de1[1]*de2[2] - de1[2]*de2[1],
-      de1[2]*de2[0] - de1[0]*de2[2],
-      de1[0]*de2[1] - de1[1]*de2[0]
-   };
+  RealT de1[3] = { 0.0, 0.0, 0.0 };
+  RealT de2[3] = { 0.0, 0.0, 0.0 };
+  if ( size1 == 4 ) {
+    de1[0] = -0.25*x1[0] + 0.25*x1[1] + 0.25*x1[2] - 0.25*x1[3];
+    de1[1] = -0.25*x1[4] + 0.25*x1[5] + 0.25*x1[6] - 0.25*x1[7];
+    de1[2] = -0.25*x1[8] + 0.25*x1[9] + 0.25*x1[10] - 0.25*x1[11];
+    de2[0] = -0.25*x1[0] - 0.25*x1[1] + 0.25*x1[2] + 0.25*x1[3];
+    de2[1] = -0.25*x1[4] - 0.25*x1[5] + 0.25*x1[6] + 0.25*x1[7];
+    de2[2] = -0.25*x1[8] - 0.25*x1[9] + 0.25*x1[10] + 0.25*x1[11];
+  } else if ( size1 == 3 ) {
+    de1[0] = x1[1] - x1[0];
+    de1[1] = x1[4] - x1[3];
+    de1[2] = x1[7] - x1[6];
+    de2[0] = x1[2] - x1[0];
+    de2[1] = x1[5] - x1[3];
+    de2[2] = x1[8] - x1[6];
+  }
+  RealT n[3] = {
+    de1[1]*de2[2] - de1[2]*de2[1],
+    de1[2]*de2[0] - de1[0]*de2[2],
+    de1[0]*de2[1] - de1[1]*de2[0]
+  };
   // clang-format on
   RealT n_mag = std::sqrt( n[0] * n[0] + n[1] * n[1] + n[2] * n[2] );
   for ( int d{ 0 }; d < 3; ++d ) {
@@ -997,17 +1003,17 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
       // 4. Evaluate mortar matrix (nonmortar/nonmortar contribs)
       // NOTE: Nonstandard node numbering with InvIso and LinIsoQuadShapeFunc
       for ( int k{ 0 }; k < size1; ++k ) {
-        RealT phiA;
-        if ( elem.numFaceVert == 4 ) {
+        RealT phiA = 0.0;
+        if ( size1 == 4 ) {
           LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
-        } else if ( elem.numFaceVert == 3 ) {
+        } else if ( size1 == 3 ) {
           LinIsoTriShapeFunc( xi1[0], xi1[1], k, phiA );
         }
         for ( int l{ 0 }; l < size1; ++l ) {
-          RealT phiB;
-          if ( elem.numFaceVert == 4 ) {
+          RealT phiB = 0.0;
+          if ( size1 == 4 ) {
             LinIsoQuadShapeFunc( xi1[0], xi1[1], l, phiB );
-          } else if ( elem.numFaceVert == 3 ) {
+          } else if ( size1 == 3 ) {
             LinIsoTriShapeFunc( xi1[0], xi1[1], l, phiB );
           }
           mortar_mat1[k * size1 + l] += phiA * phiB * quad_wt;
@@ -1016,17 +1022,17 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
 
       // 5. Evaluate mortar matrix (nonmortar/mortar contribs)
       for ( int k{ 0 }; k < size1; ++k ) {
-        RealT phiA;
-        if ( elem.numFaceVert == 4 ) {
+        RealT phiA = 0.0;
+        if ( size1 == 4 ) {
           LinIsoQuadShapeFunc( xi1[0], xi1[1], k, phiA );
-        } else if ( elem.numFaceVert == 3 ) {
+        } else if ( size1 == 3 ) {
           LinIsoTriShapeFunc( xi1[0], xi1[1], k, phiA );
         }
         for ( int l{ 0 }; l < size2; ++l ) {
-          RealT phiB;
-          if ( elem.numFaceVert == 4 ) {
+          RealT phiB = 0.0;
+          if ( size2 == 4 ) {
             LinIsoQuadShapeFunc( xi2[0], xi2[1], l, phiB );
-          } else if ( elem.numFaceVert == 3 ) {
+          } else if ( size2 == 3 ) {
             LinIsoTriShapeFunc( xi2[0], xi2[1], l, phiB );
           }
           mortar_mat2[k * size2 + l] += phiA * phiB * quad_wt;


### PR DESCRIPTION
This PR adds support for tet meshes in the mortar method in Tribol.

There are tests to verify the InvIso and the basis function computations match, as well as tests on Enzyme derivatives, and a patch test using the MFEM interface (both the example and test are updated).