### PR TITLE
Tangential Viscous Damping

### DIFF
--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -594,6 +594,194 @@ TEST_F( CommonPlaneTest, common_plane_2d_interpen_check )
   compareGaps( couplingScheme, gap, 1.E-8, "kinematic_penetration" );
 }
 
+TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
+{
+  // this test has two edges in separation so there should be no contribution
+  // from the kinematic constraint enforcement, only the velocity based viscous
+  // tangential term
+  constexpr int numVerts = 2;
+
+  RealT x1[numVerts];
+  RealT y1[numVerts];
+  RealT x2[numVerts];
+  RealT y2[numVerts];
+
+  x1[0] = 1.0;
+  x1[1] = 0.0;
+  y1[0] = 0.0;
+  y1[1] = 0.0;
+
+  x2[0] = 0.0;
+  x2[1] = 1.0; 
+  y2[0] = 0.1; 
+  y2[1] = 0.1; 
+
+  tribol::IndexT conn1[numVerts] = { 0, 1 };
+  tribol::IndexT conn2[numVerts] = { 0, 1 };
+
+  tribol::registerMesh( 0, 1, numVerts, &conn1[0], (int)( tribol::LINEAR_EDGE ), &x1[0], &y1[0], nullptr,
+                        tribol::MemorySpace::Host );
+  tribol::registerMesh( 1, 1, numVerts, &conn2[0], (int)( tribol::LINEAR_EDGE ), &x2[0], &y2[0], nullptr,
+                        tribol::MemorySpace::Host );
+
+  RealT fx1[numVerts] = { 0., 0. };
+  RealT fy1[numVerts] = { 0., 0. };
+  RealT fx2[numVerts] = { 0., 0. };
+  RealT fy2[numVerts] = { 0., 0. };
+
+  // set nodal velocities in <1,1> and <-1,-1> directions
+  RealT vx1[numVerts] = { 1., 1. };
+  RealT vy1[numVerts] = { 1., 1. };
+  RealT vx2[numVerts] = { -1., -1. };
+  RealT vy2[numVerts] = { -1., -1. };
+
+  tribol::registerNodalResponse( 0, &fx1[0], &fy1[0], nullptr );
+  tribol::registerNodalResponse( 1, &fx2[0], &fy2[0], nullptr );
+
+  tribol::registerNodalVelocities( 0, &vx1[0], &vy1[0], nullptr );
+  tribol::registerNodalVelocities( 1, &vx2[0], &vy2[0], nullptr );
+
+  tribol::setKinematicConstantPenalty( 0, 1. );
+  tribol::setKinematicConstantPenalty( 1, 1. );
+
+  tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::COMMON_PLANE,
+                                  tribol::VISCOUS_TANGENTIAL, tribol::PENALTY, tribol::BINNING_GRID,
+                                  tribol::ExecutionMode::Sequential );
+
+  tribol::setPenaltyOptions( 0, tribol::KINEMATIC, tribol::KINEMATIC_CONSTANT );
+  tribol::setContactAreaFrac( 0, 1.e-12 );
+
+  RealT dt = 1.;
+  int update_err = tribol::update( 1, 1., dt );
+
+  EXPECT_EQ( update_err, 0 );
+
+  tribol::CouplingSchemeManager& couplingSchemeManager = tribol::CouplingSchemeManager::getInstance();
+
+  tribol::CouplingScheme* couplingScheme = &couplingSchemeManager.at( 0 );
+
+  EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
+
+  // check forces
+  for ( int i=0; i<numVerts; ++i ) { 
+    EXPECT_NEAR( fx1[i], -1., 1.e-10 );
+    EXPECT_NEAR( fy1[i], 0., 1.e-10 );
+    EXPECT_NEAR( fx2[i], 1., 1.e-10 );
+    EXPECT_NEAR( fy2[i], 0., 1.e-10 );
+  }
+}
+
+TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
+{
+  // this test has two faces in separation so there should be no contribution
+  // from the kinematic constraint enforcement, only the velocity based viscous
+  // tangential term
+  constexpr int numVerts = 4;
+
+  RealT x1[numVerts];
+  RealT y1[numVerts];
+  RealT z1[numVerts];
+  RealT x2[numVerts];
+  RealT y2[numVerts];
+  RealT z2[numVerts];
+
+  // first face's coords
+  x1[0] = 0.0;
+  y1[0] = 0.0;
+  z1[0] = 0.0;
+
+  x1[1] = 1.0;
+  y1[1] = 0.0;
+  z1[1] = 0.0;
+
+  x1[2] = 1.0;
+  y1[2] = 1.0;
+  z1[2] = 0.0;
+
+  x1[3] = 0.0;
+  y1[3] = 1.0;
+  z1[3] = 0.0;
+
+  // second faces coords
+  x2[0] = 0.0;
+  y2[0] = 0.0;
+  z2[0] = 0.1;
+
+  x2[1] = 0.0;
+  y2[1] = 1.0;
+  z2[1] = 0.1;
+
+  x2[2] = 1.0;
+  y2[2] = 1.0;
+  z2[2] = 0.1;
+
+  x2[3] = 1.0;
+  y2[3] = 0.0;
+  z2[3] = 0.1;
+
+  tribol::IndexT conn1[numVerts] = { 0, 1, 2, 3 };
+  tribol::IndexT conn2[numVerts] = { 0, 1, 2, 3 };
+
+  tribol::registerMesh( 0, 1, numVerts, &conn1[0], (int)( tribol::LINEAR_QUAD ), &x1[0], &y1[0], &z1[0],
+                        tribol::MemorySpace::Host );
+  tribol::registerMesh( 1, 1, numVerts, &conn2[0], (int)( tribol::LINEAR_QUAD ), &x2[0], &y2[0], &z2[0],
+                        tribol::MemorySpace::Host );
+
+  RealT fx1[numVerts] = { 0., 0., 0., 0. };
+  RealT fy1[numVerts] = { 0., 0., 0., 0. };
+  RealT fz1[numVerts] = { 0., 0., 0., 0. };
+  
+  RealT fx2[numVerts] = { 0., 0., 0., 0. };
+  RealT fy2[numVerts] = { 0., 0., 0., 0. };
+  RealT fz2[numVerts] = { 0., 0., 0., 0. };
+
+  // set nodal velocities in <2,2,2> and <-2,-2,-2> directions
+  RealT vx1[numVerts] = { 2., 2., 2., 2. };
+  RealT vy1[numVerts] = { 2., 2., 2., 2. };
+  RealT vz1[numVerts] = { 2., 2., 2., 2. };
+  RealT vx2[numVerts] = { -2., -2., -2., -2. };
+  RealT vy2[numVerts] = { -2., -2., -2., -2. };
+  RealT vz2[numVerts] = { 2., 2., 2., 2. };
+
+  tribol::registerNodalResponse( 0, &fx1[0], &fy1[0], &fz1[0] );
+  tribol::registerNodalResponse( 1, &fx2[0], &fy2[0], &fz2[0] );
+
+  tribol::registerNodalVelocities( 0, &vx1[0], &vy1[0], &vz1[0] );
+  tribol::registerNodalVelocities( 1, &vx2[0], &vy2[0], &vz2[0] );
+
+  tribol::setKinematicConstantPenalty( 0, 1. );
+  tribol::setKinematicConstantPenalty( 1, 1. );
+
+  tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::COMMON_PLANE,
+                                  tribol::VISCOUS_TANGENTIAL, tribol::PENALTY, tribol::BINNING_GRID,
+                                  tribol::ExecutionMode::Sequential );
+
+  tribol::setPenaltyOptions( 0, tribol::KINEMATIC, tribol::KINEMATIC_CONSTANT );
+  tribol::setContactAreaFrac( 0, 1.e-12 );
+
+  RealT dt = 1.;
+  int update_err = tribol::update( 1, 1., dt );
+
+  EXPECT_EQ( update_err, 0 );
+
+  tribol::CouplingSchemeManager& couplingSchemeManager = tribol::CouplingSchemeManager::getInstance();
+
+  tribol::CouplingScheme* couplingScheme = &couplingSchemeManager.at( 0 );
+
+  EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
+
+  // check forces
+  for ( int i=0; i<numVerts; ++i ) {
+    EXPECT_NEAR( fx1[i], -1., 1.e-10 );
+    EXPECT_NEAR( fy1[i], -1., 1.e-10 );
+    EXPECT_NEAR( fz1[i], 0., 1.e-10 );
+
+    EXPECT_NEAR( fx2[i], 1., 1.e-10 );
+    EXPECT_NEAR( fy2[i], 1., 1.e-10 );
+    EXPECT_NEAR( fz2[i], 0., 1.e-10 );
+  }
+}
+
 int main( int argc, char* argv[] )
 {
   int result = 0;

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -596,9 +596,8 @@ TEST_F( CommonPlaneTest, common_plane_2d_interpen_check )
 
 TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 {
-  // this test has two edges with zero gap so there should be no contribution
-  // from the kinematic constraint enforcement, only the velocity based viscous
-  // tangential term
+  // This test has two edges with initial full interpen and tangential velocity,
+  // which will trigger a viscous force term
   constexpr int numVerts = 2;
 
   RealT x1[numVerts];
@@ -667,7 +666,9 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 
   EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
 
-  // check forces
+  // check forces. The in-plane tangential force is the velocity distributed evenly to the
+  // two nodes, while the normal force corresponds to two springs in parallel with the
+  // specified constant penalty stiffness, then divided amongst the edge nodes
   RealT force_y = 0.5 * gap / numVerts;
   for ( int i = 0; i < numVerts; ++i ) {
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
@@ -679,9 +680,8 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 
 TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
 {
-  // this test has two faces with zero gap so there should be no contribution
-  // from the kinematic constraint enforcement, only the velocity based viscous
-  // tangential term
+  // this test has two faces with some initial full interpen and a tangential velocity
+  // that will trigger a viscous force term.
   constexpr int numVerts = 4;
 
   RealT x1[numVerts];
@@ -781,7 +781,9 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
 
   EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
 
-  // check forces
+  // check forces. The in plane force will be the relative velocity multiplied by the
+  // viscous coefficient then distributed amongst the nodes, while the normal force
+  // is the two springs in parallel times the gap and then distributed to the nodes.
   RealT force_z = 0.5 * gap / numVerts;
   for ( int i = 0; i < numVerts; ++i ) {
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -644,6 +644,10 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
   tribol::setKinematicConstantPenalty( 0, 1. );
   tribol::setKinematicConstantPenalty( 1, 1. );
 
+  RealT visc_coeff = 0.5;
+  tribol::registerRealElementField( 0, tribol::VISCOUS_DAMPING_COEFF, &visc_coeff );
+  tribol::registerRealElementField( 1, tribol::VISCOUS_DAMPING_COEFF, &visc_coeff );
+
   tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::COMMON_PLANE,
                                   tribol::VISCOUS_TANGENTIAL, tribol::PENALTY, tribol::BINNING_GRID,
                                   tribol::ExecutionMode::Sequential );
@@ -664,9 +668,9 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 
   // check forces
   for ( int i=0; i<numVerts; ++i ) { 
-    EXPECT_NEAR( fx1[i], -1., 1.e-10 );
+    EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fy1[i], 0., 1.e-10 );
-    EXPECT_NEAR( fx2[i], 1., 1.e-10 );
+    EXPECT_NEAR( fx2[i], .5, 1.e-10 );
     EXPECT_NEAR( fy2[i], 0., 1.e-10 );
   }
 }
@@ -752,6 +756,10 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
   tribol::setKinematicConstantPenalty( 0, 1. );
   tribol::setKinematicConstantPenalty( 1, 1. );
 
+  RealT visc_coeff = 0.5;
+  tribol::registerRealElementField( 0, tribol::VISCOUS_DAMPING_COEFF, &visc_coeff );
+  tribol::registerRealElementField( 1, tribol::VISCOUS_DAMPING_COEFF, &visc_coeff );
+
   tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::COMMON_PLANE,
                                   tribol::VISCOUS_TANGENTIAL, tribol::PENALTY, tribol::BINNING_GRID,
                                   tribol::ExecutionMode::Sequential );
@@ -772,12 +780,12 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
 
   // check forces
   for ( int i=0; i<numVerts; ++i ) {
-    EXPECT_NEAR( fx1[i], -1., 1.e-10 );
-    EXPECT_NEAR( fy1[i], -1., 1.e-10 );
+    EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
+    EXPECT_NEAR( fy1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fz1[i], 0., 1.e-10 );
 
-    EXPECT_NEAR( fx2[i], 1., 1.e-10 );
-    EXPECT_NEAR( fy2[i], 1., 1.e-10 );
+    EXPECT_NEAR( fx2[i], 0.5, 1.e-10 );
+    EXPECT_NEAR( fy2[i], 0.5, 1.e-10 );
     EXPECT_NEAR( fz2[i], 0., 1.e-10 );
   }
 }

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -596,7 +596,7 @@ TEST_F( CommonPlaneTest, common_plane_2d_interpen_check )
 
 TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 {
-  // this test has two edges in separation so there should be no contribution
+  // this test has two edges with zero gap so there should be no contribution
   // from the kinematic constraint enforcement, only the velocity based viscous
   // tangential term
   constexpr int numVerts = 2;
@@ -611,10 +611,11 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
   y1[0] = 0.0;
   y1[1] = 0.0;
 
+  RealT gap = 0.01;
   x2[0] = 0.0;
   x2[1] = 1.0; 
-  y2[0] = 0.1; 
-  y2[1] = 0.1; 
+  y2[0] = -gap; 
+  y2[1] = -gap; 
 
   tribol::IndexT conn1[numVerts] = { 0, 1 };
   tribol::IndexT conn2[numVerts] = { 0, 1 };
@@ -667,17 +668,18 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
   EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
 
   // check forces
+  RealT force_y = 0.5 * gap / numVerts;
   for ( int i=0; i<numVerts; ++i ) { 
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
-    EXPECT_NEAR( fy1[i], 0., 1.e-10 );
+    EXPECT_NEAR( fy1[i], -force_y, 1.e-10 );
     EXPECT_NEAR( fx2[i], .5, 1.e-10 );
-    EXPECT_NEAR( fy2[i], 0., 1.e-10 );
+    EXPECT_NEAR( fy2[i], force_y, 1.e-10 );
   }
 }
 
 TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
 {
-  // this test has two faces in separation so there should be no contribution
+  // this test has two faces with zero gap so there should be no contribution
   // from the kinematic constraint enforcement, only the velocity based viscous
   // tangential term
   constexpr int numVerts = 4;
@@ -707,21 +709,22 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
   z1[3] = 0.0;
 
   // second faces coords
+  RealT gap = 0.01;
   x2[0] = 0.0;
   y2[0] = 0.0;
-  z2[0] = 0.1;
+  z2[0] = -gap;
 
   x2[1] = 0.0;
   y2[1] = 1.0;
-  z2[1] = 0.1;
+  z2[1] = -gap;
 
   x2[2] = 1.0;
   y2[2] = 1.0;
-  z2[2] = 0.1;
+  z2[2] = -gap;
 
   x2[3] = 1.0;
   y2[3] = 0.0;
-  z2[3] = 0.1;
+  z2[3] = -gap;
 
   tribol::IndexT conn1[numVerts] = { 0, 1, 2, 3 };
   tribol::IndexT conn2[numVerts] = { 0, 1, 2, 3 };
@@ -779,14 +782,15 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
   EXPECT_EQ( 1, couplingScheme->getNumActivePairs() );
 
   // check forces
+  RealT force_z = 0.5 * gap / numVerts;
   for ( int i=0; i<numVerts; ++i ) {
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fy1[i], -.5, 1.e-10 );
-    EXPECT_NEAR( fz1[i], 0., 1.e-10 );
+    EXPECT_NEAR( fz1[i], -force_z, 1.e-10 );
 
     EXPECT_NEAR( fx2[i], 0.5, 1.e-10 );
     EXPECT_NEAR( fy2[i], 0.5, 1.e-10 );
-    EXPECT_NEAR( fz2[i], 0., 1.e-10 );
+    EXPECT_NEAR( fz2[i], force_z, 1.e-10 );
   }
 }
 

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -748,7 +748,7 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
   RealT vz1[numVerts] = { 2., 2., 2., 2. };
   RealT vx2[numVerts] = { -2., -2., -2., -2. };
   RealT vy2[numVerts] = { -2., -2., -2., -2. };
-  RealT vz2[numVerts] = { 2., 2., 2., 2. };
+  RealT vz2[numVerts] = { -2., -2., -2., -2. };
 
   tribol::registerNodalResponse( 0, &fx1[0], &fy1[0], &fz1[0] );
   tribol::registerNodalResponse( 1, &fx2[0], &fy2[0], &fz2[0] );

--- a/src/tests/tribol_common_plane_penalty.cpp
+++ b/src/tests/tribol_common_plane_penalty.cpp
@@ -613,9 +613,9 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 
   RealT gap = 0.01;
   x2[0] = 0.0;
-  x2[1] = 1.0; 
-  y2[0] = -gap; 
-  y2[1] = -gap; 
+  x2[1] = 1.0;
+  y2[0] = -gap;
+  y2[1] = -gap;
 
   tribol::IndexT conn1[numVerts] = { 0, 1 };
   tribol::IndexT conn2[numVerts] = { 0, 1 };
@@ -669,7 +669,7 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_2d )
 
   // check forces
   RealT force_y = 0.5 * gap / numVerts;
-  for ( int i=0; i<numVerts; ++i ) { 
+  for ( int i = 0; i < numVerts; ++i ) {
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fy1[i], -force_y, 1.e-10 );
     EXPECT_NEAR( fx2[i], .5, 1.e-10 );
@@ -737,7 +737,7 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
   RealT fx1[numVerts] = { 0., 0., 0., 0. };
   RealT fy1[numVerts] = { 0., 0., 0., 0. };
   RealT fz1[numVerts] = { 0., 0., 0., 0. };
-  
+
   RealT fx2[numVerts] = { 0., 0., 0., 0. };
   RealT fy2[numVerts] = { 0., 0., 0., 0. };
   RealT fz2[numVerts] = { 0., 0., 0., 0. };
@@ -783,7 +783,7 @@ TEST_F( CommonPlaneTest, common_plane_viscous_tangential_3d )
 
   // check forces
   RealT force_z = 0.5 * gap / numVerts;
-  for ( int i=0; i<numVerts; ++i ) {
+  for ( int i = 0; i < numVerts; ++i ) {
     EXPECT_NEAR( fx1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fy1[i], -.5, 1.e-10 );
     EXPECT_NEAR( fz1[i], -force_z, 1.e-10 );

--- a/src/tests/tribol_coupling_scheme.cpp
+++ b/src/tests/tribol_coupling_scheme.cpp
@@ -394,7 +394,7 @@ TEST_F( CouplingSchemeTest, mortar_coulomb )
   tribol::registerMortarPressures( 1, &pressures[0] );
 
   tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::SINGLE_MORTAR,
-                                  tribol::COULOMB, tribol::LAGRANGE_MULTIPLIER, tribol::BINNING_GRID,
+                                  tribol::FRICTION_COULOMB, tribol::LAGRANGE_MULTIPLIER, tribol::BINNING_GRID,
                                   tribol::ExecutionMode::Sequential );
 
   tribol::setLagrangeMultiplierOptions( 0, tribol::ImplicitEvalMode::MORTAR_RESIDUAL_JACOBIAN,
@@ -443,7 +443,7 @@ TEST_F( CouplingSchemeTest, common_plane_coulomb )
   tribol::setKinematicConstantPenalty( 1, penalty );
 
   tribol::registerCouplingScheme( 0, 0, 1, tribol::SURFACE_TO_SURFACE, tribol::NO_CASE, tribol::COMMON_PLANE,
-                                  tribol::COULOMB, tribol::PENALTY, tribol::BINNING_GRID,
+                                  tribol::FRICTION_COULOMB, tribol::PENALTY, tribol::BINNING_GRID,
                                   tribol::ExecutionMode::Sequential );
 
   tribol::setPenaltyOptions( 0, tribol::KINEMATIC, tribol::KINEMATIC_CONSTANT );

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -210,6 +210,7 @@ enum RealElementFields
   RATE_PERCENT_STIFFNESS,        ///! Percent rate penalty stiffness
   BULK_MODULUS,                  ///! Element bulk modulus
   YOUNGS_MODULUS,                ///! Element Young's modulus
+  VISCOUS_DAMPING_COEFF,         ///! Element/material viscous damping coefficient for tangential damping
   ELEMENT_THICKNESS,             ///! Element thickness in contact normal direction
   NUM_REAL_ELEMENT_FIELDS = ELEMENT_THICKNESS
 };

--- a/src/tribol/common/Parameters.hpp
+++ b/src/tribol/common/Parameters.hpp
@@ -134,7 +134,8 @@ enum ContactModel
 {
   NO_CONTACT,                      ///! No contact
   FRICTIONLESS,                    ///! Frictionless, normal contact only
-  COULOMB,                         ///! Coulomb friction model, not supported
+  VISCOUS_TANGENTIAL,              ///! Velocity based tangential damping (viscous) term added to contact force
+  FRICTION_COULOMB,                ///! Coulomb friction model, not supported
   ADHESION_SEPARATION_SCALAR_LAW,  ///! Scalar pressure law for the separation of adhered surfaces (Used with tied
                                    /// contact)
   NULL_MODEL,                      ///! Null model, for use with ContactMethod = MORTAR_WEIGHTS

--- a/src/tribol/interface/mfem_tribol.cpp
+++ b/src/tribol/interface/mfem_tribol.cpp
@@ -44,7 +44,7 @@ void registerMfemCouplingScheme( IndexT cs_id, int mesh_id_1, int mesh_id_2, con
     }
     // TODO add the following if they are implemented with Lagrange multipliers:
     //
-    // 1) contact_model == COULOMB
+    // 1) contact_model == FRICTION_COULOMB
     // 2) contact_case == TIED_NORMAL
     // 3) contact_case == TIED_FULL
     //

--- a/src/tribol/interface/mfem_tribol.cpp
+++ b/src/tribol/interface/mfem_tribol.cpp
@@ -100,6 +100,21 @@ void setMfemKinematicConstantPenalty( IndexT cs_id, RealT mesh1_penalty, RealT m
   cs->getMfemMeshData()->SetMesh2KinematicConstantPenalty( mesh2_penalty );
 }
 
+void setMfemViscousDampingCoeff( IndexT cs_id, RealT mesh1_coeff, RealT mesh2_coeff )
+{
+  auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
+  SLIC_ERROR_ROOT_IF(
+      !cs, axom::fmt::format( "Coupling scheme cs_id={0} does not exist. Call tribol::registerMfemCouplingScheme() "
+                              "to create a coupling scheme with this cs_id.",
+                              cs_id ) );
+  SLIC_ERROR_ROOT_IF(
+      !cs->hasMfemData(),
+      "Coupling scheme does not contain MFEM data. "
+      "Create the coupling scheme using registerMfemCouplingScheme() to set the viscous damping coefficient." );
+  cs->getMfemMeshData()->SetMesh1ViscousDampingCoeff( mesh1_coeff );
+  cs->getMfemMeshData()->SetMesh2ViscousDampingCoeff( mesh2_coeff );
+}
+
 void setMfemKinematicElementPenalty( IndexT cs_id, mfem::Coefficient& modulus_coefficient )
 {
   auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
@@ -413,6 +428,13 @@ void updateMfemParallelDecomposition()
           setRatePercentPenalty( mesh_ids[0], *mfem_data->GetMesh1RatePercentPenalty() );
           setRatePercentPenalty( mesh_ids[1], *mfem_data->GetMesh2RatePercentPenalty() );
         }
+      }
+      if ( cs.getContactModel() == VISCOUS_TANGENTIAL ) {
+        SLIC_ERROR_ROOT_IF(
+            !mfem_data->GetMesh1ViscousDampingCoeff() || !mfem_data->GetMesh2ViscousDampingCoeff(),
+            "Tangential viscous damping coefficients have not been set.  Call setMfemViscousDampingCoeff()." );
+        setViscousDampingCoeff( mesh_ids[0], *mfem_data->GetMesh1ViscousDampingCoeff() );
+        setViscousDampingCoeff( mesh_ids[1], *mfem_data->GetMesh2ViscousDampingCoeff() );
       }
     }
   }

--- a/src/tribol/interface/mfem_tribol.hpp
+++ b/src/tribol/interface/mfem_tribol.hpp
@@ -150,6 +150,17 @@ void setMfemRatePercentPenalty( IndexT cs_id, RealT mesh1_ratio, RealT mesh2_rat
 void setMfemKinematicPenaltyScale( IndexT cs_id, RealT mesh1_scale, RealT mesh2_scale );
 
 /**
+ * @brief Adds a tangential viscous damping coefficient to each mesh
+ *
+ * @pre Coupling scheme cs_id must be registered using registerMfemCouplingScheme()
+ *
+ * @param cs_id The ID of the coupling scheme with the MFEM mesh
+ * @param mesh1_coeff Tangential viscous damping coefficient for the first contact surface mesh
+ * @param mesh2_coeff Tangential viscous damping coefficient for the second contact surface mesh
+ */
+void setMfemViscousDampingCoeff( IndexT cs_id, RealT mesh1_coeff, RealT mesh2_coeff );
+
+/**
  * @brief Computes element thickness for the volume elements associated with the contact surface mesh.
  *
  * Element thickness is calculated at the origin of the isoparametric volume element in the direction given by the

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -130,6 +130,12 @@ void setRatePercentPenalty( IndexT mesh_id, RealT r_p )
 }  // end setRatePercentPenalty()
 
 //------------------------------------------------------------------------------
+void setViscousDampingCoeff( IndexT mesh_id, RealT coeff )
+{
+  registerRealElementField( mesh_id, VISCOUS_DAMPING_COEFF, &coeff );
+}
+
+//------------------------------------------------------------------------------
 void setAutoContactPenScale( IndexT cs_id, RealT scale )
 {
   auto cs = CouplingSchemeManager::getInstance().findData( cs_id );

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -739,6 +739,21 @@ void registerRealElementField( IndexT mesh_id, const RealElementFields field, co
 
       break;
     }
+    case VISCOUS_DAMPING_COEFF: {
+      if ( fieldVariable == nullptr ) {
+        if ( mesh->numberOfElements() > 0 ) {
+          SLIC_ERROR( "tribol::registerRealElementField(): null pointer to data for "
+                      << "'VISCOUS_DAMPING_COEFF' on mesh " << mesh_id << "." );
+          mesh->getElementData().m_is_viscous_damping_coeff_set = false;
+        } else {
+          mesh->getElementData().m_is_viscous_damping_coeff_set = true;
+        }
+      } else {
+        mesh->getElementData().m_viscous_damping_coeff = *fieldVariable;
+        mesh->getElementData().m_is_viscous_damping_coeff_set = true;
+      }
+      break;
+    }
     default: {
       SLIC_ERROR( "tribol::registerRealElementField(): the field argument "
                   << "on mesh " << mesh_id << " is not an accepted tribol real element field." );

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -87,6 +87,13 @@ void setKinematicElementPenalty( IndexT mesh_id, const RealT* material_modulus, 
 void setRateConstantPenalty( IndexT mesh_id, RealT r_k );
 
 /*!
+ * \brief Sets the tangential viscous damping coefficient
+ * \param [in] mesh_id mesh id for penalty stiffness
+ * \param [in] coeff viscous damping coefficient
+ */
+void setViscousDampingCoeff( IndexT mesh_id, RealT coeff );
+
+/*!
  * \brief Sets the percent rate penalty stiffness
  * \param [in] mesh_id mesh id for penalty stiffness
  * \param [in] r_p rate penalty as percent of kinematic penalty

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -455,7 +455,7 @@ void registerIntElementField( IndexT mesh_id, const IntElementFields field, int*
  * \param [in] contact_mode the type of contact, e.g. SURFACE_TO_SURFACE
  * \param [in] contact_case the specific case of contact application, e.g. auto
  * \param [in] contact_method the contact method, e.g. SINGLE_MORTAR
- * \param [in] contact_model the contact model, e.g. COULOMB
+ * \param [in] contact_model the contact model, e.g. FRICTION_COULOMB
  * \param [in] enforcement_method the enforcement method, e.g. PENALTY
  * \param [in] binning_method the binning method, e.g. BINNING_GRID
  * \param [in] given_exec_mode preferred execution mode for RAJA kernels

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -658,7 +658,8 @@ bool CouplingScheme::isValidModel()
     }
 
     case COMMON_PLANE: {
-      if ( this->m_contactModel != FRICTIONLESS && this->m_contactModel != NULL_MODEL && this->m_contactModel != VISCOUS_TANGENTIAL ) {
+      if ( this->m_contactModel != FRICTIONLESS && this->m_contactModel != NULL_MODEL &&
+           this->m_contactModel != VISCOUS_TANGENTIAL ) {
         this->m_couplingSchemeErrors.cs_model_error = NO_MODEL_IMPLEMENTATION_FOR_REGISTERED_METHOD;
         return false;
       }

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -658,7 +658,7 @@ bool CouplingScheme::isValidModel()
     }
 
     case COMMON_PLANE: {
-      if ( this->m_contactModel != FRICTIONLESS && this->m_contactModel != NULL_MODEL ) {
+      if ( this->m_contactModel != FRICTIONLESS && this->m_contactModel != NULL_MODEL && this->m_contactModel != VISCOUS_TANGENTIAL ) {
         this->m_couplingSchemeErrors.cs_model_error = NO_MODEL_IMPLEMENTATION_FOR_REGISTERED_METHOD;
         return false;
       }

--- a/src/tribol/mesh/CouplingScheme.hpp
+++ b/src/tribol/mesh/CouplingScheme.hpp
@@ -251,7 +251,7 @@ class CouplingScheme {
    * @param [in] contact_mode the type of contact, e.g. SURFACE_TO_SURFACE
    * @param [in] contact_case the specific case of contact application, e.g. auto
    * @param [in] contact_method the contact method, e.g. SINGLE_MORTAR
-   * @param [in] contact_model the contact model, e.g. COULOMB
+   * @param [in] contact_model the contact model, e.g. FRICTION_COULOMB
    * @param [in] enforcement_method the enforcement method, e.g. PENALTY
    * @param [in] binning_method the binning method, e.g. BINNING_GRID
    *

--- a/src/tribol/mesh/MeshData.hpp
+++ b/src/tribol/mesh/MeshData.hpp
@@ -55,10 +55,13 @@ struct MeshElemData {
   RealT m_rate_penalty_stiffness{ 0. };  ///< single scalar rate penalty stiffness for each mesh
   RealT m_rate_percent_stiffness{ 0. };  ///< rate penalty is percentage of gap penalty
 
+  RealT m_viscous_damping_coeff{ 0. };
+
   bool m_is_kinematic_constant_penalty_set{ false };  ///< True if single kinematic constant penalty is set
   bool m_is_kinematic_element_penalty_set{ false };   ///< True if the element-wise kinematic penalty is set
   bool m_is_rate_constant_penalty_set{ false };       ///< True if the constant rate penalty is set
   bool m_is_rate_percent_penalty_set{ false };        ///< True if the rate percent penalty is set
+  bool m_is_viscous_damping_coeff_set{ false };
 
   bool m_is_element_thickness_set{ false };  ///< True if element thickness is set
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -398,6 +398,8 @@ void MfemMeshData::ClearAllPenaltyData()
   kinematic_constant_penalty_2_.reset( nullptr );
   kinematic_penalty_scale_1_.reset( nullptr );
   kinematic_penalty_scale_2_.reset( nullptr );
+  viscous_damping_coeff_1_.reset( nullptr );
+  viscous_damping_coeff_2_.reset( nullptr );
   elem_thickness_.reset( nullptr );
   redecomp_elem_thickness_.reset( nullptr );
   tribol_elem_thickness_1_.reset( nullptr );

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -890,6 +890,34 @@ class MfemMeshData {
   const RealT* GetMesh2RatePercentPenalty() const { return rate_percent_ratio_2_.get(); }
 
   /**
+   * @brief Sets the tangential viscous damping coefficient on mesh 1
+   *
+   * @param coeff coefficient for viscous damping
+   */
+  void SetMesh1ViscousDampingCoeff( RealT coeff ) { viscous_damping_coeff_1_ = std::make_unique<RealT>( coeff ); }
+
+  /**
+   * @brief Sets the tangential viscous damping coefficient on mesh 2
+   *
+   * @param coeff coefficient for viscous damping
+   */
+  void SetMesh2ViscousDampingCoeff( RealT coeff ) { viscous_damping_coeff_2_ = std::make_unique<RealT>( coeff ); }
+
+  /**
+   * @brief Get the tangential viscous damping coefficient for the first registered Tribol mesh
+   *
+   * @return const RealT*
+   */
+  const RealT* GetMesh1ViscousDampingCoeff() const { return viscous_damping_coeff_1_.get(); }
+
+  /**
+   * @brief Get the tangential viscous damping coefficient for the second registered Tribol mesh
+   *
+   * @return const RealT*
+   */
+  const RealT* GetMesh2ViscousDampingCoeff() const { return viscous_damping_coeff_2_.get(); }
+
+  /**
    * @brief Get a pointer to the element thickness array for the first Tribol
    * registered mesh
    *
@@ -1266,6 +1294,16 @@ class MfemMeshData {
    * Tribol registered mesh
    */
   std::unique_ptr<RealT> rate_percent_ratio_2_;
+
+  /**
+   * @brief Tangential viscous damping coefficient for the first Tribol registered mesh
+   */
+  std::unique_ptr<RealT> viscous_damping_coeff_1_;
+
+  /**
+   * @brief Tangential viscous damping coefficient for the second Tribol registered mesh
+   */
+  std::unique_ptr<RealT> viscous_damping_coeff_2_;
 
   /**
    * @brief Stores element thicknesses for element-based penalty calculations on

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -419,4 +419,201 @@ int ApplyNormal<COMMON_PLANE, PENALTY>( CouplingScheme* cs )
 
 }  // end ApplyNormal<COMMON_PLANE, PENALTY>()
 
+//------------------------------------------------------------------------------
+template <>
+int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* cs ) {
+
+  ///////////////////////////////
+  // loop over interface pairs //
+  ///////////////////////////////
+  ArrayT<int> err_data( { 0 }, cs->getAllocatorId() );
+  ArrayViewT<int> err = err_data;
+  auto cs_view = cs->getView();
+  const auto num_pairs = cs->getNumActivePairs();
+  forAllExec( cs->getExecutionMode(), num_pairs, [cs_view, err] TRIBOL_HOST_DEVICE( IndexT i ) {
+    auto& cg_view = cs_view.getCompGeomView();
+    auto& plane = cg_view.getCommonPlane( i );
+    const auto dim = plane.m_dim;
+
+    auto& mesh1 = cs_view.getMesh1View();
+    auto& mesh2 = cs_view.getMesh2View();
+
+    // get pair indices
+    IndexT index1 = plane.getCpElementId1();
+    IndexT index2 = plane.getCpElementId2();
+
+    // TODO write this routine
+    // compute the velocity gap and pressure contribution
+    constexpr int max_dim = 3;
+    constexpr int max_nodes_per_elem = 4;
+    constexpr int max_nodes_per_overlap = 10;
+
+    StackArrayT<RealT, max_dim * max_nodes_per_elem> x1;
+    StackArrayT<RealT, max_dim * max_nodes_per_elem> v1;
+    auto numNodesPerFace1 = mesh1.numberOfNodesPerElement();
+    plane.getFace1Coords( x1, numNodesPerFace1 );  // get avg face coords off the contact plane
+    mesh1.getFaceVelocities( index1, v1 );
+
+    StackArrayT<RealT, max_dim * max_nodes_per_elem> x2;
+    StackArrayT<RealT, max_dim * max_nodes_per_elem> v2;
+    auto numNodesPerFace2 = mesh2.numberOfNodesPerElement();
+    plane.getFace2Coords( x2, numNodesPerFace2 );  // get avg face coords off the contact plane
+    mesh2.getFaceVelocities( index2, v2 );
+
+    //////////////////////////////////////////////////////////
+    // compute velocity Galerkin approximation at projected //
+    // overlap centroid                                     //
+    //////////////////////////////////////////////////////////
+    RealT vel_f1[max_dim];
+    RealT vel_f2[max_dim];
+    initRealArray( vel_f1, dim, 0. );
+    initRealArray( vel_f2, dim, 0. );
+
+    // interpolate nodal velocity at overlap centroid as projected
+    // onto face 1
+    RealT cXf1 = plane.m_cXf1;
+    RealT cYf1 = plane.m_cYf1;
+    RealT cZf1 = ( dim == 3 ) ? plane.m_cZf1 : 0.;
+    GalerkinEval( x1, cXf1, cYf1, cZf1, LINEAR, PHYSICAL, dim, dim, v1, vel_f1 );
+
+    // interpolate nodal velocity at overlap centroid as projected
+    // onto face 2
+    RealT cXf2 = plane.m_cXf2;
+    RealT cYf2 = plane.m_cYf2;
+    RealT cZf2 = ( dim == 3 ) ? plane.m_cZf2 : 0.;
+    GalerkinEval( x2, cXf2, cYf2, cZf2, LINEAR, PHYSICAL, dim, dim, v2, vel_f2 );
+
+    // compute velocity gap vector
+    RealT velGap[max_dim];
+    velGap[0] = vel_f1[0] - vel_f2[0];
+    velGap[1] = vel_f1[1] - vel_f2[1];
+    if ( dim == 3 ) {
+      velGap[2] = vel_f1[2] - vel_f2[2];
+    }
+
+    // subtract off the common-plane normal component of the velocity gap
+    RealT velGap_dot_n = velGap[0] * plane.m_nX + velGap[1] * plane.m_nY;
+    if ( dim == 3 ) {
+      velGap_dot_n += velGap[2] * plane.m_nZ;
+    }
+    RealT velGapTan[max_dim];
+    velGapTan[0] = velGap[0] - velGap_dot_n * plane.m_nX;
+    velGapTan[1] = velGap[1] - velGap_dot_n * plane.m_nY;
+    if ( dim == 3 ) {
+      velGapTan[2] = velGap[2] - velGap_dot_n * plane.m_nZ;
+    }
+
+    // setup the contact element struct for purposes of evaluating basis functions on overlap
+    // initialize assuming 2d
+    RealT xVert[max_dim * max_nodes_per_overlap];
+    auto xVert_size = 4;
+    auto numPolyVert = 2;
+    // update if we are in 3d
+    if ( dim == 3 ) {
+      numPolyVert = plane.m_numPolyVert;
+      xVert_size = 3 * numPolyVert;
+    }
+    initRealArray( xVert, xVert_size, 0. );
+
+    // construct array of polygon overlap vertex coordinates
+    plane.getOverlapVertices( &xVert[0] );
+
+    // instantiate surface contact element struct. Note, this is done with current
+    // configuration face coordinates (i.e. NOT on the contact plane) and overlap
+    // coordinates ON the contact plane. The surface contact element does not need
+    // to be used this way, but the developer should do the book-keeping.
+    SurfaceContactElem cntctElem( dim, x1, x2, xVert, numNodesPerFace1, numPolyVert, &mesh1, &mesh2, index1,
+                                  index2 );
+
+    // set SurfaceContactElem face normals and overlap normal
+    RealT faceNormal1[max_dim];
+    RealT faceNormal2[max_dim];
+    RealT overlapNormal[max_dim];
+
+    mesh1.getFaceNormal( index1, faceNormal1 );
+    mesh2.getFaceNormal( index2, faceNormal2 );
+    overlapNormal[0] = plane.m_nX;
+    overlapNormal[1] = plane.m_nY;
+    if ( dim == 3 ) {
+      overlapNormal[2] = plane.m_nZ;
+    }
+
+    cntctElem.faceNormal1 = faceNormal1;
+    cntctElem.faceNormal2 = faceNormal2;
+    cntctElem.overlapNormal = overlapNormal;
+    cntctElem.overlapArea = plane.m_area;
+
+    // create arrays to hold nodal residual weak form integral evaluations
+    RealT phi1[max_nodes_per_elem];
+    RealT phi2[max_nodes_per_elem];
+    initRealArray( phi1, numNodesPerFace1, 0. );
+    initRealArray( phi2, numNodesPerFace2, 0. );
+
+    ////////////////////////////////////////////////////////////////////////
+    // Integration of contact integrals: integral of shape functions over //
+    // contact overlap patch                                              //
+    ////////////////////////////////////////////////////////////////////////
+    EvalWeakFormIntegral<COMMON_PLANE, SINGLE_POINT>( cntctElem, phi1, phi2 );
+
+    /////////////////////////////////////////////////////
+    // Computation of tangential viscous damping force //
+    /////////////////////////////////////////////////////
+    RealT visc = 1.0; // TODO grab viscous scalar 
+    RealT force_x = visc * velGapTan[0];
+    RealT force_y = visc * velGapTan[1];
+    RealT force_z = 0.;
+    if ( dim == 3 ) {
+      force_z = visc * velGapTan[2];
+    }
+
+    //////////////////////////////////////////////////////
+    // loop over nodes and compute contact nodal forces //
+    //////////////////////////////////////////////////////
+    for ( IndexT a = 0; a < numNodesPerFace1; ++a ) {
+      IndexT node0 = mesh1.getGlobalNodeId( index1, a );
+      IndexT node1 = mesh2.getGlobalNodeId( index2, a );
+
+      const RealT nodal_force_x1 = force_x * phi1[a];
+      const RealT nodal_force_y1 = force_y * phi1[a];
+      const RealT nodal_force_z1 = force_z * phi1[a];
+
+      const RealT nodal_force_x2 = force_x * phi2[a];
+      const RealT nodal_force_y2 = force_y * phi2[a];
+      const RealT nodal_force_z2 = force_z * phi2[a];
+
+      // accumulate contributions in host code's registered nodal force arrays
+#ifdef TRIBOL_USE_RAJA
+      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[0][node0], -nodal_force_x1 );
+      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[0][node1], nodal_force_x2 );
+
+      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[1][node0], -nodal_force_y1 );
+      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[1][node1], nodal_force_y2 );
+
+      // there is no z component for 2D
+      if ( dim == 3 ) {
+        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[2][node0], -nodal_force_z1 );
+        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[2][node1], nodal_force_z2 );
+      }
+#else
+          mesh1.getResponse()[0][node0] -= nodal_force_x1;
+          mesh2.getResponse()[0][node1] += nodal_force_x2;
+
+          mesh1.getResponse()[1][node0] -= nodal_force_y1;
+          mesh2.getResponse()[1][node1] += nodal_force_y2;
+
+          // there is no z component for 2D
+          if (dim == 3)
+          {
+            mesh1.getResponse()[2][node0] -= nodal_force_z1;
+            mesh2.getResponse()[2][node1] += nodal_force_z2;
+          }
+#endif
+    }  // end for loop over face nodes
+
+  } );
+
+  return 0;
+}
+//------------------------------------------------------------------------------
+
 }  // namespace tribol

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -422,8 +422,8 @@ int ApplyNormal<COMMON_PLANE, PENALTY>( CouplingScheme* cs )
 
 //------------------------------------------------------------------------------
 template <>
-int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* cs ) {
-
+int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* cs )
+{
   ///////////////////////////////
   // loop over interface pairs //
   ///////////////////////////////
@@ -447,7 +447,6 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
     IndexT index1 = plane.getCpElementId1();
     IndexT index2 = plane.getCpElementId2();
 
-    // TODO write this routine
     // compute the velocity gap and pressure contribution
     constexpr int max_dim = 3;
     constexpr int max_nodes_per_elem = 4;
@@ -527,8 +526,7 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
     // configuration face coordinates (i.e. NOT on the contact plane) and overlap
     // coordinates ON the contact plane. The surface contact element does not need
     // to be used this way, but the developer should do the book-keeping.
-    SurfaceContactElem cntctElem( dim, x1, x2, xVert, numNodesPerFace1, numPolyVert, &mesh1, &mesh2, index1,
-                                  index2 );
+    SurfaceContactElem cntctElem( dim, x1, x2, xVert, numNodesPerFace1, numPolyVert, &mesh1, &mesh2, index1, index2 );
 
     // set SurfaceContactElem face normals and overlap normal
     RealT faceNormal1[max_dim];
@@ -563,7 +561,8 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
     /////////////////////////////////////////////////////
     // Computation of tangential viscous damping force //
     /////////////////////////////////////////////////////
-    RealT visc = 0.5 * ( mesh1.getElementData().m_viscous_damping_coeff + mesh2.getElementData().m_viscous_damping_coeff );
+    RealT visc =
+        0.5 * ( mesh1.getElementData().m_viscous_damping_coeff + mesh2.getElementData().m_viscous_damping_coeff );
     RealT force_x = visc * velGapTan[0];
     RealT force_y = visc * velGapTan[1];
     RealT force_z = 0.;
@@ -614,10 +613,10 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
           }
 #endif
     }  // end for loop over face nodes
-
   } );
 
-  return 0;
+  ArrayT<int, 1, MemorySpace::Host> err_host( err_data );
+  return err_host[0];
 }
 //------------------------------------------------------------------------------
 

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -558,7 +558,7 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
     /////////////////////////////////////////////////////
     // Computation of tangential viscous damping force //
     /////////////////////////////////////////////////////
-    RealT visc = 1.0; // TODO grab viscous scalar 
+    RealT visc = 0.5 * ( mesh1.getElementData().m_viscous_damping_coeff + mesh2.getElementData().m_viscous_damping_coeff );
     RealT force_x = visc * velGapTan[0];
     RealT force_y = visc * velGapTan[1];
     RealT force_z = 0.;

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -335,6 +335,7 @@ int ApplyNormal<COMMON_PLANE, PENALTY>( CouplingScheme* cs )
 
     // compute contact force (spring force)
     RealT contact_force = totalPressure * A;
+
     RealT force_x = overlapNormal[0] * contact_force;
     RealT force_y = overlapNormal[1] * contact_force;
     RealT force_z = 0.;
@@ -433,8 +434,12 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
   forAllExec( cs->getExecutionMode(), num_pairs, [cs_view, err] TRIBOL_HOST_DEVICE( IndexT i ) {
     auto& cg_view = cs_view.getCompGeomView();
     auto& plane = cg_view.getCommonPlane( i );
-    const auto dim = plane.m_dim;
 
+    if ( !plane.m_inContact ) {
+      return;
+    }
+
+    const auto dim = plane.m_dim;
     auto& mesh1 = cs_view.getMesh1View();
     auto& mesh2 = cs_view.getMesh2View();
 

--- a/src/tribol/physics/CommonPlane.hpp
+++ b/src/tribol/physics/CommonPlane.hpp
@@ -36,6 +36,18 @@ TRIBOL_HOST_DEVICE RealT ComputePenaltyStiffnessPerArea( const RealT K1_over_t1,
 template <>
 int ApplyNormal<COMMON_PLANE, PENALTY>( CouplingScheme* cs );
 
+/*!
+ *
+ * \brief routine to apply interface physics in the direction tangential to the interface
+ *
+ * \param [in] cs pointer to the coupling scheme
+ *
+ * \return 0 if no error
+ *
+ */
+template <>
+int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* cs );
+
 }  // end namespace tribol
 
 #endif /* SRC_PHYSICS_COMMONPLANE_HPP_ */

--- a/src/tribol/physics/Physics.cpp
+++ b/src/tribol/physics/Physics.cpp
@@ -43,7 +43,10 @@ int ApplyInterfacePhysics( CouplingScheme* cs, int TRIBOL_UNUSED_PARAM( cycle ),
           }
           // query the model for application of tangential physics
           switch ( cs->getContactModel() ) {
-            // no tangential physics implemented yet
+            case VISCOUS_TANGENTIAL: {
+              err_tang = ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( cs );
+              break;
+            }
             default: {
               break;
             }

--- a/src/tribol/physics/Physics.hpp
+++ b/src/tribol/physics/Physics.hpp
@@ -11,8 +11,6 @@
 namespace tribol {
 
 // forward declarations
-// struct InterfacePair;
-// struct SurfaceContactElem;
 class CouplingScheme;
 
 /*!

--- a/src/tribol/physics/Physics.hpp
+++ b/src/tribol/physics/Physics.hpp
@@ -11,8 +11,8 @@
 namespace tribol {
 
 // forward declarations
-//struct InterfacePair;
-//struct SurfaceContactElem;
+// struct InterfacePair;
+// struct SurfaceContactElem;
 class CouplingScheme;
 
 /*!

--- a/src/tribol/physics/Physics.hpp
+++ b/src/tribol/physics/Physics.hpp
@@ -11,8 +11,8 @@
 namespace tribol {
 
 // forward declarations
-struct InterfacePair;
-struct SurfaceContactElem;
+//struct InterfacePair;
+//struct SurfaceContactElem;
 class CouplingScheme;
 
 /*!


### PR DESCRIPTION
This PR adds a tangential velocity based damping force term to the contact nodal response. This is taken as some damping coefficient scaling the tangential velocity gap vector. This is enabled using VISCOUS_TANGENTIAL as the contact model, and a damping coefficient for each mesh can be registered. The force is now added to the response arrays in ApplyTangential<>() for the common plane method only. A 2D and a 3D test were added to confirm that the normal component of any velocity gap vector is subtracted out and only the tangential component of the velocity gap is applied. 