### PR TITLE
Check 5 Logic Fix

### DIFF
--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1931,9 +1931,9 @@ TRIBOL_HOST_DEVICE bool CouplingScheme::Viewer::pruneMethodFacePair( const Index
         cx[i] = cx2[i];
       }
 
-      if ( IsOverlappingOnPlane( &x1[0], &y1[0], &z1[0], &x2[0], &y2[0], &z2[0], &nrml[0], &cx[0], num_nodes_face_1,
-                                 num_nodes_face_2, dim ) ) {
-        return false;
+      if ( !IsOverlappingOnPlane( &x1[0], &y1[0], &z1[0], &x2[0], &y2[0], &z2[0], &nrml[0], &cx[0], num_nodes_face_1,
+                                  num_nodes_face_2, dim ) ) {
+        return true;
       }
 
       break;
@@ -1980,9 +1980,9 @@ TRIBOL_HOST_DEVICE bool CouplingScheme::Viewer::pruneMethodFacePair( const Index
         }
       }
 
-      if ( IsOverlappingOnPlane( &x1_prime[0], &y1_prime[0], &z1_prime[0], &x2_prime[0], &y2_prime[0], &z2_prime[0],
-                                 &nrml[0], &cx[0], num_nodes_face_1, num_nodes_face_2, dim ) ) {
-        return false;
+      if ( !IsOverlappingOnPlane( &x1_prime[0], &y1_prime[0], &z1_prime[0], &x2_prime[0], &y2_prime[0], &z2_prime[0],
+                                  &nrml[0], &cx[0], num_nodes_face_1, num_nodes_face_2, dim ) ) {
+        return true;
       }
       break;
     }


### PR DESCRIPTION
There was some reversed logic with the if check on the check 5 overlap calc and the boolean that is returned. Prior to this fix there was no pruning of 3D face-pairs with zero overlap. 