### PR TITLE
Fuzz Factor Added in Check 5, 2D

### DIFF
--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -1018,13 +1018,13 @@ TRIBOL_HOST_DEVICE bool IsOverlappingOnPlane( const RealT* const x1, const RealT
     }
 
     // check if either of edge 1's projected vertices are inside projected edge 2
-    bool vert1_inside2 = IsPointInEdge( &projX2[0], &projY2[0], projX1[0], projY1[0] );
-    bool vert2_inside2 = IsPointInEdge( &projX2[0], &projY2[0], projX1[1], projY1[1] );
+    bool vert1_inside2 = IsPointInEdge( &projX2[0], &projY2[0], projX1[0], projY1[0], 1.e-12 );
+    bool vert2_inside2 = IsPointInEdge( &projX2[0], &projY2[0], projX1[1], projY1[1], 1.e-12 );
 
     // now, check if either of edge 2's projected vertices are inside projected edge 1
     // note, if we just checked for 1 in 2, then if 2 lies entirely within 1 we would have missed that
-    bool vert1_inside1 = IsPointInEdge( &projX1[0], &projY1[0], projX2[0], projY2[0] );
-    bool vert2_inside1 = IsPointInEdge( &projX1[0], &projY1[0], projX2[1], projY2[1] );
+    bool vert1_inside1 = IsPointInEdge( &projX1[0], &projY1[0], projX2[0], projY2[0], 1.e-12 );
+    bool vert2_inside1 = IsPointInEdge( &projX1[0], &projY1[0], projX2[1], projY2[1], 1.e-12 );
 
     // return false if none of the vertices lie inside the other edge
     if ( !vert1_inside2 && !vert2_inside2 ) {

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1972,9 +1972,11 @@ TRIBOL_HOST_DEVICE bool CouplingScheme::Viewer::pruneMethodFacePair( const Index
         ProjectFaceNodesToPlane( mesh2, fid2, fn2[0], fn2[1], fn2[2], cx2[0], cx2[1], cx2[2], &x2_prime[0],
                                  &y2_prime[0], &z2_prime[0] );
       } else {
-        for ( int i = 0; i < dim; ++i ) {
+        for ( int i = 0; i < num_nodes_face_1; ++i ) {
           x1_prime[i] = x1[i];
           y1_prime[i] = y1[i];
+        }
+        for ( int i = 0; i < num_nodes_face_2; ++i ) {
           x2_prime[i] = x2[i];
           y2_prime[i] = y2[i];
         }


### PR DESCRIPTION
Have to add a 1.e-12 fuzz factor for numerically coincident and opposing vertices. I was missing perfect overlaps because numerical precision wasn't catching topologically coincident nodes.