### PR TITLE
Get Number of Contact Pairs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a lot more 2D and 3D computational geometry unit tests covering more face/edge configurations
 - Support for linear triangle meshes in Tribol's SINGLE_MORTAR method (exact Jacobians through Enzyme or approximate
   Jacobians)
+- Added API function to get the number of active contact pairs on a coupling scheme.
 
 ### Changed
 - Return negative timestep vote for non-null meshes with null velocity pointers.

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -827,6 +827,27 @@ void setInterfacePairs( IndexT cs_id, IndexT numPairs, IndexT const* const pairI
 }  // end setInterfacePairs()
 
 //------------------------------------------------------------------------------
+int getNumberOfContactPairsOnRank( IndexT cs_id )
+{
+  auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
+  return cs->getNumActivePairs();
+}
+
+//------------------------------------------------------------------------------
+int getTotalNumberOfContactPairs( IndexT cs_id )
+{
+// note this routine is only for host calls
+#ifdef TRIBOL_USE_HOST
+  auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
+  auto comm = cs->getProblemComm();
+  int local_num_pairs = cs->getNumActivePairs();
+  int global_num_pairs = 0;
+  MPI_Allreduce( &local_num_pairs, &global_num_pairs, 1, MPI_INT, MPI_SUM, comm );
+  return global_num_pairs;
+#endif
+}
+
+//------------------------------------------------------------------------------
 int update( int cycle, RealT t, RealT& dt )
 {
   bool err_cs = false;

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -836,8 +836,6 @@ int getNumberOfContactPairsOnRank( IndexT cs_id )
 //------------------------------------------------------------------------------
 int getTotalNumberOfContactPairs( IndexT cs_id )
 {
-// note this routine is only for host calls
-#ifdef TRIBOL_USE_HOST
   auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
   if ( cs != nullptr ) {
     auto comm = cs->getProblemComm();
@@ -846,7 +844,6 @@ int getTotalNumberOfContactPairs( IndexT cs_id )
     MPI_Allreduce( &local_num_pairs, &global_num_pairs, 1, MPI_INT, MPI_SUM, comm );
     return global_num_pairs;
   }
-#endif
   return 0;
 }
 

--- a/src/tribol/interface/tribol.cpp
+++ b/src/tribol/interface/tribol.cpp
@@ -839,12 +839,15 @@ int getTotalNumberOfContactPairs( IndexT cs_id )
 // note this routine is only for host calls
 #ifdef TRIBOL_USE_HOST
   auto cs = CouplingSchemeManager::getInstance().findData( cs_id );
-  auto comm = cs->getProblemComm();
-  int local_num_pairs = cs->getNumActivePairs();
-  int global_num_pairs = 0;
-  MPI_Allreduce( &local_num_pairs, &global_num_pairs, 1, MPI_INT, MPI_SUM, comm );
-  return global_num_pairs;
+  if ( cs != nullptr ) {
+    auto comm = cs->getProblemComm();
+    int local_num_pairs = cs->getNumActivePairs();
+    int global_num_pairs = 0;
+    MPI_Allreduce( &local_num_pairs, &global_num_pairs, 1, MPI_INT, MPI_SUM, comm );
+    return global_num_pairs;
+  }
 #endif
+  return 0;
 }
 
 //------------------------------------------------------------------------------

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -498,7 +498,7 @@ void setInterfacePairs( IndexT cs_id, IndexT numPairs, IndexT const* mesh_id1, I
  *
  * \param [in] cs_id coupling scheme id
  *
- * \return the number of contact pairs on rank 
+ * \return the number of contact pairs on rank
  */
 int getNumberOfContactPairsOnRank( IndexT cs_id );
 

--- a/src/tribol/interface/tribol.hpp
+++ b/src/tribol/interface/tribol.hpp
@@ -494,6 +494,26 @@ void setInterfacePairs( IndexT cs_id, IndexT numPairs, IndexT const* mesh_id1, I
                         IndexT const* pairIndex2 );
 
 /*!
+ * \brief Get the number of contact pairs on rank for the given coupling scheme
+ *
+ * \param [in] cs_id coupling scheme id
+ *
+ * \return the number of contact pairs on rank 
+ */
+int getNumberOfContactPairsOnRank( IndexT cs_id );
+
+/*!
+ * \brief Get the total number of contact pairs across all ranks for the given coupling scheme
+ *
+ * \param [in] cs_id coupling scheme id
+ *
+ * \return the total number of contact pairs across all rank
+ *
+ * \note this routine only works on host
+ */
+int getTotalNumberOfContactPairs( IndexT cs_id );
+
+/*!
  * \brief Computes the contact response at the given cycle.
  *
  * \param [in] cycle the current cycle.


### PR DESCRIPTION
Adding API functions to return the number of contact pairs per rank and total pairs across all ranks. This will help catch bugs/changes in the computational geometry filtering and cg algorithm in general.

This routine is host callable meant for diagnostics/metrics. 