### PR TITLE
Small refactors to get debug build working with enzyme

### DIFF
--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -483,10 +483,10 @@ TRIBOL_HOST_DEVICE inline bool CheckPolyOrientation( const RealT* const x, const
     if ( prod < 0. )  // don't keep checking
     {
       check = false;
-      return check;
+      break;
     }
   }
-  return check;  // should equal true if here.
+  return check;
 }
 
 /*!
@@ -1468,11 +1468,6 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
       edgeATemp2[i] = edgeATemp[vertIdx[i]];
       edgeBTemp2[i] = edgeBTemp[vertIdx[i]];
     }
-    for ( int i = 0; i < numPolyVert; ++i ) {
-      vertTypeTemp[i] = vertTypeTemp2[i];
-      edgeATemp[i] = edgeATemp2[i];
-      edgeBTemp[i] = edgeBTemp2[i];
-    }
 
     // check length of segs against tolerance and collapse short segments if necessary
     // This is where polyX and polyY get allocated for any overlap that remains with
@@ -1483,13 +1478,13 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
         CheckPolySegs( polyXTemp, polyYTemp, numPolyVert, lenTol, polyX, polyY, vertIdx, numFinalVert );
     for ( int i = 0; i < numFinalVert; ++i ) {
       if ( vertType ) {
-        vertType[i] = vertTypeTemp[vertIdx[i]];
+        vertType[i] = vertTypeTemp2[vertIdx[i]];
       }
       if ( edgeA ) {
-        edgeA[i] = edgeATemp[vertIdx[i]];
+        edgeA[i] = edgeATemp2[vertIdx[i]];
       }
       if ( edgeB ) {
-        edgeB[i] = edgeBTemp[vertIdx[i]];
+        edgeB[i] = edgeBTemp2[vertIdx[i]];
       }
     }
 

--- a/src/tribol/integ/FE.hpp
+++ b/src/tribol/integ/FE.hpp
@@ -114,7 +114,6 @@ inline void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const Re
                     RealT xi[2] )
 {
   if ( numNodes == 4 ) {
-    bool convrg = false;
     int kmax = 15;
     RealT xtol = 1.E-12;
 
@@ -207,15 +206,14 @@ inline void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const Re
       RealT abs_dxi_2 = std::abs( dxi_2 );
 
       if ( abs_dxi_1 <= xtol && abs_dxi_2 <= xtol ) {
-        convrg = true;
         xi[0] = x_sol[0];
         xi[1] = x_sol[1];
 
         //       check to make sure point is inside isoparametric quad
         bool in_quad = true;
         if ( std::abs( xi[0] ) > 1. || std::abs( xi[1] ) > 1. ) {
-          if ( std::abs( xi[0] ) > 1. + 100 * xtol ||
-               std::abs( xi[1] ) > 1. + 100 * xtol )  // should have some tolerance dependent conv tol?
+          if ( std::abs( xi[0] ) > 1. + 100. * xtol ||
+               std::abs( xi[1] ) > 1. + 100. * xtol )  // should have some tolerance dependent conv tol?
           {
             in_quad = false;
           } else {
@@ -230,15 +228,13 @@ inline void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const Re
         SLIC_WARNING_IF( !in_quad, "InvIso(): (xi,eta) coordinate does not lie inside isoparametric quad." );
 #endif
 
-        return;
+        break;
       }
     }
 
 #if !defined( TRIBOL_USE_ENZYME )
-    SLIC_ERROR_IF( !convrg, "InvIso: Newtons method did not converge." );
+    SLIC_ERROR_IF( k == kmax, "InvIso: Newtons method did not converge." );
 #endif
-
-    return;
 
   } else if ( numNodes == 3 ) {
     // use area (barycentric) coords to get xi, eta

--- a/src/tribol/integ/FE.hpp
+++ b/src/tribol/integ/FE.hpp
@@ -114,8 +114,8 @@ inline void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const Re
                     RealT xi[2] )
 {
   if ( numNodes == 4 ) {
-    int kmax = 15;
-    RealT xtol = 1.E-12;
+    constexpr int kmax = 15;
+    constexpr RealT xtol = 1.E-12;
 
     RealT x_sol[2] = { 0., 0. };
 
@@ -127,7 +127,8 @@ inline void InvIso( const RealT x[3], const RealT* xA, const RealT* yA, const Re
     RealT djde_22 = 0.;
 
     // loop over newton iterations
-    for ( int k = 0; k < kmax; ++k ) {
+    int k = 0;
+    for ( ; k < kmax; ++k ) {
       // evaluate Jacobian
       RealT j_x_1 = 0.25 * ( xA[0] * ( 1. + x_sol[1] ) - xA[1] * ( 1. + x_sol[1] ) - xA[2] * ( 1. - x_sol[1] ) +
                              xA[3] * ( 1. - x_sol[1] ) );


### PR DESCRIPTION
The debug build was not compiling with enzyme due to errors like this:
```
PHI Node must not have any attached DbgRecords
  %53 = phi i64 [ %15, %19 ], !dbg !71744
; Function Attrs: mustprogress noinline optnone willreturn uwtable
```

This PR contains small refactors to get the code building with enzyme again on debug.