### PR TITLE
Add Caliper to spack recipe and CMake

### DIFF
--- a/cmake/SetupThirdParty.cmake
+++ b/cmake/SetupThirdParty.cmake
@@ -196,6 +196,36 @@ foreach(dep ${EXPORTED_TPL_DEPS})
   endif()
 endforeach()
 
+#------------------------------------------------------------------------------
+# Caliper
+#------------------------------------------------------------------------------
+if(TRIBOL_ENABLE_PROFILING AND NOT CALIPER_DIR)
+    message(FATAL_ERROR "TRIBOL_ENABLE_PROFILING cannot be ON without CALIPER_DIR defined. Either specify a host \
+                          config with CALIPER_DIR, or rebuild Tribol TPLs with +profiling variant.")
+endif()
+
+if(CALIPER_DIR AND TRIBOL_ENABLE_PROFILING)
+    tribol_assert_path_exists(${CALIPER_DIR})
+
+    # Should this logic be in the Caliper CMake package?
+    # If CMake version doesn't support CUDAToolkit the libraries
+    # are just "baked in"
+    if(TRIBOL_ENABLE_CUDA)
+        if(CMAKE_VERSION VERSION_LESS 3.17)
+            message(FATAL_ERROR "Tribol+Caliper+CUDA requires CMake > 3.17.")
+        else()
+            find_package(CUDAToolkit REQUIRED)
+        endif() 
+    endif()
+
+    find_dependency(caliper REQUIRED PATHS "${CALIPER_DIR}")
+    message(STATUS "Caliper support is ON")
+    set(TRIBOL_USE_CALIPER TRUE)
+else()
+    message(STATUS "Caliper support is OFF")
+    set(TRIBOL_USE_CALIPER FALSE)
+endif()
+
 message(STATUS "--------------------------\n"
                "Finished configuring TPLs")
 

--- a/cmake/tribol-config.cmake.in
+++ b/cmake/tribol-config.cmake.in
@@ -37,9 +37,10 @@ if(NOT TRIBOL_FOUND)
   set(TRIBOL_USE_64BIT_INDEXTYPE  "@TRIBOL_USE_64BIT_INDEXTYPE@")
 
   # TPLs
-  set(TRIBOL_USE_UMPIRE "@TRIBOL_USE_UMPIRE@")
-  set(TRIBOL_USE_RAJA   "@TRIBOL_USE_RAJA@")
-  set(TRIBOL_USE_ENZYME "@TRIBOL_USE_ENZYME@")
+  set(TRIBOL_USE_UMPIRE  "@TRIBOL_USE_UMPIRE@")
+  set(TRIBOL_USE_RAJA    "@TRIBOL_USE_RAJA@")
+  set(TRIBOL_USE_ENZYME  "@TRIBOL_USE_ENZYME@")
+  set(TRIBOL_USE_CALIPER "@TRIBOL_USE_CALIPER@")
 
   # Configuration for Tribol compiler defines
   set(TRIBOL_DEBUG_DEFINE         "@TRIBOL_DEBUG_DEFINE@")
@@ -54,15 +55,6 @@ if(NOT TRIBOL_FOUND)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS TRUE)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIBX32_PATHS TRUE)
-
-  # Enzyme is optional
-  if(TRIBOL_USE_ENZYME)
-    set(TRIBOL_ENZYME_DIR  "@ENZYME_DIR@")
-    if(NOT ENZYME_DIR) 
-      set(ENZYME_DIR "${TRIBOL_ENZYME_DIR}")
-    endif()
-    find_dependency(Enzyme REQUIRED PATHS "${ENZYME_DIR}")
-  endif()
 
   # Umpire is optional
   if(TRIBOL_USE_UMPIRE)
@@ -80,6 +72,24 @@ if(NOT TRIBOL_FOUND)
       set(RAJA_DIR "${TRIBOL_RAJA_DIR}")
     endif()
     find_dependency(RAJA REQUIRED PATHS "${RAJA_DIR}")
+  endif()
+
+  # Enzyme is optional
+  if(TRIBOL_USE_ENZYME)
+    set(TRIBOL_ENZYME_DIR  "@ENZYME_DIR@")
+    if(NOT ENZYME_DIR) 
+      set(ENZYME_DIR "${TRIBOL_ENZYME_DIR}")
+    endif()
+    find_dependency(Enzyme REQUIRED PATHS "${ENZYME_DIR}")
+  endif()
+
+  # Caliper is optional
+  if(TRIBOL_USE_CALIPER)
+    set(TRIBOL_CALIPER_DIR  "@CALIPER_DIR@")
+    if(NOT CALIPER_DIR) 
+      set(CALIPER_DIR "${TRIBOL_CALIPER_DIR}")
+    endif()
+    find_dependency(caliper REQUIRED PATHS "${CALIPER_DIR}")
   endif()
 
   # axom is a required TPL. It is either external, or built-in

--- a/scripts/spack/configs/linux_ubuntu_24/spack.yaml
+++ b/scripts/spack/configs/linux_ubuntu_24/spack.yaml
@@ -239,3 +239,8 @@ spack:
       - spec: gawk@5.2.1
         prefix: /usr
       buildable: false
+    elfutils:
+      externals:
+      - spec: elfutils@0.190
+        prefix: /usr
+      buildable: false

--- a/scripts/spack/packages/tribol/package.py
+++ b/scripts/spack/packages/tribol/package.py
@@ -51,6 +51,8 @@ class Tribol(CachedCMakePackage, CudaPackage, ROCmPackage):
             description="Build development tools (Sphinx, Doxygen, Shroud, clang-format)")
     variant("asan", default=False,
             description="Build with address sanitizer flags")
+    variant("profiling", default=False,
+            description="Build with hooks for Caliper performance analysis")
     variant("umpire",   default=False,
             description="Build with portable memory access support")
     variant("raja",     default=False,
@@ -93,6 +95,9 @@ class Tribol(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("mfem+metis+mpi", when="+redecomp")
     depends_on("mfem+asan", when="+asan")
+
+    with when("+profiling"):
+        depends_on("caliper+mpi")
     
     with when("+openmp"):
         depends_on("axom+openmp")
@@ -105,25 +110,33 @@ class Tribol(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     for val in CudaPackage.cuda_arch_values:
         ext_cuda_dep = f"+cuda cuda_arch={val}"
-        depends_on(f"mfem{ext_cuda_dep}", when=f"{ext_cuda_dep}")
-        depends_on(f"axom{ext_cuda_dep}", when=f"{ext_cuda_dep}")
+        depends_on(f"mfem {ext_cuda_dep}", when=f"{ext_cuda_dep}")
+        depends_on(f"axom {ext_cuda_dep}", when=f"{ext_cuda_dep}")
         # NOTE: Tribol requires RAJA and Umpire for CUDA support
-        depends_on(f"raja{ext_cuda_dep}", when=f"{ext_cuda_dep}")
-        depends_on(f"umpire{ext_cuda_dep}", when=f"{ext_cuda_dep}")
+        depends_on(f"raja {ext_cuda_dep}", when=f"{ext_cuda_dep}")
+        depends_on(f"umpire {ext_cuda_dep}", when=f"{ext_cuda_dep}")
+        # NOTE: Caliper is an optional dependency
+        depends_on(f"caliper {ext_cuda_dep}", when=f"+profiling {ext_cuda_dep}")
 
     for val in ROCmPackage.amdgpu_targets:
         ext_rocm_dep = f"+rocm amdgpu_target={val}"
-        depends_on(f"mfem{ext_rocm_dep}", when=f"{ext_rocm_dep}")
-        depends_on(f"axom{ext_rocm_dep}", when=f"{ext_rocm_dep}")
+        depends_on(f"mfem {ext_rocm_dep}", when=f"{ext_rocm_dep}")
+        depends_on(f"axom {ext_rocm_dep}", when=f"{ext_rocm_dep}")
         # NOTE: Tribol requires RAJA and Umpire for HIP support
-        depends_on(f"raja{ext_rocm_dep}", when=f"{ext_rocm_dep}")
-        depends_on(f"umpire{ext_rocm_dep}", when=f"{ext_rocm_dep}")
+        depends_on(f"raja {ext_rocm_dep}", when=f"{ext_rocm_dep}")
+        depends_on(f"umpire {ext_rocm_dep}", when=f"{ext_rocm_dep}")
+        # NOTE: Caliper is an optional dependency
+        depends_on(f"caliper {ext_rocm_dep}", when=f"+profiling {ext_rocm_dep}")
 
     depends_on("rocprim", when="+rocm")
+
     
     # Optional (require our variant in "when")
     for dep in ["raja", "umpire"]:
         depends_on("{0} build_type=Debug".format(dep), when="+{0} build_type=Debug".format(dep))
+    
+    # Optional, but variant name doesn't match package name
+    depends_on("caliper build_type=Debug".format(dep), when="+profiling build_type=Debug")
         
     # Required
     for dep in ["axom", "conduit", "metis", "parmetis"]:
@@ -395,7 +408,7 @@ class Tribol(CachedCMakePackage, CudaPackage, ROCmPackage):
                                             dep_dir))
 
         # optional tpls
-        for dep in ('raja', 'umpire', 'enzyme'):
+        for dep in ('raja', 'umpire', 'enzyme', 'caliper'):
             if spec.satisfies('^{0}'.format(dep)):
                 dep_dir = get_spec_path(spec, dep, path_replacements)
                 entries.append(cmake_cache_path('%s_DIR' % dep.upper(),

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -27,7 +27,7 @@
     [ "+enzyme" ],
 
     "linux_ubuntu_24":
-    [ "+raja+umpire+enzyme+profiling %clang_19",
-      "+cuda+raja+umpire+enzyme+profiling cuda_arch=86 %clang_19" ]
+    [ "+raja+umpire+enzyme+profiling ^hypre+int64 %clang_19",
+      "+cuda+raja+umpire+enzyme+profiling cuda_arch=86 ^hypre+int64 %clang_19" ]
       
 }

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -27,6 +27,7 @@
     [ "+enzyme" ],
 
     "linux_ubuntu_24":
-    [ "+cuda+raja+umpire+enzyme cuda_arch=86 %clang_19"]
+    [ "+raja+umpire+enzyme+profiling %clang_19",
+      "+cuda+raja+umpire+enzyme+profiling cuda_arch=86 %clang_19" ]
       
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -256,3 +256,22 @@ if( TRIBOL_USE_ENZYME )
 
 endif()
 
+if( TRIBOL_USE_CALIPER )
+
+  set(caliper_smoke_depends caliper gtest)
+  blt_add_executable(
+    NAME caliper_smoke_test
+    SOURCES caliper_smoke.cpp
+    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+    DEPENDS_ON ${caliper_smoke_depends} ${tribol_device_depends}
+    FOLDER tribol/tests )
+
+  blt_add_test( NAME caliper_smoke_test
+                COMMAND caliper_smoke_test )
+
+  if (ENABLE_CUDA)
+    set_target_properties(caliper_smoke_test PROPERTIES CUDA_SEPARABLE_COMPILATION On)
+  endif()
+
+endif()
+

--- a/src/tests/caliper_smoke.cpp
+++ b/src/tests/caliper_smoke.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Tribol Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (MIT)
+
+//-----------------------------------------------------------------------------
+//
+// file: caliper_smoke.cpp
+//
+//-----------------------------------------------------------------------------
+
+#include "gtest/gtest.h"
+
+#include "caliper/cali-manager.h"
+#include "caliper/cali.h"
+
+void testFunction()
+{
+  CALI_CXX_MARK_FUNCTION;
+  std::cout << "Writing output..." << std::endl;
+}
+
+TEST( caliper_smoke, basic_use ) { testFunction(); }
+
+int main( int, char** )
+{
+  cali::ConfigManager mgr;
+  mgr.add( "runtime-report,spot" );
+  mgr.start();
+
+  auto result = RUN_ALL_TESTS();
+
+  mgr.stop();
+  mgr.flush();
+
+  return result;
+}

--- a/src/tests/caliper_smoke.cpp
+++ b/src/tests/caliper_smoke.cpp
@@ -22,8 +22,10 @@ void testFunction()
 
 TEST( caliper_smoke, basic_use ) { testFunction(); }
 
-int main( int, char** )
+int main( int argc, char* argv[] )
 {
+  ::testing::InitGoogleTest( &argc, argv );
+
   cali::ConfigManager mgr;
   mgr.add( "runtime-report,spot" );
   mgr.start();

--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -108,6 +108,7 @@ blt_list_append(TO tribol_depends ELEMENTS redecomp IF BUILD_REDECOMP )
 blt_list_append(TO tribol_depends ELEMENTS umpire IF TRIBOL_USE_UMPIRE )
 blt_list_append(TO tribol_depends ELEMENTS RAJA IF TRIBOL_USE_RAJA )
 blt_list_append(TO tribol_depends ELEMENTS ClangEnzymeFlags IF TRIBOL_USE_ENZYME)
+blt_list_append(TO tribol_depends ELEMENTS caliper IF TRIBOL_USE_CALIPER)
 message(STATUS "Tribol library dependencies: ${tribol_depends}")
 
 ## create the library

--- a/src/tribol/config.hpp.in
+++ b/src/tribol/config.hpp.in
@@ -32,9 +32,10 @@
  */
 #cmakedefine TRIBOL_USE_SINGLE_PRECISION
 #cmakedefine TRIBOL_USE_MPI
-#cmakedefine TRIBOL_USE_ENZYME
 #cmakedefine TRIBOL_USE_UMPIRE
 #cmakedefine TRIBOL_USE_RAJA
+#cmakedefine TRIBOL_USE_ENZYME
+#cmakedefine TRIBOL_USE_CALIPER
 #cmakedefine TRIBOL_USE_CUDA
 #cmakedefine TRIBOL_USE_HIP
 #cmakedefine TRIBOL_USE_OPENMP

--- a/src/tribol/utils/Profiling.hpp
+++ b/src/tribol/utils/Profiling.hpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Tribol Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (MIT)
+
+#ifndef SRC_TRIBOL_UTILS_PROFILING_HPP_
+#define SRC_TRIBOL_UTILS_PROFILING_HPP_
+
+/**
+ * @file profiling.hpp
+ *
+ * @brief Various helper functions and macros for profiling using Caliper
+ */
+
+// Tribol config include
+#include "tribol/config.hpp"
+
+#ifdef TRIBOL_USE_CALIPER
+#include "caliper/cali.h"
+#endif
+
+/**
+ * @def TRIBOL_MARK_FUNCTION
+ * Marks a function for Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_LOOP_BEGIN(id, name)
+ * Marks the beginning of a loop block for Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_LOOP_ITERATION(id, i)
+ * Marks the beginning of a loop iteration for Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_LOOP_END(id)
+ * Marks the end of a loop block for Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_BEGIN(id)
+ * Marks the start of a region Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_END(id)
+ * Marks the end of a region Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+/**
+ * @def TRIBOL_MARK_SCOPE(name)
+ * Marks a particular scope for Caliper profiling. No-op macro when TRIBOL_ENABLE_PROFILING is off.
+ */
+
+// NOTE: The motivation behind wrapping Caliper macros to avoid conflicting macro definitions in the no-op case, and
+// give downstream users the option to disable profiling Smith if it pollutes their timings.
+
+#ifdef TRIBOL_USE_CALIPER
+#define TRIBOL_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
+#define TRIBOL_MARK_LOOP_BEGIN( id, name ) CALI_CXX_MARK_LOOP_BEGIN( id, name )
+#define TRIBOL_MARK_LOOP_ITERATION( id, i ) CALI_CXX_MARK_LOOP_ITERATION( id, i )
+#define TRIBOL_MARK_LOOP_END( id ) CALI_CXX_MARK_LOOP_END( id )
+#define TRIBOL_MARK_BEGIN( name ) CALI_MARK_BEGIN( name )
+#define TRIBOL_MARK_END( name ) CALI_MARK_END( name )
+#define TRIBOL_MARK_SCOPE( name ) CALI_CXX_MARK_SCOPE( name )
+#else
+// Define no-op macros in case Smith has not been configured with Caliper
+#define TRIBOL_MARK_FUNCTION
+#define TRIBOL_MARK_LOOP_BEGIN( id, name )
+#define TRIBOL_MARK_LOOP_ITERATION( id, i )
+#define TRIBOL_MARK_LOOP_END( id )
+#define TRIBOL_MARK_BEGIN( name )
+#define TRIBOL_MARK_END( name )
+#define TRIBOL_MARK_SCOPE( name )
+#endif
+
+#endif  // SRC_TRIBOL_UTILS_PROFILING_HPP_


### PR DESCRIPTION
Adds Caliper as a TPL of Tribol for profiling Tribol routines.  No annotations have been added in this PR, just the plumbing to use Caliper in Tribol and in downstream packages.

Specifically, the following has been added:
- CMake build system changes required for building with Caliper support
- Spack recipe changes for building Caliper with TPLs when `+profiling` variant is active
- Tribol macros for more fine-tuned profiling output
- Caliper smoke test

NOTE: All of this was heavily borrowed from [Smith](https://github.com/LLNL/smith).  Thanks @chapman39 and @white238!