### PR TITLE
Add caliper annotations to `updateMfemParallelDecomposition()`

### DIFF
--- a/src/redecomp/CMakeLists.txt
+++ b/src/redecomp/CMakeLists.txt
@@ -45,7 +45,7 @@ set( redecomp_sources
      )
 
 ## setup the dependency list for redecomp
-set(redecomp_depends axom::primal mfem)
+set(redecomp_depends tribol_shared axom::primal mfem)
 blt_list_append(TO redecomp_depends ELEMENTS blt::mpi IF TRIBOL_USE_MPI )
 
 ## create the library

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -7,6 +7,8 @@
 
 #include "axom/slic.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/RedecompTransfer.hpp"
 #include "redecomp/transfer/TransferByNodes.hpp"
 #include "redecomp/partition/Partitioner.hpp"
@@ -23,6 +25,7 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, PartitionType method, i
 RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length, PartitionType method, int n_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
+  TRIBOL_MARK_FUNCTION;
   // build partitioner
   std::unique_ptr<Partitioner> partitioner = nullptr;
   switch ( parent_.SpaceDimension() ) {
@@ -80,6 +83,7 @@ RedecompMesh::RedecompMesh( const mfem::ParMesh& parent, double ghost_length,
                             std::unique_ptr<const Partitioner> partitioner, int n_ranks )
     : parent_{ parent }, mpi_{ parent.GetComm() }
 {
+  TRIBOL_MARK_FUNCTION;
   // check partitioner
   switch ( parent_.SpaceDimension() ) {
     case 2: {
@@ -139,6 +143,7 @@ EntityIndexByRank RedecompMesh::BuildP2RElementList( const Partitioner& partitio
 
 void RedecompMesh::BuildRedecomp()
 {
+  TRIBOL_MARK_FUNCTION;
   // dimension information
   Dim = parent_.Dimension();
   spaceDim = parent_.SpaceDimension();

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -85,9 +85,13 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
     auto last_el = redecomp->getRedecompToParentElemOffsets()[r + 1];
     auto quadpt_ct = 0;
     for ( int e{ first_el }; e < last_el; ++e ) {
+      TRIBOL_MARK_BEGIN( "Read element values" );
       dst.GetValues( e, vals );
       const mfem::Vector dof_vals( &dst_vals[r][quadpt_ct], vals.Size() );
+      TRIBOL_MARK_END( "Read element values" );
+      TRIBOL_MARK_BEGIN( "Copy element values" );
       vals = dof_vals;
+      TRIBOL_MARK_END( "Copy element values" );
       quadpt_ct += vals.Size();
       dst.SyncMemory( vals );
     }

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -78,8 +78,7 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
   // map received quadrature point values to local quadrature points
   TRIBOL_MARK_BEGIN( "Map received values to local values" );
   auto vals = mfem::Vector();
-  // vals.UseDevice( true );
-  dst.HostWrite();
+  vals.UseDevice( true );
   auto n_ranks = redecomp->getMPIUtility().NRanks();
   for ( int r{ 0 }; r < n_ranks; ++r ) {
     auto first_el = redecomp->getRedecompToParentElemOffsets()[r];
@@ -94,6 +93,7 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
       vals = dof_vals;
       TRIBOL_MARK_END( "Copy element values" );
       quadpt_ct += vals.Size();
+      dst.SyncMemory( vals );
     }
   }
   TRIBOL_MARK_END( "Map received values to local values" );

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -78,7 +78,8 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
   // map received quadrature point values to local quadrature points
   TRIBOL_MARK_BEGIN( "Map received values to local values" );
   auto vals = mfem::Vector();
-  vals.UseDevice( true );
+  // vals.UseDevice( true );
+  dst.HostWrite();
   auto n_ranks = redecomp->getMPIUtility().NRanks();
   for ( int r{ 0 }; r < n_ranks; ++r ) {
     auto first_el = redecomp->getRedecompToParentElemOffsets()[r];
@@ -93,7 +94,6 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
       vals = dof_vals;
       TRIBOL_MARK_END( "Copy element values" );
       quadpt_ct += vals.Size();
-      dst.SyncMemory( vals );
     }
   }
   TRIBOL_MARK_END( "Map received values to local values" );

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -49,6 +49,7 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
                       "Redecomp -> ParMesh relationship." );
 
   // send and receive quadrature point values from other ranks
+  TRIBOL_MARK_BEGIN( "Send and receive values over MPI" );
   auto dst_vals = MPIArray<double>( &redecomp->getMPIUtility() );
   dst_vals.SendRecvEach( [redecomp, &src]( int dest ) {
     auto src_vals = axom::Array<double>();
@@ -72,8 +73,10 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
     }
     return src_vals;
   } );
+  TRIBOL_MARK_END( "Send and receive values over MPI" );
 
   // map received quadrature point values to local quadrature points
+  TRIBOL_MARK_BEGIN( "Map received values to local values" );
   auto vals = mfem::Vector();
   vals.UseDevice( true );
   auto n_ranks = redecomp->getMPIUtility().NRanks();
@@ -89,6 +92,7 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
       dst.SyncMemory( vals );
     }
   }
+  TRIBOL_MARK_END( "Map received values to local values" );
 }
 
 void RedecompTransfer::TransferToParallel( const mfem::QuadratureFunction& src, mfem::QuadratureFunction& dst ) const

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -57,11 +57,15 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
     if ( n_els > 0 ) {
       auto vals = mfem::Vector();
       // guess the size of send_vals based on the size of the first element
+      TRIBOL_MARK_BEGIN( "Getting element values" );
       src.GetValues( src_elem_idx[0], vals );
+      TRIBOL_MARK_END( "Getting element values" );
       src_vals.reserve( vals.Size() * n_els );
       auto quadpt_ct = 0;
       for ( auto src_elem_id : src_elem_idx ) {
+        TRIBOL_MARK_BEGIN( "Getting element values" );
         src.GetValues( src_elem_id, vals );
+        TRIBOL_MARK_END( "Getting element values" );
         src_vals.insert( quadpt_ct, vals.Size(), vals.GetData() );
         quadpt_ct += vals.Size();
       }

--- a/src/redecomp/RedecompTransfer.cpp
+++ b/src/redecomp/RedecompTransfer.cpp
@@ -7,6 +7,8 @@
 
 #include "axom/slic.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/RedecompMesh.hpp"
 #include "redecomp/transfer/TransferByNodes.hpp"
 #include "redecomp/transfer/TransferByElements.hpp"
@@ -38,6 +40,7 @@ void RedecompTransfer::TransferToParallel( const mfem::GridFunction& src, mfem::
 
 void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mfem::QuadratureFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // checks to make sure src and dst are valid
   auto redecomp = dynamic_cast<RedecompMesh*>( dst.GetSpace()->GetMesh() );
   SLIC_ERROR_ROOT_IF( redecomp == nullptr, "The Mesh of QuadratureFunction dst must be a Redecomp mesh." );
@@ -86,6 +89,7 @@ void RedecompTransfer::TransferToSerial( const mfem::QuadratureFunction& src, mf
 
 void RedecompTransfer::TransferToParallel( const mfem::QuadratureFunction& src, mfem::QuadratureFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // checks to make sure src and dst are valid
   auto redecomp = dynamic_cast<RedecompMesh*>( src.GetSpace()->GetMesh() );
   SLIC_ERROR_ROOT_IF( redecomp == nullptr, "The Mesh of QuadratureFunction src must be a Redecomp mesh." );

--- a/src/redecomp/partition/RCB.cpp
+++ b/src/redecomp/partition/RCB.cpp
@@ -7,6 +7,8 @@
 
 #include "axom/slic.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/common/TypeDefs.hpp"
 #include "redecomp/utils/ArrayUtility.hpp"
 #include "redecomp/utils/MPIUtility.hpp"
@@ -23,6 +25,7 @@ template <int NDIMS>
 std::vector<EntityIndexByRank> RCB<NDIMS>::generatePartitioning(
     int n_parts, const std::vector<axom::Array<Point<NDIMS>>>& coords_by_mesh, double ghost_len ) const
 {
+  TRIBOL_MARK_FUNCTION;
   auto partitioning = std::vector<EntityIndexByRank>();
   partitioning.reserve( coords_by_mesh.size() );
 
@@ -72,6 +75,7 @@ BisecTree<RCBInfo<NDIMS>> RCB<NDIMS>::BuildProblemTree( int n_parts,
                                                         const std::vector<axom::Array<Point<NDIMS>>>& coords_by_mesh,
                                                         double ghost_len ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // subdivide the domain into n_parts pieces.  create a bisection tree of the
   // domain so we can focus on one piece at a time.
   auto problem_tree = BisecTree<RCBInfo<NDIMS>>( n_parts );

--- a/src/redecomp/transfer/TransferByElements.cpp
+++ b/src/redecomp/transfer/TransferByElements.cpp
@@ -7,12 +7,15 @@
 
 #include "axom/slic.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/RedecompMesh.hpp"
 
 namespace redecomp {
 
 void TransferByElements::TransferToSerial( const mfem::ParGridFunction& src, mfem::GridFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // checks to make sure src and dst are valid
   auto redecomp = dynamic_cast<RedecompMesh*>( dst.FESpace()->GetMesh() );
   SLIC_ERROR_ROOT_IF( redecomp == nullptr, "The Mesh of GridFunction dst must be a Redecomp mesh." );
@@ -67,6 +70,7 @@ void TransferByElements::TransferToSerial( const mfem::ParGridFunction& src, mfe
 
 void TransferByElements::TransferToParallel( const mfem::GridFunction& src, mfem::ParGridFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // checks to make sure src and dst are valid
   auto redecomp = dynamic_cast<RedecompMesh*>( src.FESpace()->GetMesh() );
   SLIC_ERROR_ROOT_IF( redecomp == nullptr, "The Mesh of GridFunction dst must be a Redecomp mesh." );

--- a/src/redecomp/transfer/TransferByNodes.cpp
+++ b/src/redecomp/transfer/TransferByNodes.cpp
@@ -9,6 +9,8 @@
 
 #include "axom/slic.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/RedecompMesh.hpp"
 #include "redecomp/common/TypeDefs.hpp"
 
@@ -20,6 +22,7 @@ TransferByNodes::TransferByNodes( const mfem::ParFiniteElementSpace& parent_fes,
       redecomp_fes_{ &redecomp_fes },
       redecomp_{ dynamic_cast<const RedecompMesh*>( redecomp_fes.GetMesh() ) }
 {
+  TRIBOL_MARK_FUNCTION;
   SLIC_ERROR_ROOT_IF( redecomp_ == nullptr,
                       "The Redecomp mesh pointer is null.  Does the redecomp_fes contain an "
                       "underlying Redecomp mesh?" );
@@ -41,6 +44,7 @@ TransferByNodes::TransferByNodes( const mfem::ParFiniteElementSpace& parent_fes,
 
 void TransferByNodes::TransferToSerial( const mfem::ParGridFunction& src, mfem::GridFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // define transfer-specific data
   auto src_fes = src.ParFESpace();
   auto dst_fes = dst.FESpace();
@@ -89,6 +93,7 @@ void TransferByNodes::TransferToSerial( const mfem::ParGridFunction& src, mfem::
 
 void TransferByNodes::TransferToParallel( const mfem::GridFunction& src, mfem::ParGridFunction& dst ) const
 {
+  TRIBOL_MARK_FUNCTION;
   // define transfer specific data
   auto src_fes = src.FESpace();
   auto dst_fes = dst.ParFESpace();
@@ -146,6 +151,7 @@ void TransferByNodes::TransferToParallel( const mfem::GridFunction& src, mfem::P
 
 EntityIndexByRank TransferByNodes::P2RNodeList( bool use_global_ids )
 {
+  TRIBOL_MARK_FUNCTION;
   // p2r = parent to redecomp
   auto p2r_node_idx = MPIArray<int>( &redecomp_->getMPIUtility() );
   auto p2r_node_ghost = MPIArray<bool>( &redecomp_->getMPIUtility() );
@@ -187,6 +193,7 @@ EntityIndexByRank TransferByNodes::P2RNodeList( bool use_global_ids )
 
 EntityIndexByRank TransferByNodes::R2PNodeList()
 {
+  TRIBOL_MARK_FUNCTION;
   // r2p = redecomp to parent
   auto r2p_node_idx = MPIArray<int>( &redecomp_->getMPIUtility() );
   auto r2p_node_ghost = MPIArray<bool>( &redecomp_->getMPIUtility() );

--- a/src/redecomp/utils/MPIArray.hpp
+++ b/src/redecomp/utils/MPIArray.hpp
@@ -8,6 +8,8 @@
 
 #include "axom/core.hpp"
 
+#include "shared/infrastructure/Profiling.hpp"
+
 #include "redecomp/utils/MPIUtility.hpp"
 
 namespace redecomp {
@@ -109,6 +111,7 @@ class MPIArray : public ArrayType {
   template <typename F>
   void SendRecvEach( F&& build_send )
   {
+    TRIBOL_MARK_FUNCTION;
     mpi_->SendRecvEach(
         type<axom::Array<T, DIM>>(), std::forward<F>( build_send ),
         [this]( axom::Array<T, DIM>&& recv_data, axom::IndexType src ) { at( src ) = std::move( recv_data ); } );

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -6,6 +6,7 @@
 ## list of headers
 set(shared_headers
 
+    infrastructure/Profiling.hpp
     mesh/MeshBuilder.hpp
     )
 
@@ -17,7 +18,8 @@ set(shared_sources
 
 ## setup the dependency list for tribol shared library
 set(shared_depends mfem)
-blt_list_append(TO tribol_depends ELEMENTS blt::mpi IF TRIBOL_USE_MPI )
+blt_list_append(TO shared_depends ELEMENTS blt::mpi IF TRIBOL_USE_MPI )
+blt_list_append(TO shared_depends ELEMENTS caliper IF TRIBOL_USE_CALIPER )
 message(STATUS "Tribol shared library dependencies: ${shared_depends}")
 
 ## create the library

--- a/src/shared/config.hpp.in
+++ b/src/shared/config.hpp.in
@@ -14,6 +14,7 @@
 /*
  * Build information
  */
+#cmakedefine TRIBOL_USE_CALIPER
 #cmakedefine TRIBOL_USE_MPI
 
 #endif /* SHARED_CONFIG_HPP_ */

--- a/src/shared/infrastructure/Profiling.hpp
+++ b/src/shared/infrastructure/Profiling.hpp
@@ -3,17 +3,17 @@
 //
 // SPDX-License-Identifier: (MIT)
 
-#ifndef SRC_TRIBOL_UTILS_PROFILING_HPP_
-#define SRC_TRIBOL_UTILS_PROFILING_HPP_
+#ifndef SRC_SHARED_INFRASTRUCTURE_PROFILING_HPP_
+#define SRC_SHARED_INFRASTRUCTURE_PROFILING_HPP_
 
 /**
- * @file profiling.hpp
+ * @file Profiling.hpp
  *
  * @brief Various helper functions and macros for profiling using Caliper
  */
 
-// Tribol config include
-#include "tribol/config.hpp"
+// Shared config include
+#include "shared/config.hpp"
 
 #ifdef TRIBOL_USE_CALIPER
 #include "caliper/cali.h"
@@ -76,4 +76,4 @@
 #define TRIBOL_MARK_SCOPE( name )
 #endif
 
-#endif  // SRC_TRIBOL_UTILS_PROFILING_HPP_
+#endif  // SRC_SHARED_INFRASTRUCTURE_PROFILING_HPP_

--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -108,7 +108,6 @@ blt_list_append(TO tribol_depends ELEMENTS redecomp IF BUILD_REDECOMP )
 blt_list_append(TO tribol_depends ELEMENTS umpire IF TRIBOL_USE_UMPIRE )
 blt_list_append(TO tribol_depends ELEMENTS RAJA IF TRIBOL_USE_RAJA )
 blt_list_append(TO tribol_depends ELEMENTS ClangEnzymeFlags IF TRIBOL_USE_ENZYME)
-blt_list_append(TO tribol_depends ELEMENTS caliper IF TRIBOL_USE_CALIPER)
 message(STATUS "Tribol library dependencies: ${tribol_depends}")
 
 ## create the library

--- a/src/tribol/config.hpp.in
+++ b/src/tribol/config.hpp.in
@@ -35,7 +35,6 @@
 #cmakedefine TRIBOL_USE_UMPIRE
 #cmakedefine TRIBOL_USE_RAJA
 #cmakedefine TRIBOL_USE_ENZYME
-#cmakedefine TRIBOL_USE_CALIPER
 #cmakedefine TRIBOL_USE_CUDA
 #cmakedefine TRIBOL_USE_HIP
 #cmakedefine TRIBOL_USE_OPENMP

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -348,17 +348,23 @@ void MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
   // update coordinates of submesh and LOR mesh
   auto submesh_nodes = dynamic_cast<mfem::ParGridFunction*>( submesh_.GetNodes() );
   SLIC_ERROR_ROOT_IF( !submesh_nodes, "submesh_ Nodes is not a ParGridFunction." );
-  TRIBOL_MARK_BEGIN( "SubMesh coords transfer" );
+  TRIBOL_MARK_BEGIN( "Update SubMesh coords" );
   submesh_.Transfer( coords_.GetParentGridFn(), *submesh_nodes );
-  TRIBOL_MARK_END( "SubMesh coords transfer" );
+  TRIBOL_MARK_END( "Update SubMesh coords" );
   if ( lor_mesh_.get() ) {
+    TRIBOL_MARK_BEGIN( "Update LOR coords" );
     auto lor_nodes = dynamic_cast<mfem::ParGridFunction*>( lor_mesh_->GetNodes() );
     SLIC_ERROR_ROOT_IF( !lor_nodes, "lor_mesh_ Nodes is not a ParGridFunction." );
     submesh_lor_xfer_->SubmeshToLOR( *submesh_nodes, *lor_nodes );
+    TRIBOL_MARK_END( "Update LOR coords" );
   }
+  TRIBOL_MARK_BEGIN( "Build new Redecomp mesh" );
   update_data_ = std::make_unique<UpdateData>( submesh_, lor_mesh_.get(), *coords_.GetParentGridFn().ParFESpace(),
                                                submesh_xfer_gridfn_, submesh_lor_xfer_.get(), attributes_1_,
                                                attributes_2_, binning_proximity_scale, allocator_id_, n_ranks );
+  TRIBOL_MARK_END( "Build new Redecomp mesh" );
+
+  TRIBOL_MARK_BEGIN( "Copy fields to Redecomp mesh" );
   coords_.UpdateField( update_data_->vector_xfer_, use_device_ );
   // NOTE: SetSpace() would be preferrable to call here, but it looks like all memory isn't mapped to
   // mfem::MemoryManager when this is used. TODO: Debug this and switch to SetSpace()
@@ -371,12 +377,14 @@ void MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
   if ( velocity_ ) {
     velocity_->UpdateField( update_data_->vector_xfer_, use_device_ );
   }
+  TRIBOL_MARK_END( "Copy fields to Redecomp mesh" );
   if ( elem_thickness_ ) {
     if ( !material_modulus_ ) {
       SLIC_ERROR_ROOT(
           "Kinematic element penalty requires material modulus information. "
           "Call registerMfemMaterialModulus() to set this." );
     }
+    TRIBOL_MARK_BEGIN( "Copy element thickness to Redecomp mesh" );
     redecomp::RedecompTransfer redecomp_xfer;
     // set element thickness on redecomp mesh
     redecomp_elem_thickness_ =
@@ -430,6 +438,7 @@ void MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
                 [tribol_m2_view, redecomp_m_view, elem_map2_view] TRIBOL_HOST_DEVICE( int i ) {
                   tribol_m2_view[i] = redecomp_m_view[elem_map2_view[i]];
                 } );
+    TRIBOL_MARK_END( "Copy element thickness to Redecomp mesh" );
   }
 }
 

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -5,11 +5,15 @@
 
 #include "tribol/mesh/MfemData.hpp"
 
+#include "tribol/config.hpp"
+
 #ifdef BUILD_REDECOMP
 
 #include "axom/slic.hpp"
 
 #include "redecomp/utils/ArrayUtility.hpp"
+
+#include "tribol/utils/Profiling.hpp"
 
 namespace tribol {
 
@@ -338,6 +342,7 @@ void MfemMeshData::SetParentReferenceCoords( const mfem::ParGridFunction& refere
 
 void MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_ranks )
 {
+  TRIBOL_MARK_FUNCTION;
   // update coordinates of submesh and LOR mesh
   auto submesh_nodes = dynamic_cast<mfem::ParGridFunction*>( submesh_.GetNodes() );
   SLIC_ERROR_ROOT_IF( !submesh_nodes, "submesh_ Nodes is not a ParGridFunction." );

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -40,6 +40,7 @@ void SubmeshLORTransfer::TransferFromLORVector( mfem::Vector& submesh_dst ) cons
 
 void SubmeshLORTransfer::SubmeshToLOR( const mfem::ParGridFunction& submesh_src, mfem::ParGridFunction& lor_dst )
 {
+  TRIBOL_MARK_FUNCTION;
   // make sure host data is up to date.  this transfer needs to be on the host until submesh supports device transfer
   submesh_src.HostRead();
   lor_dst.HostWrite();
@@ -346,7 +347,9 @@ void MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
   // update coordinates of submesh and LOR mesh
   auto submesh_nodes = dynamic_cast<mfem::ParGridFunction*>( submesh_.GetNodes() );
   SLIC_ERROR_ROOT_IF( !submesh_nodes, "submesh_ Nodes is not a ParGridFunction." );
+  TRIBOL_MARK_BEGIN( "SubMesh coords transfer" );
   submesh_.Transfer( coords_.GetParentGridFn(), *submesh_nodes );
+  TRIBOL_MARK_END( "SubMesh coords transfer" );
   if ( lor_mesh_.get() ) {
     auto lor_nodes = dynamic_cast<mfem::ParGridFunction*>( lor_mesh_->GetNodes() );
     SLIC_ERROR_ROOT_IF( !lor_nodes, "lor_mesh_ Nodes is not a ParGridFunction." );
@@ -589,6 +592,7 @@ MfemMeshData::UpdateData::UpdateData( mfem::ParSubMesh& submesh, mfem::ParMesh* 
       vector_xfer_{ parent_fes, submesh_gridfn, submesh_lor_xfer, redecomp_mesh_ },
       allocator_id_{ allocator_id }
 {
+  TRIBOL_MARK_FUNCTION;
   // set element type based on redecomp mesh
   SetElementData();
   // updates the connectivity of the tribol surface mesh

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -11,9 +11,9 @@
 
 #include "axom/slic.hpp"
 
-#include "redecomp/utils/ArrayUtility.hpp"
+#include "shared/infrastructure/Profiling.hpp"
 
-#include "tribol/utils/Profiling.hpp"
+#include "redecomp/utils/ArrayUtility.hpp"
 
 namespace tribol {
 
@@ -228,6 +228,7 @@ ParentField::UpdateData::UpdateData( ParentRedecompTransfer& parent_redecomp_xfe
                                      const mfem::ParGridFunction& parent_gridfn, bool use_device )
     : parent_redecomp_xfer_{ parent_redecomp_xfer }, redecomp_gridfn_{ &parent_redecomp_xfer.GetRedecompFESpace() }
 {
+  TRIBOL_MARK_FUNCTION;
   redecomp_gridfn_.UseDevice( use_device );
   redecomp_gridfn_ = 0.0;
   parent_redecomp_xfer_.ParentToRedecomp( parent_gridfn, redecomp_gridfn_ );

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -6,7 +6,8 @@
 #ifndef SRC_MESH_MFEMDATA_HPP_
 #define SRC_MESH_MFEMDATA_HPP_
 
-#include "tribol/common/BasicTypes.hpp"
+// Tribol config include
+#include "tribol/config.hpp"
 
 #ifdef BUILD_REDECOMP
 
@@ -18,6 +19,7 @@
 #include "axom/core.hpp"
 #include "redecomp/redecomp.hpp"
 
+#include "tribol/common/BasicTypes.hpp"
 #include "tribol/common/Parameters.hpp"
 #include "tribol/mesh/MethodCouplingData.hpp"
 


### PR DESCRIPTION
This PR does 2 things:
- moves caliper to `tribol_shared` to allow profiling in redecomp and Tribol
- adds annotations to `updateMfemParallelDecompsition()` and the functions that it calls to get a better idea of where time is spent in this routine