### PR TITLE
MFEM missing config info when including enzyme header only

### DIFF
--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -9,7 +9,7 @@
 #include "tribol/utils/Math.hpp"
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/mfem.hpp"
+#include "mfem.hpp"
 #endif
 
 #include "axom/core.hpp"

--- a/src/tribol/geom/GeomUtilities.cpp
+++ b/src/tribol/geom/GeomUtilities.cpp
@@ -9,7 +9,7 @@
 #include "tribol/utils/Math.hpp"
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/general/enzyme.hpp"
+#include "mfem/mfem.hpp"
 #endif
 
 #include "axom/core.hpp"

--- a/src/tribol/geom/NodalNormal.cpp
+++ b/src/tribol/geom/NodalNormal.cpp
@@ -9,7 +9,7 @@
 #include "tribol/utils/Math.hpp"
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/general/enzyme.hpp"
+#include "mfem/mfem.hpp"
 #endif
 
 namespace tribol {

--- a/src/tribol/geom/NodalNormal.cpp
+++ b/src/tribol/geom/NodalNormal.cpp
@@ -9,7 +9,7 @@
 #include "tribol/utils/Math.hpp"
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/mfem.hpp"
+#include "mfem.hpp"
 #endif
 
 namespace tribol {

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -25,7 +25,7 @@
 #include <iomanip>
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/general/enzyme.hpp"
+#include "mfem/mfem.hpp"
 #endif
 
 namespace tribol {

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -25,7 +25,7 @@
 #include <iomanip>
 
 #ifdef TRIBOL_USE_ENZYME
-#include "mfem/mfem.hpp"
+#include "mfem.hpp"
 #endif
 
 namespace tribol {


### PR DESCRIPTION
Fixes the following error:

```
In file included from /usr/WS2/meemee/smith/repo/tribol/src/tribol/geom/GeomUtilities.cpp:12:
In file included from /usr/WS2/meemee/smith/repo/mfem/general/enzyme.hpp:12:
/usr/WS2/meemee/smith/repo/mfem/general/../config/config.hpp:50:2: error: "Either DOUBLE or SINGLE precision must be specified"
   50 | #error "Either DOUBLE or SINGLE precision must be specified"
      |  ^
/usr/WS2/meemee/smith/repo/mfem/general/../config/config.hpp:54:11: error: unknown type name 'real_t'
   54 | constexpr real_t operator""_r(long double v)
      |           ^
/usr/WS2/meemee/smith/repo/mfem/general/../config/config.hpp:56:23: error: unknown type name 'real_t'
   56 |    return static_cast<real_t>(v);
      |                       ^
/usr/WS2/meemee/smith/repo/mfem/general/../config/config.hpp:60:11: error: unknown type name 'real_t'
   60 | constexpr real_t operator""_r(unsigned long long v)
      |           ^
/usr/WS2/meemee/smith/repo/mfem/general/../config/config.hpp:62:23: error: unknown type name 'real_t'
   62 |    return static_cast<real_t>(v);
      |                       ^
```