### PR TITLE
Fix race condition

### DIFF
--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1067,7 +1067,11 @@ int CouplingScheme::apply( int cycle, RealT t, RealT& dt )
                 // TODO refine how these errors are handled. Here we skip over face-pairs with errors. That is,
                 // they are not registered for contact, but we don't error out.
                 if ( interact_err != NO_FACE_GEOM_EXCEPTION ) {
+#ifdef TRIBOL_USE_RAJA
+                  RAJA::atomicMax<RAJA::auto_atomic>( &pair_err[0], 1 );
+#else
                   pair_err[0] = 1;
+#endif
                   pair.m_is_contact_candidate = false;
                   // TODO consider printing offending face(s) coordinates for debugging
                   // SLIC_DEBUG("Face geometry error, " << static_cast<int>(interact_err) << "for pair, " << kp << ".");


### PR DESCRIPTION
This is technically a race condition if more than one thread set the same value, though in practice it will probably work fine without the atomic.  This is, however, detected by thread sanitizer.