### PR TITLE
Workaround for CUDA failure that can occur for optimized code

### DIFF
--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -127,7 +127,7 @@ class CartesianProduct : public SearchBase {
     contactPairs.resize( countArray_host[0] );
 
     int zero = 0;
-    axom::copy(countArray.data(), &zero, sizeof(int));
+    axom::copy( countArray.data(), &zero, sizeof(int) );
     auto pairs_view = m_coupling_scheme->getInterfacePairs().view();
     // fill proximate pairs array
     forAllExec(

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -128,7 +128,7 @@ class CartesianProduct : public SearchBase {
 
     int zero = 0;
     // Workaround for axom::Array::fill() issue for optimized CUDA code, see Axom #1833.
-    axom::copy( countArray.data(), &zero, sizeof(int) );
+    axom::copy( countArray.data(), &zero, sizeof( int ) );
     auto pairs_view = m_coupling_scheme->getInterfacePairs().view();
     // fill proximate pairs array
     forAllExec(

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -126,7 +126,8 @@ class CartesianProduct : public SearchBase {
     auto& contactPairs = m_coupling_scheme->getInterfacePairs();
     contactPairs.resize( countArray_host[0] );
 
-    countArray.fill( 0 );
+    int zero = 0;
+    axom::copy(countArray.data(), &zero, sizeof(int));
     auto pairs_view = m_coupling_scheme->getInterfacePairs().view();
     // fill proximate pairs array
     forAllExec(

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -127,6 +127,7 @@ class CartesianProduct : public SearchBase {
     contactPairs.resize( countArray_host[0] );
 
     int zero = 0;
+    // Workaround for axom::Array::fill() issue for optimized CUDA code, see Axom #1833.
     axom::copy( countArray.data(), &zero, sizeof(int) );
     auto pairs_view = m_coupling_scheme->getInterfacePairs().view();
     // fill proximate pairs array


### PR DESCRIPTION
Workaround for a CUDA segfault that only occurs for optimized code.
The longer term solution is probably using an axom reducer.

The issue is referenced in
https://github.com/llnl/axom/issues/1833