### PR TITLE
Fix mac build warnings

### DIFF
--- a/cmake/SetupThirdParty.cmake
+++ b/cmake/SetupThirdParty.cmake
@@ -186,6 +186,26 @@ foreach(_target ${_imported_targets})
     endif()
 endforeach()
 
+set(_mfem_targets
+        mfem
+        axom::mfem)
+
+# On Apple, Spack-built cmake configs embed literal -Wl,-rpath,... entries in
+# INTERFACE_LINK_LIBRARIES. These duplicate CMake's own rpath management
+# (CMAKE_INSTALL_RPATH_USE_LINK_PATH) and cause ld "duplicate -rpath" warnings.
+if(APPLE)
+    foreach(_target ${_mfem_targets})
+        if(TARGET ${_target})
+            get_target_property(_link_libs ${_target} INTERFACE_LINK_LIBRARIES)
+            if(_link_libs)
+                list(FILTER _link_libs EXCLUDE REGEX "^-Wl,-rpath,")
+                set_target_properties(${_target} PROPERTIES INTERFACE_LINK_LIBRARIES "${_link_libs}")
+            endif()
+        endif()
+    endforeach()
+    unset(_link_libs)
+endif()
+
 # export tribol-targets
 foreach(dep ${EXPORTED_TPL_DEPS})
   # If the target is EXPORTABLE, add it to the export set

--- a/cmake/TribolCompilerFlags.cmake
+++ b/cmake/TribolCompilerFlags.cmake
@@ -12,3 +12,11 @@ endif()
 
 # Need to add symbols to dynamic symtab in order to be visible from stacktraces
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
+
+# Apple ld warns about duplicate -l flags when the same library is reachable
+# via multiple dependency paths (common with Spack-built CMake targets that use
+# raw -l strings instead of imported targets). Suppress the spurious warning.
+if(APPLE)
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-no_warn_duplicate_libraries")
+endif()
+

--- a/cmake/thirdparty/SetupMFEM.cmake
+++ b/cmake/thirdparty/SetupMFEM.cmake
@@ -101,6 +101,17 @@ else()
         string(FIND  "${mfem_tpl_lnk_flags}" "\n" mfem_tpl_lnl_flags_end_pos )
         string(SUBSTRING "${mfem_tpl_lnk_flags}" 0 ${mfem_tpl_lnl_flags_end_pos} mfem_tpl_lnk_flags)
         string(STRIP "${mfem_tpl_lnk_flags}" mfem_tpl_lnk_flags)
+        
+        # filter out items containing "Xlinker"
+        set(_mfem_tpl_list ${mfem_tpl_lnk_flags})
+        separate_arguments(_mfem_tpl_list)
+        list(FILTER _mfem_tpl_list EXCLUDE REGEX Xlinker)
+        # On Apple, -Wl,-rpath,... entries duplicate CMake's own rpath management
+        # (CMAKE_INSTALL_RPATH_USE_LINK_PATH) and cause ld "duplicate -rpath" warnings
+        if(APPLE)
+            list(FILTER _mfem_tpl_list EXCLUDE REGEX "^-Wl,-rpath,")
+        endif()
+        list(JOIN _mfem_tpl_list " " mfem_tpl_lnk_flags)
     else()
         message(WARNING "No third party library flags found in ${MFEM_CFG_DIR}/config.mk")
     endif()

--- a/src/redecomp/RedecompMesh.cpp
+++ b/src/redecomp/RedecompMesh.cpp
@@ -300,7 +300,7 @@ void RedecompMesh::BuildRedecomp()
     }
     return parent_gelems;
   } );
-  for ( int i{ 1 }; i < r2p_ghost_elems_.size(); ++i ) {
+  for ( size_t i{ 1 }; i < r2p_ghost_elems_.size(); ++i ) {
     for ( auto& recv_gelem : r2p_ghost_elems_[i] ) {
       recv_gelem += r2p_elem_offsets_[i];
     }


### PR DESCRIPTION
Brings over duplicate rpath linker warning fixes from [Smith #1563](https://github.com/llnl/smith/pull/1563) and fix a compiler warning.