### PR TITLE
Consolidate atomic operations

### DIFF
--- a/src/tribol/CMakeLists.txt
+++ b/src/tribol/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 set(tribol_headers
 
     common/ArrayTypes.hpp
+    common/Atomics.hpp
     common/BasicTypes.hpp
     common/Containers.hpp
     common/Enzyme.hpp

--- a/src/tribol/common/Atomics.hpp
+++ b/src/tribol/common/Atomics.hpp
@@ -16,49 +16,53 @@
 namespace tribol {
 
 template <typename T, typename U>
-TRIBOL_HOST_DEVICE inline T atomicAdd(T* addr, U val) {
+TRIBOL_HOST_DEVICE inline T atomicAdd( T* addr, U val )
+{
 #ifdef TRIBOL_USE_RAJA
-    return RAJA::atomicAdd<RAJA::auto_atomic>(addr, static_cast<T>(val));
+  return RAJA::atomicAdd<RAJA::auto_atomic>( addr, static_cast<T>( val ) );
 #else
-    T old = *addr;
-    *addr += static_cast<T>(val);
-    return old;
+  T old = *addr;
+  *addr += static_cast<T>( val );
+  return old;
 #endif
 }
 
 template <typename T, typename U>
-TRIBOL_HOST_DEVICE inline T atomicMin(T* addr, U val) {
+TRIBOL_HOST_DEVICE inline T atomicMin( T* addr, U val )
+{
 #ifdef TRIBOL_USE_RAJA
-    return RAJA::atomicMin<RAJA::auto_atomic>(addr, static_cast<T>(val));
+  return RAJA::atomicMin<RAJA::auto_atomic>( addr, static_cast<T>( val ) );
 #else
-    T old = *addr;
-    *addr = axom::utilities::min(*addr, static_cast<T>(val));
-    return old;
+  T old = *addr;
+  *addr = axom::utilities::min( *addr, static_cast<T>( val ) );
+  return old;
 #endif
 }
 
 template <typename T, typename U>
-TRIBOL_HOST_DEVICE inline T atomicMax(T* addr, U val) {
+TRIBOL_HOST_DEVICE inline T atomicMax( T* addr, U val )
+{
 #ifdef TRIBOL_USE_RAJA
-    return RAJA::atomicMax<RAJA::auto_atomic>(addr, static_cast<T>(val));
+  return RAJA::atomicMax<RAJA::auto_atomic>( addr, static_cast<T>( val ) );
 #else
-    T old = *addr;
-    *addr = axom::utilities::max(*addr, static_cast<T>(val));
-    return old;
+  T old = *addr;
+  *addr = axom::utilities::max( *addr, static_cast<T>( val ) );
+  return old;
 #endif
 }
 
 template <typename T>
-TRIBOL_HOST_DEVICE inline T atomicInc(T* addr) {
+TRIBOL_HOST_DEVICE inline T atomicInc( T* addr )
+{
 #ifdef TRIBOL_USE_RAJA
-    return RAJA::atomicInc<RAJA::auto_atomic>(addr);
+  return RAJA::atomicInc<RAJA::auto_atomic>( addr );
 #else
-    T old = *addr;
-    (*addr)++;
-    return old;
+  T old = *addr;
+  ( *addr )++;
+  return old;
 #endif
 }
 
-} // namespace tribol
+}  // namespace tribol
 
 #endif /* SRC_TRIBOL_COMMON_ATOMICS_HPP_ */

--- a/src/tribol/common/Atomics.hpp
+++ b/src/tribol/common/Atomics.hpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Tribol Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (MIT)
+
+#ifndef SRC_TRIBOL_COMMON_ATOMICS_HPP_
+#define SRC_TRIBOL_COMMON_ATOMICS_HPP_
+
+#include "tribol/common/ExecModel.hpp"
+#include "axom/core.hpp"
+
+#ifdef TRIBOL_USE_RAJA
+#include "RAJA/RAJA.hpp"
+#endif
+
+namespace tribol {
+
+template <typename T, typename U>
+TRIBOL_HOST_DEVICE inline T atomicAdd(T* addr, U val) {
+#ifdef TRIBOL_USE_RAJA
+    return RAJA::atomicAdd<RAJA::auto_atomic>(addr, static_cast<T>(val));
+#else
+    T old = *addr;
+    *addr += static_cast<T>(val);
+    return old;
+#endif
+}
+
+template <typename T, typename U>
+TRIBOL_HOST_DEVICE inline T atomicMin(T* addr, U val) {
+#ifdef TRIBOL_USE_RAJA
+    return RAJA::atomicMin<RAJA::auto_atomic>(addr, static_cast<T>(val));
+#else
+    T old = *addr;
+    *addr = axom::utilities::min(*addr, static_cast<T>(val));
+    return old;
+#endif
+}
+
+template <typename T, typename U>
+TRIBOL_HOST_DEVICE inline T atomicMax(T* addr, U val) {
+#ifdef TRIBOL_USE_RAJA
+    return RAJA::atomicMax<RAJA::auto_atomic>(addr, static_cast<T>(val));
+#else
+    T old = *addr;
+    *addr = axom::utilities::max(*addr, static_cast<T>(val));
+    return old;
+#endif
+}
+
+template <typename T>
+TRIBOL_HOST_DEVICE inline T atomicInc(T* addr) {
+#ifdef TRIBOL_USE_RAJA
+    return RAJA::atomicInc<RAJA::auto_atomic>(addr);
+#else
+    T old = *addr;
+    (*addr)++;
+    return old;
+#endif
+}
+
+} // namespace tribol
+
+#endif /* SRC_TRIBOL_COMMON_ATOMICS_HPP_ */

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -12,6 +12,7 @@
 #include "tribol/mesh/MeshData.hpp"
 #include "tribol/mesh/InterfacePairs.hpp"
 #include "tribol/common/Parameters.hpp"
+#include "tribol/common/Atomics.hpp"
 
 namespace tribol {
 
@@ -975,12 +976,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CheckInterfacePairByMethod(
     SLIC_DEBUG( "face_err: " << face_err );
 #endif
   } else if ( my_plane.m_inContact ) {
-#ifdef TRIBOL_USE_RAJA
-    auto idx = RAJA::atomicInc<RAJA::auto_atomic>( plane_ct );
-#else
-    auto idx = *plane_ct;
-    ++( *plane_ct );
-#endif
+    auto idx = tribol::atomicInc( plane_ct );
     cg.getPlane<T>( idx ) = my_plane;
     isInteracting = true;
   } else {

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -1054,7 +1054,7 @@ int CouplingScheme::apply( int cycle, RealT t, RealT& dt )
   // array of size one for counting number of planes on device
   ArrayT<IndexT> planes_ct_data( 1, 1, getAllocatorId() );
   auto planes_ct = planes_ct_data.view();
-// Note: A true reduction would be more efficient here.
+  // Note: A true reduction would be more efficient here.
   // However, it is not currently implemented because forAllExec would need
   // to know the execution mode at compile time to instantiate the correct reducer.
   forAllExec( getExecutionMode(), numPairs,
@@ -1321,7 +1321,7 @@ void CouplingScheme::computeCommonPlaneTimeStep( RealT& dt )
                              static_cast<IndexT>( false ) },
                            getAllocatorId() );
   ArrayViewT<IndexT> msg = msg_data;
-// Note: A true reduction would be more efficient here.
+  // Note: A true reduction would be more efficient here.
   // However, it is not currently implemented because forAllExec would need
   // to know the execution mode at compile time to instantiate the correct reducer.
   forAllExec( getExecutionMode(), getNumActivePairs(),

--- a/src/tribol/mesh/CouplingScheme.cpp
+++ b/src/tribol/mesh/CouplingScheme.cpp
@@ -17,6 +17,7 @@
 // Tribol includes
 #include "tribol/common/ExecModel.hpp"
 #include "tribol/common/LoopExec.hpp"
+#include "tribol/common/Atomics.hpp"
 #include "tribol/geom/ElementNormal.hpp"
 #include "tribol/geom/GeomUtilities.hpp"
 #include "tribol/mesh/MethodCouplingData.hpp"
@@ -1053,6 +1054,9 @@ int CouplingScheme::apply( int cycle, RealT t, RealT& dt )
   // array of size one for counting number of planes on device
   ArrayT<IndexT> planes_ct_data( 1, 1, getAllocatorId() );
   auto planes_ct = planes_ct_data.view();
+// Note: A true reduction would be more efficient here.
+  // However, it is not currently implemented because forAllExec would need
+  // to know the execution mode at compile time to instantiate the correct reducer.
   forAllExec( getExecutionMode(), numPairs,
               [pairs, mesh1, mesh2, params, contact_method, contact_case, cg_view, planes_ct,
                pair_err] TRIBOL_HOST_DEVICE( IndexT i ) mutable {
@@ -1072,11 +1076,7 @@ int CouplingScheme::apply( int cycle, RealT t, RealT& dt )
                 // TODO refine how these errors are handled. Here we skip over face-pairs with errors. That is,
                 // they are not registered for contact, but we don't error out.
                 if ( interact_err != NO_FACE_GEOM_EXCEPTION ) {
-#ifdef TRIBOL_USE_RAJA
-                  RAJA::atomicMax<RAJA::auto_atomic>( &pair_err[0], 1 );
-#else
-                  pair_err[0] = 1;
-#endif
+                  tribol::atomicMax( &pair_err[0], 1 );
                   pair.m_is_contact_candidate = false;
                   // TODO consider printing offending face(s) coordinates for debugging
                   // SLIC_DEBUG("Face geometry error, " << static_cast<int>(interact_err) << "for pair, " << kp << ".");
@@ -1321,6 +1321,9 @@ void CouplingScheme::computeCommonPlaneTimeStep( RealT& dt )
                              static_cast<IndexT>( false ) },
                            getAllocatorId() );
   ArrayViewT<IndexT> msg = msg_data;
+// Note: A true reduction would be more efficient here.
+  // However, it is not currently implemented because forAllExec would need
+  // to know the execution mode at compile time to instantiate the correct reducer.
   forAllExec( getExecutionMode(), getNumActivePairs(),
               [cs_view, dim, proj_ratio, msg, dt_temp, dt] TRIBOL_HOST_DEVICE( IndexT i ) {
                 auto& cg_view = cs_view.getCompGeomView();
@@ -1497,13 +1500,8 @@ void CouplingScheme::computeCommonPlaneTimeStep( RealT& dt )
                   dt1_check1 = ( dt1_vel_check ) ? exceed_max_gap1 : false;
                   dt2_check1 = ( dt2_vel_check ) ? exceed_max_gap2 : false;
 
-#ifdef TRIBOL_USE_RAJA
-                  RAJA::atomicMax<RAJA::auto_atomic>( &msg[0], static_cast<IndexT>( exceed_max_gap1 ) );
-                  RAJA::atomicMax<RAJA::auto_atomic>( &msg[1], static_cast<IndexT>( exceed_max_gap2 ) );
-#else
-                  msg[0] = exceed_max_gap1;
-                  msg[1] = exceed_max_gap2;
-#endif
+                  tribol::atomicMax( &msg[0], static_cast<IndexT>( exceed_max_gap1 ) );
+                  tribol::atomicMax( &msg[1], static_cast<IndexT>( exceed_max_gap2 ) );
 
                   // compute dt for face 1 and 2 based on the velocity and gap projections onto
                   // the face-normals for faces where currect gap exceeds max allowable gap.
@@ -1530,26 +1528,14 @@ void CouplingScheme::computeCommonPlaneTimeStep( RealT& dt )
 
                   // update dt_temp1 only for positive dt1 and/or dt2
                   if ( dt1 > 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMin<RAJA::auto_atomic>( &dt_temp[0], axom::utilities::min( dt1, 1.e6 ) );
-#else
-                    dt_temp[0] = axom::utilities::min(dt_temp[0], axom::utilities::min(dt1, 1.e6));
-#endif
+                    tribol::atomicMin( &dt_temp[0], axom::utilities::min( dt1, 1.e6 ) );
                   }
                   if ( dt2 > 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMin<RAJA::auto_atomic>( &dt_temp[0], axom::utilities::min( 1.e6, dt2 ) );
-#else
-                    dt_temp[0] = axom::utilities::min(dt_temp[0], axom::utilities::min(1.e6, dt2));
-#endif
+                    tribol::atomicMin( &dt_temp[0], axom::utilities::min( 1.e6, dt2 ) );
                   }
 
                   if ( dt1 < 0. || dt2 < 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMax<RAJA::auto_atomic>( &msg[2], static_cast<IndexT>( true ) );
-#else
-                    msg[2] = true;
-#endif
+                    tribol::atomicMax( &msg[2], static_cast<IndexT>( true ) );
                   }
                 }  // end case 1
 
@@ -1650,25 +1636,13 @@ void CouplingScheme::computeCommonPlaneTimeStep( RealT& dt )
 
                   // update dt_temp2 only for positive dt1 and/or dt2
                   if ( dt1 > 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMin<RAJA::auto_atomic>( &dt_temp[1], axom::utilities::min( dt1, 1.e6 ) );
-#else
-                    dt_temp[1] = axom::utilities::min(dt_temp[1], axom::utilities::min(dt1, 1.e6));
-#endif
+                    tribol::atomicMin( &dt_temp[1], axom::utilities::min( dt1, 1.e6 ) );
                   }
                   if ( dt2 > 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMin<RAJA::auto_atomic>( &dt_temp[1], axom::utilities::min( 1.e6, dt2 ) );
-#else
-                    dt_temp[1] = axom::utilities::min(dt_temp[1], axom::utilities::min(1.e6, dt2));
-#endif
+                    tribol::atomicMin( &dt_temp[1], axom::utilities::min( 1.e6, dt2 ) );
                   }
                   if ( dt1 < 0. || dt2 < 0. ) {
-#ifdef TRIBOL_USE_RAJA
-                    RAJA::atomicMax<RAJA::auto_atomic>( &msg[3], static_cast<IndexT>( true ) );
-#else
-                    msg[3] = true;
-#endif
+                    tribol::atomicMax( &msg[3], static_cast<IndexT>( true ) );
                   }
 
                 }  // end check 2

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -15,6 +15,7 @@
 
 #include "tribol/common/ExecModel.hpp"
 #include "tribol/common/LoopExec.hpp"
+#include "tribol/common/Atomics.hpp"
 #include "tribol/geom/ElementNormal.hpp"
 #include "tribol/utils/Math.hpp"
 
@@ -68,20 +69,15 @@ bool MeshElemData::isValidKinematicPenalty( PenaltyEnforcementOptions& pen_optio
       Array1DView<const RealT> mod = this->m_mat_mod;
       Array1DView<const RealT> thickness = this->m_thickness;
 
+// Note: A true reduction would be more efficient here.
+      // However, it is not currently implemented because forAllExec would need
+      // to know the execution mode at compile time to instantiate the correct reducer.
       forAllExec( exec_mode, this->m_num_cells, [mod, thickness, mod_ok, thickness_ok] TRIBOL_HOST_DEVICE( IndexT i ) {
         if ( mod[i] <= 0. ) {
-#ifdef TRIBOL_USE_RAJA
-          RAJA::atomicMin<RAJA::auto_atomic>( mod_ok.data(), static_cast<IndexT>( false ) );
-#else
-          mod_ok[0] = false;
-#endif
+          tribol::atomicMin( mod_ok.data(), static_cast<IndexT>( false ) );
         }
         if ( thickness[i] <= 0. ) {
-#ifdef TRIBOL_USE_RAJA
-          RAJA::atomicMin<RAJA::auto_atomic>( thickness_ok.data(), static_cast<IndexT>( false ) );
-#else
-          thickness_ok[0] = false;
-#endif
+          tribol::atomicMin( thickness_ok.data(), static_cast<IndexT>( false ) );
         }
       } );  // end element loop
 

--- a/src/tribol/mesh/MeshData.cpp
+++ b/src/tribol/mesh/MeshData.cpp
@@ -69,7 +69,7 @@ bool MeshElemData::isValidKinematicPenalty( PenaltyEnforcementOptions& pen_optio
       Array1DView<const RealT> mod = this->m_mat_mod;
       Array1DView<const RealT> thickness = this->m_thickness;
 
-// Note: A true reduction would be more efficient here.
+      // Note: A true reduction would be more efficient here.
       // However, it is not currently implemented because forAllExec would need
       // to know the execution mode at compile time to instantiate the correct reducer.
       forAllExec( exec_mode, this->m_num_cells, [mod, thickness, mod_ok, thickness_ok] TRIBOL_HOST_DEVICE( IndexT i ) {

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -351,7 +351,7 @@ bool MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
     max_diff.UseDevice( use_device_ );
     max_diff = 0.0;
     RealT* d_max_diff = max_diff.Write( use_device_ );
-// Note: A true reduction would be more efficient here.
+    // Note: A true reduction would be more efficient here.
     // However, it is not currently implemented because forAllExec would need
     // to know the execution mode at compile time to instantiate the correct reducer.
     forAllExec( exec_mode_, current_coords_gf.Size(), [d_curr, d_last, d_max_diff] TRIBOL_HOST_DEVICE( int i ) {

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -17,6 +17,7 @@
 #include "redecomp/utils/ArrayUtility.hpp"
 
 #include "tribol/common/LoopExec.hpp"
+#include "tribol/common/Atomics.hpp"
 
 namespace tribol {
 
@@ -350,12 +351,11 @@ bool MfemMeshData::UpdateMfemMeshData( RealT binning_proximity_scale, int n_rank
     max_diff.UseDevice( use_device_ );
     max_diff = 0.0;
     RealT* d_max_diff = max_diff.Write( use_device_ );
+// Note: A true reduction would be more efficient here.
+    // However, it is not currently implemented because forAllExec would need
+    // to know the execution mode at compile time to instantiate the correct reducer.
     forAllExec( exec_mode_, current_coords_gf.Size(), [d_curr, d_last, d_max_diff] TRIBOL_HOST_DEVICE( int i ) {
-#ifdef TRIBOL_USE_RAJA
-      RAJA::atomicMax<RAJA::auto_atomic>( d_max_diff, std::abs( d_curr[i] - d_last[i] ) );
-#else
-      d_max_diff[0] = std::max( d_max_diff[0], std::abs( d_curr[i] - d_last[i] ) );
-#endif
+      tribol::atomicMax( d_max_diff, std::abs( d_curr[i] - d_last[i] ) );
     } );
     RealT* h_max_diff = max_diff.HostReadWrite();
     // Allreduce to get global max

--- a/src/tribol/physics/CommonPlane.cpp
+++ b/src/tribol/physics/CommonPlane.cpp
@@ -6,6 +6,7 @@
 #include "CommonPlane.hpp"
 
 #include "tribol/common/LoopExec.hpp"
+#include "tribol/common/Atomics.hpp"
 #include "tribol/mesh/MethodCouplingData.hpp"
 #include "tribol/mesh/CouplingScheme.hpp"
 #include "tribol/geom/CompGeom.hpp"
@@ -351,32 +352,17 @@ int ApplyNormal<COMMON_PLANE, PENALTY>( CouplingScheme* cs )
       // }
 
       // accumulate contributions in host code's registered nodal force arrays
-#ifdef TRIBOL_USE_RAJA
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[0][node0], -nodal_force_x1 );
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[0][node1], nodal_force_x2 );
+      tribol::atomicAdd( &mesh1.getResponse()[0][node0], -nodal_force_x1 );
+      tribol::atomicAdd( &mesh2.getResponse()[0][node1], nodal_force_x2 );
 
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[1][node0], -nodal_force_y1 );
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[1][node1], nodal_force_y2 );
+      tribol::atomicAdd( &mesh1.getResponse()[1][node0], -nodal_force_y1 );
+      tribol::atomicAdd( &mesh2.getResponse()[1][node1], nodal_force_y2 );
 
       // there is no z component for 2D
       if ( dim == 3 ) {
-        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[2][node0], -nodal_force_z1 );
-        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[2][node1], nodal_force_z2 );
+        tribol::atomicAdd( &mesh1.getResponse()[2][node0], -nodal_force_z1 );
+        tribol::atomicAdd( &mesh2.getResponse()[2][node1], nodal_force_z2 );
       }
-#else
-          mesh1.getResponse()[0][node0] -= nodal_force_x1;
-          mesh2.getResponse()[0][node1] += nodal_force_x2;
-
-          mesh1.getResponse()[1][node0] -= nodal_force_y1;
-          mesh2.getResponse()[1][node1] += nodal_force_y2;
-
-          // there is no z component for 2D
-          if (dim == 3)
-          {
-            mesh1.getResponse()[2][node0] -= nodal_force_z1;
-            mesh2.getResponse()[2][node1] += nodal_force_z2;
-          }
-#endif
     }  // end for loop over face nodes
 
     // comment out debug logs; too much output during tests. Keep for easy
@@ -560,32 +546,17 @@ int ApplyTangential<COMMON_PLANE, PENALTY, VISCOUS_TANGENTIAL>( CouplingScheme* 
       const RealT nodal_force_z2 = force_z * phi2[a];
 
       // accumulate contributions in host code's registered nodal force arrays
-#ifdef TRIBOL_USE_RAJA
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[0][node0], -nodal_force_x1 );
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[0][node1], nodal_force_x2 );
+      tribol::atomicAdd( &mesh1.getResponse()[0][node0], -nodal_force_x1 );
+      tribol::atomicAdd( &mesh2.getResponse()[0][node1], nodal_force_x2 );
 
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[1][node0], -nodal_force_y1 );
-      RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[1][node1], nodal_force_y2 );
+      tribol::atomicAdd( &mesh1.getResponse()[1][node0], -nodal_force_y1 );
+      tribol::atomicAdd( &mesh2.getResponse()[1][node1], nodal_force_y2 );
 
       // there is no z component for 2D
       if ( dim == 3 ) {
-        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh1.getResponse()[2][node0], -nodal_force_z1 );
-        RAJA::atomicAdd<RAJA::auto_atomic>( &mesh2.getResponse()[2][node1], nodal_force_z2 );
+        tribol::atomicAdd( &mesh1.getResponse()[2][node0], -nodal_force_z1 );
+        tribol::atomicAdd( &mesh2.getResponse()[2][node1], nodal_force_z2 );
       }
-#else
-          mesh1.getResponse()[0][node0] -= nodal_force_x1;
-          mesh2.getResponse()[0][node1] += nodal_force_x2;
-
-          mesh1.getResponse()[1][node0] -= nodal_force_y1;
-          mesh2.getResponse()[1][node1] += nodal_force_y2;
-
-          // there is no z component for 2D
-          if (dim == 3)
-          {
-            mesh1.getResponse()[2][node0] -= nodal_force_z1;
-            mesh2.getResponse()[2][node1] += nodal_force_z2;
-          }
-#endif
     }  // end for loop over face nodes
   } );
 

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -21,6 +21,7 @@
 #include "tribol/mesh/InterfacePairs.hpp"
 #include "tribol/utils/Algorithm.hpp"
 #include "tribol/common/LoopExec.hpp"
+#include "tribol/common/Atomics.hpp"
 
 // Define some namespace aliases to help with axom usage
 namespace primal = axom::primal;
@@ -110,13 +111,12 @@ class CartesianProduct : public SearchBase {
                     toIdx = i - offset;
                   }
                   isProximate[i] = geomFilter( cs_view, fromIdx, toIdx );
-#ifdef TRIBOL_USE_RAJA
-                  RAJA::atomicAdd<RAJA::auto_atomic>( pCount, static_cast<int>( isProximate[i] ) );
-#else
+                  // Note: A true reduction like axom::ReduceSum would be more efficient here.
+                  // However, it is not currently implemented because forAllExec would need
+                  // to know the execution mode at compile time to instantiate the correct reducer.
                   if ( isProximate[i] ) {
-                    ++( *pCount );
+                    tribol::atomicAdd( pCount, 1 );
                   }
-#endif
                 } );
 
     ArrayT<int, 1, MemorySpace::Host> countArray_host( countArray );
@@ -149,12 +149,7 @@ class CartesianProduct : public SearchBase {
           }
 
       // get unique index for the array
-#ifdef TRIBOL_USE_RAJA
-          auto idx = RAJA::atomicInc<RAJA::auto_atomic>( pCount );
-#else
-          auto idx = *pCount;
-          ++( *pCount );
-#endif
+          auto idx = tribol::atomicInc( pCount );
 
           pairs_view[idx] = InterfacePair( fromIdx, toIdx, true );
         } );
@@ -461,11 +456,7 @@ class BvhSearch : public SearchBase {
           auto mesh1_elem = candidates_view[i];
           auto mesh2_elem = algorithm::binarySearch( offsets_view, counts_view, i );
           if ( geomFilter( cs_view, mesh1_elem, mesh2_elem ) ) {
-#ifdef TRIBOL_USE_RAJA
-            RAJA::atomicInc<AtomicPolicy>( filtered_candidates.data() );
-#else
-            ++filtered_candidates[0];
-#endif
+            tribol::atomicInc( filtered_candidates.data() );
           } else {
             candidates_view[i] = -1;
           }
@@ -489,12 +480,7 @@ class BvhSearch : public SearchBase {
           auto mesh2_elem = algorithm::binarySearch( offsets_view, counts_view, i );
 
       // get unique index for the array
-#ifdef TRIBOL_USE_RAJA
-          auto idx = RAJA::atomicInc<AtomicPolicy>( filtered_candidates.data() );
-#else
-          auto idx = filtered_candidates[0];
-          ++filtered_candidates[0];
-#endif
+          auto idx = tribol::atomicInc( filtered_candidates.data() );
 
           pairs_view[idx] = InterfacePair( mesh1_elem, mesh2_elem, true );
         } );

--- a/src/tribol/search/InterfacePairFinder.cpp
+++ b/src/tribol/search/InterfacePairFinder.cpp
@@ -148,7 +148,7 @@ class CartesianProduct : public SearchBase {
             toIdx = i - offset;
           }
 
-      // get unique index for the array
+          // get unique index for the array
           auto idx = tribol::atomicInc( pCount );
 
           pairs_view[idx] = InterfacePair( fromIdx, toIdx, true );
@@ -479,7 +479,7 @@ class BvhSearch : public SearchBase {
           auto mesh1_elem = candidates_view[i];
           auto mesh2_elem = algorithm::binarySearch( offsets_view, counts_view, i );
 
-      // get unique index for the array
+          // get unique index for the array
           auto idx = tribol::atomicInc( filtered_candidates.data() );
 
           pairs_view[idx] = InterfacePair( mesh1_elem, mesh2_elem, true );


### PR DESCRIPTION
- Creates an atomics header with atomic operations in the tribol namespace (using RAJA where available)
- Adds notes where reducers might be more efficient. To do this, the execution mode of the `forAllExec()` call would need to be known at compile time, which would need some refactoring.