### PR TITLE
check TRIBOL_DEBUG to fix not defined error

### DIFF
--- a/config-build.py
+++ b/config-build.py
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+# Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and
 # other Tribol Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: (MIT)
@@ -31,6 +31,18 @@ def get_machine_name():
     return socket.gethostname().rstrip('1234567890')
 
 def get_default_host_config():
+    # Prefer the repo helper script when present. This allows SYS_TYPE-aware
+    # selection and compiler preference (e.g., prefer LLVM unless specified).
+    repodir = os.path.dirname(os.path.abspath(__file__))
+    helper = os.path.join(repodir, "skills", "building", "scripts", "determine_host_config")
+    if os.path.isfile(helper) and os.access(helper, os.X_OK):
+        try:
+            hostconfig = subprocess.check_output([helper, "--basename"], text=True).strip()
+            if hostconfig:
+                return hostconfig
+        except Exception:
+            pass
+
     machine_name = get_machine_name()
 
     if machine_name in _host_configs_map.keys():
@@ -73,8 +85,7 @@ def parse_arguments():
                         "--buildtype",
                         type=str,
                         choices=["Release", "Debug", "RelWithDebInfo", "MinSizeRel"],
-                        default="Debug",
-                        help="build type.")
+                        help="build type. defaults to Release")
 
     parser.add_argument("-e",
                         "--eclipse",
@@ -100,8 +111,11 @@ def parse_arguments():
                         action='store_true',
                         help="print the machine name for this system and exit")
 
+    parser.add_argument("-n", 
+                        "--ninja",
+                        action='store_true',
+                        help="use ninja generator to build Smith instead of make")
 
-    
     args, unknown_args = parser.parse_known_args()
     if unknown_args:
         print("[config-build]: Passing the following arguments directly to cmake... %s" % unknown_args)
@@ -225,6 +239,7 @@ def create_cmake_command_line(args, unknown_args, buildpath, installpath, hostco
 
     # Add build type (opt or debug)
     cmakeline += " -DCMAKE_BUILD_TYPE=" + args.buildtype
+
     # Set install dir
     cmakeline += " -DCMAKE_INSTALL_PREFIX=%s" % installpath
 
@@ -233,6 +248,9 @@ def create_cmake_command_line(args, unknown_args, buildpath, installpath, hostco
 
     if args.eclipse:
         cmakeline += ' -G "Eclipse CDT4 - Unix Makefiles"'
+
+    if args.ninja:
+        cmakeline += ' -G Ninja'
 
     if unknown_args:
         cmakeline += " " + " ".join( unknown_args )
@@ -269,7 +287,7 @@ def run_cmake(buildpath, cmakeline):
 # Main
 ############################
 def main():
-    repodir = os.path.abspath(os.path.dirname(__file__))     
+    repodir = os.path.abspath(os.path.dirname(__file__))
     assert os.path.abspath(os.getcwd())==repodir, "config-build must be run from %s" % repodir
 
     args, unknown_args = parse_arguments()
@@ -286,6 +304,15 @@ def main():
           return True
        else:
           return False
+
+    if args.buildtype == None:
+        # Set default CMake build type
+        args.buildtype = "Release"
+        # If CMAKE_BUILD_TYPE was passed in as an argument, use that option instead
+        for unknown_arg in unknown_args:
+            if "-DCMAKE_BUILD_TYPE" in unknown_arg:
+                args.buildtype = unknown_arg.split("=")[1]
+                break
 
     basehostconfigpath = find_host_config(args, repodir)
     platform_info = get_platform_info(basehostconfigpath)

--- a/config-build.py
+++ b/config-build.py
@@ -31,18 +31,6 @@ def get_machine_name():
     return socket.gethostname().rstrip('1234567890')
 
 def get_default_host_config():
-    # Prefer the repo helper script when present. This allows SYS_TYPE-aware
-    # selection and compiler preference (e.g., prefer LLVM unless specified).
-    repodir = os.path.dirname(os.path.abspath(__file__))
-    helper = os.path.join(repodir, "skills", "building", "scripts", "determine_host_config")
-    if os.path.isfile(helper) and os.access(helper, os.X_OK):
-        try:
-            hostconfig = subprocess.check_output([helper, "--basename"], text=True).strip()
-            if hostconfig:
-                return hostconfig
-        except Exception:
-            pass
-
     machine_name = get_machine_name()
 
     if machine_name in _host_configs_map.keys():

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -793,19 +793,27 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
   // check to see if pointers have been set
+#ifdef TRIBOL_DEBUG
   bool deleteVels = false;
+#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->vx1 != nullptr ) {
       delete[] this->vx1;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
     if ( this->vy1 != nullptr ) {
       delete[] this->vy1;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
     if ( this->vz1 != nullptr ) {
       delete[] this->vz1;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
 
     allocRealArray( &this->vx1, this->numTotalNodes, valX );
@@ -816,15 +824,21 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->vx2 != nullptr ) {
       delete[] this->vx2;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
     if ( this->vy2 != nullptr ) {
       delete[] this->vy2;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
     if ( this->vz2 != nullptr ) {
       delete[] this->vz2;
+#ifdef TRIBOL_DEBUG
       deleteVels = true;
+#endif
     }
 
     allocRealArray( &this->vx2, this->numTotalNodes, valX );
@@ -836,8 +850,10 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
     SLIC_ERROR( "TestMesh::allocateAndSetVelocities(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteVels,
                  "TestMesh::allocateAndSetVelocities(): " << "a velocity array has been deleted and reallocated." );
+#endif
 
 }  // end TestMesh::allocateAndSetVelocities()
 
@@ -852,18 +868,24 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
   // check to see if pointers have been set
+#ifdef TRIBOL_DEBUG
   bool deleteData = false;
+#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_bulk_mod != nullptr ) {
       delete[] this->mortar_bulk_mod;
+#ifdef TRIBOL_DEBUG
       deleteData = true;
+#endif
     }
 
     allocRealArray( &this->mortar_bulk_mod, this->numMortarFaces, val );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_bulk_mod != nullptr ) {
       delete[] this->nonmortar_bulk_mod;
+#ifdef TRIBOL_DEBUG
       deleteData = true;
+#endif
     }
 
     allocRealArray( &this->nonmortar_bulk_mod, this->numNonmortarFaces, val );
@@ -871,8 +893,10 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
     SLIC_ERROR( "TestMesh::allocateAndSetBulkModulus(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetBulkModulus(): "
                                  << "a bulk modulus array has been deleted and reallocated." );
+#endif
 
 }  // end TestMesh::allocateAndSetBulkModulus()
 
@@ -880,18 +904,24 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
 void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
 {
   // check to see if pointers have been set
+#ifdef TRIBOL_DEBUG
   bool deleteData = false;
+#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_element_thickness != nullptr ) {
       delete[] this->mortar_element_thickness;
+#ifdef TRIBOL_DEBUG
       deleteData = true;
+#endif
     }
 
     allocRealArray( &this->mortar_element_thickness, this->numMortarFaces, t );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_element_thickness != nullptr ) {
       delete[] this->nonmortar_element_thickness;
+#ifdef TRIBOL_DEBUG
       deleteData = true;
+#endif
     }
 
     allocRealArray( &this->nonmortar_element_thickness, this->numNonmortarFaces, t );
@@ -899,8 +929,10 @@ void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
     SLIC_ERROR( "TestMesh::allocateAndSetElementThickness(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetElementThickness(): "
                                  << "an element thickness array has been deleted and reallocated." );
+#endif
 
 }  // end TestMesh::allocateAndSetElementThickness()
 

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -793,27 +793,19 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
 // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
   bool deleteVels = false;
-#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->vx1 != nullptr ) {
       delete[] this->vx1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vy1 != nullptr ) {
       delete[] this->vy1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vz1 != nullptr ) {
       delete[] this->vz1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
 
     allocRealArray( &this->vx1, this->numTotalNodes, valX );
@@ -824,21 +816,15 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->vx2 != nullptr ) {
       delete[] this->vx2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vy2 != nullptr ) {
       delete[] this->vy2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vz2 != nullptr ) {
       delete[] this->vz2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
 
     allocRealArray( &this->vx2, this->numTotalNodes, valX );
@@ -866,24 +852,18 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
   // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
   bool deleteData = false;
-#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_bulk_mod != nullptr ) {
       delete[] this->mortar_bulk_mod;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->mortar_bulk_mod, this->numMortarFaces, val );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_bulk_mod != nullptr ) {
       delete[] this->nonmortar_bulk_mod;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->nonmortar_bulk_mod, this->numNonmortarFaces, val );
@@ -900,24 +880,18 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
 void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
 {
   // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
   bool deleteData = false;
-#endif
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_element_thickness != nullptr ) {
       delete[] this->mortar_element_thickness;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->mortar_element_thickness, this->numMortarFaces, t );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_element_thickness != nullptr ) {
       delete[] this->nonmortar_element_thickness;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->nonmortar_element_thickness, this->numNonmortarFaces, t );

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -792,7 +792,7 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
                  "TestMesh::allocateAndSetVelocities(): please set unique "
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
-// check to see if pointers have been set
+  // check to see if pointers have been set
   bool deleteVels = false;
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->vx1 != nullptr ) {

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -793,27 +793,19 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
   // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
-  bool deleteVels = false;
-#endif
+  [[maybe_unused]] bool deleteVels = false;
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->vx1 != nullptr ) {
       delete[] this->vx1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vy1 != nullptr ) {
       delete[] this->vy1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vz1 != nullptr ) {
       delete[] this->vz1;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
 
     allocRealArray( &this->vx1, this->numTotalNodes, valX );
@@ -824,21 +816,15 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->vx2 != nullptr ) {
       delete[] this->vx2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vy2 != nullptr ) {
       delete[] this->vy2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
     if ( this->vz2 != nullptr ) {
       delete[] this->vz2;
-#ifdef TRIBOL_DEBUG
       deleteVels = true;
-#endif
     }
 
     allocRealArray( &this->vx2, this->numTotalNodes, valX );
@@ -850,10 +836,8 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
     SLIC_ERROR( "TestMesh::allocateAndSetVelocities(): " << "not a valid mesh id." );
   }
 
-#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteVels,
                  "TestMesh::allocateAndSetVelocities(): " << "a velocity array has been deleted and reallocated." );
-#endif
 
 }  // end TestMesh::allocateAndSetVelocities()
 
@@ -868,24 +852,18 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
                      << "mortarMeshId and nonmortarMeshId prior to calling this routine." );
 
   // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
-  bool deleteData = false;
-#endif
+  [[maybe_unused]] bool deleteData = false;
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_bulk_mod != nullptr ) {
       delete[] this->mortar_bulk_mod;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->mortar_bulk_mod, this->numMortarFaces, val );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_bulk_mod != nullptr ) {
       delete[] this->nonmortar_bulk_mod;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->nonmortar_bulk_mod, this->numNonmortarFaces, val );
@@ -893,10 +871,8 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
     SLIC_ERROR( "TestMesh::allocateAndSetBulkModulus(): " << "not a valid mesh id." );
   }
 
-#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetBulkModulus(): "
                                  << "a bulk modulus array has been deleted and reallocated." );
-#endif
 
 }  // end TestMesh::allocateAndSetBulkModulus()
 
@@ -904,24 +880,18 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
 void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
 {
   // check to see if pointers have been set
-#ifdef TRIBOL_DEBUG
-  bool deleteData = false;
-#endif
+  [[maybe_unused]] bool deleteData = false;
   if ( mesh_id == this->mortarMeshId ) {
     if ( this->mortar_element_thickness != nullptr ) {
       delete[] this->mortar_element_thickness;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->mortar_element_thickness, this->numMortarFaces, t );
   } else if ( mesh_id == this->nonmortarMeshId ) {
     if ( this->nonmortar_element_thickness != nullptr ) {
       delete[] this->nonmortar_element_thickness;
-#ifdef TRIBOL_DEBUG
       deleteData = true;
-#endif
     }
 
     allocRealArray( &this->nonmortar_element_thickness, this->numNonmortarFaces, t );
@@ -929,10 +899,8 @@ void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
     SLIC_ERROR( "TestMesh::allocateAndSetElementThickness(): " << "not a valid mesh id." );
   }
 
-#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetElementThickness(): "
                                  << "an element thickness array has been deleted and reallocated." );
-#endif
 
 }  // end TestMesh::allocateAndSetElementThickness()
 


### PR DESCRIPTION
fixes the following error

`/usr/WS2/meemee/lido/lido_tpls/toss_4_x86_64_ib/2026_07_28_10_36_28/build_stage/spack-stage-tribol-0.1.0.27-b5fab4p32rlralyaon7w3jszfb2cwatc/spack-src/src/tribol/utils/TestUtils.cpp:853:18: error: 'deleteVels' was not declared in this scope 853 | SLIC_DEBUG_IF( deleteVels, ...`

the issue is when axom is built as debug, but tribol is built as release. so SLIC_ERROR_IF runs, but `deleteVels` isn't set.