### PR TITLE
Fix error messages that occur building with gcc 16 on Fedora 44.

### DIFF
--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -850,8 +850,10 @@ void TestMesh::allocateAndSetVelocities( IndexT mesh_id, RealT valX, RealT valY,
     SLIC_ERROR( "TestMesh::allocateAndSetVelocities(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteVels,
                  "TestMesh::allocateAndSetVelocities(): " << "a velocity array has been deleted and reallocated." );
+#endif
 
 }  // end TestMesh::allocateAndSetVelocities()
 
@@ -891,8 +893,10 @@ void TestMesh::allocateAndSetBulkModulus( IndexT mesh_id, RealT val )
     SLIC_ERROR( "TestMesh::allocateAndSetBulkModulus(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetBulkModulus(): "
                                  << "a bulk modulus array has been deleted and reallocated." );
+#endif
 
 }  // end TestMesh::allocateAndSetBulkModulus()
 
@@ -925,8 +929,11 @@ void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
     SLIC_ERROR( "TestMesh::allocateAndSetElementThickness(): " << "not a valid mesh id." );
   }
 
+#ifdef TRIBOL_DEBUG
   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetElementThickness(): "
                                  << "an element thickness array has been deleted and reallocated." );
+#endif
+
 
 }  // end TestMesh::allocateAndSetElementThickness()
 

--- a/src/tribol/utils/TestUtils.cpp
+++ b/src/tribol/utils/TestUtils.cpp
@@ -934,7 +934,6 @@ void TestMesh::allocateAndSetElementThickness( IndexT mesh_id, RealT t )
                                  << "an element thickness array has been deleted and reallocated." );
 #endif
 
-
 }  // end TestMesh::allocateAndSetElementThickness()
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
* Statements refer to variables that aren't declared in a non-debug build.

When building Tribol via spack using gcc 16 from Fedora 44, I see error messages like this:
```
> /home/user/current/lido/lido_libs/linux_fedora_44/2026_07_28_06_51_57/build_stage/spack-stage-tribol-0.1.0.27-sv63uqad7h7hijaxc5sudgmgahjgka7s/spack-src/src/tribol/utils/TestUtils.cpp:853:18: error: 'deleteVels' was not declared in this scope
    853 |   SLIC_DEBUG_IF( deleteVels,
        |                  ^~~~~~~~~~
  /home/user/current/lido/lido_libs/linux_fedora_44/2026_07_28_06_51_57/build_stage/spack-stage-tribol-0.1.0.27-sv63uqad7h7hijaxc5sudgmgahjgka7s/spack-src/src/tribol/utils/TestUtils.cpp: In member function 'void tribol::TestMesh::allocateAndSetBulkModulus(tribol::IndexT, tribol::RealT)':
> /home/user/current/lido/lido_libs/linux_fedora_44/2026_07_28_06_51_57/build_stage/spack-stage-tribol-0.1.0.27-sv63uqad7h7hijaxc5sudgmgahjgka7s/spack-src/src/tribol/utils/TestUtils.cpp:894:18: error: 'deleteData' was not declared in this scope
    894 |   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetBulkModulus(): "
        |                  ^~~~~~~~~~
  /home/user/current/lido/lido_libs/linux_fedora_44/2026_07_28_06_51_57/build_stage/spack-stage-tribol-0.1.0.27-sv63uqad7h7hijaxc5sudgmgahjgka7s/spack-src/src/tribol/utils/TestUtils.cpp: In member function 'void tribol::TestMesh::allocateAndSetElementThickness(tribol::IndexT, tribol::RealT)':
> /home/user/current/lido/lido_libs/linux_fedora_44/2026_07_28_06_51_57/build_stage/spack-stage-tribol-0.1.0.27-sv63uqad7h7hijaxc5sudgmgahjgka7s/spack-src/src/tribol/utils/TestUtils.cpp:928:18: error: 'deleteData' was not declared in this scope
    928 |   SLIC_DEBUG_IF( deleteData, "TestMesh::allocateAndSetElementThickness(): "
        |                  ^~~~~~~~~~
> make[2]: *** [src/tribol/CMakeFiles/tribol.dir/build.make:390: src/tribol/CMakeFiles/tribol.dir/utils/TestUtils.cpp.o] Error 1
  make[2]: *** Waiting for unfinished jobs....
```

With the changes I've made in this PR, I'm able to build.