### PR TITLE
fix dual submesh->parent transfers

### DIFF
--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -535,18 +535,22 @@ void ParentRedecompTransfer::ParentToRedecomp( const mfem::ParGridFunction& pare
 
 void ParentRedecompTransfer::RedecompToParent( const mfem::GridFunction& redecomp_src, mfem::Vector& parent_dst ) const
 {
+  const bool use_device = parent_dst.UseDevice();
+  submesh_gridfn_.UseDevice( use_device );
   submesh_gridfn_ = 0.0;
   submesh_redecomp_xfer_.RedecompToSubmesh( redecomp_src, submesh_gridfn_ );
 
   // Response is a dual field; scatter local submesh contributions directly instead of using ParSubMesh::Transfer,
   // which communicates/averages shared DOFs as a primal grid function.
-  submesh_gridfn_.HostRead();
-  parent_dst.HostReadWrite();
-  for ( int i{ 0 }; i < submesh_to_parent_vdof_map_.Size(); ++i ) {
-    mfem::real_t sign = 1.0;
-    const int parent_vdof = mfem::FiniteElementSpace::DecodeDof( submesh_to_parent_vdof_map_[i], sign );
-    parent_dst( parent_vdof ) += sign * submesh_gridfn_( i );
-  }
+  const auto submesh_data = submesh_gridfn_.Read( use_device );
+  const auto submesh_to_parent_vdof_map = submesh_to_parent_vdof_map_.Read( use_device );
+  auto parent_data = parent_dst.ReadWrite( use_device );
+  mfem::forall_switch( use_device, submesh_to_parent_vdof_map_.Size(), [=] MFEM_HOST_DEVICE( int i ) {
+    const int encoded_parent_vdof = submesh_to_parent_vdof_map[i];
+    const mfem::real_t sign = encoded_parent_vdof >= 0 ? 1.0 : -1.0;
+    const int parent_vdof = encoded_parent_vdof >= 0 ? encoded_parent_vdof : -1 - encoded_parent_vdof;
+    parent_data[parent_vdof] += sign * submesh_data[i];
+  } );
 }
 
 ParentField::ParentField( const mfem::ParGridFunction& parent_gridfn ) : parent_gridfn_{ parent_gridfn } {}

--- a/src/tribol/mesh/MfemData.cpp
+++ b/src/tribol/mesh/MfemData.cpp
@@ -519,6 +519,10 @@ ParentRedecompTransfer::ParentRedecompTransfer( const mfem::ParFiniteElementSpac
   // );
   SLIC_ERROR_ROOT_IF( submesh_redecomp_xfer_.GetSubmesh().GetParent() != parent_fes_.GetParMesh(),
                       "submesh_gridfn's parent mesh must match the parent_fes ParMesh." );
+
+  const auto& submesh = submesh_redecomp_xfer_.GetSubmesh();
+  mfem::SubMeshUtils::BuildVdofToVdofMap( *submesh_gridfn_.ParFESpace(), parent_fes_, submesh.GetFrom(),
+                                          submesh.GetParentElementIDMap(), submesh_to_parent_vdof_map_ );
 }
 
 void ParentRedecompTransfer::ParentToRedecomp( const mfem::ParGridFunction& parent_src,
@@ -533,10 +537,16 @@ void ParentRedecompTransfer::RedecompToParent( const mfem::GridFunction& redecom
 {
   submesh_gridfn_ = 0.0;
   submesh_redecomp_xfer_.RedecompToSubmesh( redecomp_src, submesh_gridfn_ );
-  // submesh transfer requires a grid function.  create one using parent_dst's data
-  mfem::ParGridFunction parent_gridfn( &parent_fes_, parent_dst );
-  submesh_redecomp_xfer_.GetSubmesh().Transfer( submesh_gridfn_, parent_gridfn );
-  parent_dst.SyncMemory( parent_gridfn );
+
+  // Response is a dual field; scatter local submesh contributions directly instead of using ParSubMesh::Transfer,
+  // which communicates/averages shared DOFs as a primal grid function.
+  submesh_gridfn_.HostRead();
+  parent_dst.HostReadWrite();
+  for ( int i{ 0 }; i < submesh_to_parent_vdof_map_.Size(); ++i ) {
+    mfem::real_t sign = 1.0;
+    const int parent_vdof = mfem::FiniteElementSpace::DecodeDof( submesh_to_parent_vdof_map_[i], sign );
+    parent_dst( parent_vdof ) += sign * submesh_gridfn_( i );
+  }
 }
 
 ParentField::ParentField( const mfem::ParGridFunction& parent_gridfn ) : parent_gridfn_{ parent_gridfn } {}

--- a/src/tribol/mesh/MfemData.hpp
+++ b/src/tribol/mesh/MfemData.hpp
@@ -327,6 +327,11 @@ class ParentRedecompTransfer {
    * submesh level from/to the redecomp level
    */
   SubmeshRedecompTransfer submesh_redecomp_xfer_;
+
+  /**
+   * @brief Map from submesh vector DOFs to parent vector DOFs
+   */
+  mfem::Array<int> submesh_to_parent_vdof_map_;
 };
 
 /**


### PR DESCRIPTION
Fixes an issue where primal transfers were used to transfer a dual field from the submesh -> parent mesh.  In general, the transfers in MfemData need to be cleaned up so it is clear 1) what mesh the field starts on and where it should end up and 2) whether the transfer is for a primal field or a dual field. See #227.