### PR TITLE
unify length scales in Intersection2DPolygon

### DIFF
--- a/src/tests/tribol_enzyme_element_mortar.cpp
+++ b/src/tests/tribol_enzyme_element_mortar.cpp
@@ -968,7 +968,10 @@ TEST_F( EnzymeElementMortarTest, NoOverlap )
                              1.0,  1.0,  1.0,  1.0 };
   // clang-format on
 
-  FDCheck( x1, x2, n1, p1, x1_stencil, x2_stencil, 4, 1.0, 1.0e-7 );
+  constexpr int num_nodes = 4;
+  constexpr double check_scale = 1.0;
+  constexpr double len_collapse_ratio = 1.0e-7;
+  FDCheck( x1, x2, n1, p1, x1_stencil, x2_stencil, num_nodes, check_scale, len_collapse_ratio );
 }
 
 }  // namespace tribol

--- a/src/tests/tribol_enzyme_element_mortar.cpp
+++ b/src/tests/tribol_enzyme_element_mortar.cpp
@@ -49,7 +49,8 @@ class EnzymeElementMortarTest : public testing::Test {
    * @param x2_stencil Stencil coordinate directions of the second face
    */
   void FDCheck( double* x1, double* x2, double* n1, double* p1, const double* x1_stencil = nullptr,
-                const double* x2_stencil = nullptr, int num_nodes = 4, double check_scale = 1.0 )
+                const double* x2_stencil = nullptr, int num_nodes = 4, double check_scale = 1.0,
+                double len_collapse_ratio = 1.0e-8 )
   {
     constexpr int max_num_disp_dofs = 12;
     constexpr int max_num_pres_dofs = 4;
@@ -85,7 +86,8 @@ class EnzymeElementMortarTest : public testing::Test {
     double df2dp1[max_num_disp_dofs * max_num_pres_dofs] = { 0.0 };
 
     tribol::ComputeMortarJacobianEnzyme( x1, n1, p1, f1, df1dx1, df1dx2, df1dn1, df1dp1, g1, dg1dx1, dg1dx2, dg1dn1,
-                                         num_nodes, x2, f2, df2dx1, df2dx2, df2dn1, df2dp1, num_nodes );
+                                         num_nodes, x2, f2, df2dx1, df2dx2, df2dn1, df2dp1, num_nodes,
+                                         len_collapse_ratio );
 
     // Finite difference derivative of the force on the first face w.r.t. the coordinates of the first face
     double df1dx1_fd[max_num_disp_dofs * max_num_disp_dofs] = { 0.0 };
@@ -150,7 +152,7 @@ class EnzymeElementMortarTest : public testing::Test {
       for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
         g1[i] = 0.0;
       }
-      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes );
+      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes, len_collapse_ratio );
       for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
         df1dx1_fd[j * num_disp_dofs + i] += f1[i];
         df1dx1_fd[j * num_disp_dofs + i] /= shift1;
@@ -177,7 +179,7 @@ class EnzymeElementMortarTest : public testing::Test {
       for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
         g1[i] = 0.0;
       }
-      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes );
+      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes, len_collapse_ratio );
       for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
         df1dx2_fd[j * num_disp_dofs + i] += f1[i];
         df1dx2_fd[j * num_disp_dofs + i] /= shift2;
@@ -201,7 +203,7 @@ class EnzymeElementMortarTest : public testing::Test {
       for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
         g1[i] = 0.0;
       }
-      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes );
+      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes, len_collapse_ratio );
       for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
         df1dn1_fd[j * num_disp_dofs + i] += f1[i];
         df1dn1_fd[j * num_disp_dofs + i] /= shift;
@@ -225,7 +227,7 @@ class EnzymeElementMortarTest : public testing::Test {
       for ( int i{ 0 }; i < num_pres_dofs; ++i ) {
         g1[i] = 0.0;
       }
-      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes );
+      tribol::ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, num_nodes, x2, f2, num_nodes, len_collapse_ratio );
       for ( int i{ 0 }; i < num_disp_dofs; ++i ) {
         df1dp1_fd[j * num_disp_dofs + i] += f1[i];
         df1dp1_fd[j * num_disp_dofs + i] /= shift;
@@ -966,7 +968,7 @@ TEST_F( EnzymeElementMortarTest, NoOverlap )
                              1.0,  1.0,  1.0,  1.0 };
   // clang-format on
 
-  FDCheck( x1, x2, n1, p1, x1_stencil, x2_stencil );
+  FDCheck( x1, x2, n1, p1, x1_stencil, x2_stencil, 4, 1.0, 1.0e-7 );
 }
 
 }  // namespace tribol

--- a/src/tests/tribol_enzyme_poly_intersect.cpp
+++ b/src/tests/tribol_enzyme_poly_intersect.cpp
@@ -25,6 +25,20 @@
 
 namespace tribol {
 
+namespace {
+
+RealT SignedArea2DPolygon( const RealT* x, const RealT* y, int num_vert )
+{
+  RealT area = 0.0;
+  for ( int i{ 0 }; i < num_vert; ++i ) {
+    const int j = ( i + 1 ) % num_vert;
+    area += x[i] * y[j] - y[i] * x[j];
+  }
+  return 0.5 * area;
+}
+
+}  // namespace
+
 /**
  * @brief Test fixture for the Enzyme-based derivatives of intersection polygon calculations.
  *
@@ -36,8 +50,8 @@ class EnzymePolyIntersectTest : public testing::Test {
   static constexpr double delta_{ 1.0e-8 };
   void SetUp() override {}
 
-  void CheckIntersectionJacobian( RealT* x1, RealT* x2, int* stencil_dir, RealT fd_tol = delta_, RealT pos_tol = 1.0e-8,
-                                  RealT len_tol = 1.0e-8 )
+  void CheckIntersectionJacobian( RealT* x1, RealT* x2, int* stencil_dir, RealT fd_tol = delta_,
+                                  RealT length_tol = 1.0e-8 )
   {
     constexpr int max_overlap_vert = 8;
     constexpr int dim = 2;
@@ -61,15 +75,14 @@ class EnzymePolyIntersectTest : public testing::Test {
     }
     auto num_poly_verts = 0;
     auto d_num_poly_verts = 0;
-    auto d_pos_tol = 0.0;
-    auto d_len_tol = 0.0;
+    auto d_length_tol = 0.0;
     RealT area = 0.0;
     constexpr int num_elem_coords = 4;
     constexpr bool check_orientation = true;
 
     // compute the overlap polygon
     Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                           pos_tol, len_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
+                           length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
                            edge1, edge2 );
     // print some info about the overlap
     std::cout << std::setprecision( 15 ) << "Element 1 coords" << std::endl;
@@ -126,8 +139,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         x2, zeros,
         x2 + num_elem_coords, zeros,
         num_elem_coords,
-        pos_tol, d_pos_tol,
-        len_tol, d_len_tol,
+        length_tol, d_length_tol,
         xi, dxidx1 + rows * i,
         xi + max_overlap_vert, dxidx1 + rows * i + max_overlap_vert,
         &num_poly_verts, &d_num_poly_verts );
@@ -139,8 +151,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         x2, zeros,
         x2 + num_elem_coords, zeros,
         num_elem_coords,
-        pos_tol, d_pos_tol,
-        len_tol, d_len_tol,
+        length_tol, d_length_tol,
         xi, dxidx1 + rows * ( num_elem_coords + i ),
         xi + max_overlap_vert, dxidx1 + rows * ( num_elem_coords + i ) + max_overlap_vert,
         &num_poly_verts, &d_num_poly_verts );
@@ -152,8 +163,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         x2, x_dot,
         x2 + num_elem_coords, zeros,
         num_elem_coords,
-        pos_tol, d_pos_tol,
-        len_tol, d_len_tol,
+        length_tol, d_length_tol,
         xi, dxidx2 + rows * i,
         xi + max_overlap_vert, dxidx2 + rows * i + max_overlap_vert,
         &num_poly_verts, &d_num_poly_verts );
@@ -165,8 +175,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         x2, zeros,
         x2 + num_elem_coords, x_dot,
         num_elem_coords,
-        pos_tol, d_pos_tol,
-        len_tol, d_len_tol,
+        length_tol, d_length_tol,
         xi, dxidx2 + rows * ( num_elem_coords + i ),
         xi + max_overlap_vert, dxidx2 + rows * ( num_elem_coords + i ) + max_overlap_vert,
         &num_poly_verts, &d_num_poly_verts );
@@ -216,7 +225,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         xi[i] = 0.0;
       }
       Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                             pos_tol, len_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
+                             length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
                              edge1, edge2 );
       for ( int i{ 0 }; i < rows; ++i ) {
         dxidx1_fd[rows * j + i] = x_sgn1[num_elem_coords * stencil_dir[j] + j] * ( xi[i] - xi_base[i] ) / delta_;
@@ -228,7 +237,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         xi[i] = 0.0;
       }
       Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                             pos_tol, len_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
+                             length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
                              edge1, edge2 );
       for ( int i{ 0 }; i < rows; ++i ) {
         dxidx1_fd[rows * ( num_elem_coords + j ) + i] =
@@ -241,7 +250,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         xi[i] = 0.0;
       }
       Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                             pos_tol, len_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
+                             length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
                              edge1, edge2 );
       for ( int i{ 0 }; i < rows; ++i ) {
         dxidx2_fd[rows * j + i] = x_sgn2[num_elem_coords * stencil_dir[j] + j] * ( xi[i] - xi_base[i] ) / delta_;
@@ -253,7 +262,7 @@ class EnzymePolyIntersectTest : public testing::Test {
         xi[i] = 0.0;
       }
       Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                             pos_tol, len_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
+                             length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
                              edge1, edge2 );
       for ( int i{ 0 }; i < rows; ++i ) {
         dxidx2_fd[rows * ( num_elem_coords + j ) + i] =
@@ -292,22 +301,20 @@ class EnzymePolyIntersectTest : public testing::Test {
 
 TEST_F( EnzymePolyIntersectTest, PerfectOverlap )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   RealT x2[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   int stencil_dir[4] = { 0, 0, 0, 0 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, length_tol );
 }
 
 TEST_F( EnzymePolyIntersectTest, Mesh2VertexMovedInByPosTol )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
-  RealT x2[8] = { 0.0 + pos_tol, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
+  RealT x2[8] = { 0.0 + length_tol, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   int stencil_dir[4] = { 1, 1, 1, 1 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, length_tol );
 }
 
 // NOTE: edges are too nearly parallel which makes the derivative explode for some terms.  this makes the FD inaccurate.
@@ -315,48 +322,67 @@ TEST_F( EnzymePolyIntersectTest, Mesh2VertexMovedInByPosTol )
 // change in the overlap coordinate.
 TEST_F( EnzymePolyIntersectTest, NearlyParallelEdges )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
-  RealT x2[8] = { 0.0, 1.0, 1.0, 0.0, 0.0 - 2 * pos_tol, 0.0 + 2 * pos_tol, 1.0, 1.0 };
+  RealT x2[8] = { 0.0, 1.0, 1.0, 0.0, 0.0 - 2 * length_tol, 0.0 + 2 * length_tol, 1.0, 1.0 };
   int stencil_dir[4] = { 0, 1, 0, 0 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, 31000.0, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, 31000.0, length_tol );
 }
 
 TEST_F( EnzymePolyIntersectTest, LessNearlyParallelEdges )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   constexpr auto offset = 0.2;
   // shift node 3 in a little to prevent edge class change with FD
-  RealT x1[8] = { 0.0, 1.0, 1.0 - pos_tol, 0.0, 0.0, 0.0, 1.0 - pos_tol, 1.0 };
+  RealT x1[8] = { 0.0, 1.0, 1.0 - length_tol, 0.0, 0.0, 0.0, 1.0 - length_tol, 1.0 };
   RealT x2[8] = { 0.0, 1.0, 1.0, 0.0, 0.0 - offset, 0.0 + offset, 1.0, 1.0 };
   int stencil_dir[4] = { 0, 1, 1, 0 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, 4.0 * delta_, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, 4.0 * delta_, length_tol );
 }
 
 TEST_F( EnzymePolyIntersectTest, OffsetElements )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   constexpr auto offset = 0.2;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   RealT x2[8] = { 0.0 + offset, 1.0 + offset, 1.0 + offset, 0.0 + offset,
                   0.0 + offset, 0.0 + offset, 1.0 + offset, 1.0 + offset };
   int stencil_dir[4] = { 1, 0, 0, 0 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, 2.0 * delta_, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, 2.0 * delta_, length_tol );
 }
 
 TEST_F( EnzymePolyIntersectTest, EightOverlapVertices )
 {
-  constexpr auto pos_tol = 10.0 * delta_;
-  constexpr auto len_tol = 10.0 * delta_;
+  constexpr auto length_tol = 10.0 * delta_;
   auto xmin = -1.0 / std::sqrt( 2.0 ) + 0.5;
   auto xmax = 1.0 / std::sqrt( 2.0 ) + 0.5;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   RealT x2[8] = { 0.5, xmax, 0.5, xmin, xmin, 0.5, xmax, 0.5 };
   int stencil_dir[4] = { 0, 0, 0, 0 };
-  CheckIntersectionJacobian( x1, x2, stencil_dir, 2.0 * delta_, pos_tol, len_tol );
+  CheckIntersectionJacobian( x1, x2, stencil_dir, 2.0 * delta_, length_tol );
+}
+
+TEST( PolyIntersect, NearlyCoincidentTriangleOverlapUsesLengthTol )
+{
+  constexpr RealT length_tol = 1.0e-8;
+  const RealT xA[3] = { -1.7720926303008128e-01, 1.7720926303008130e-01, 7.6327832942979648e-17 };
+  const RealT yA[3] = { -5.9069754343360363e-02, -5.9069754343360349e-02, 1.1813950868672080e-01 };
+  const RealT xB[3] = { 1.7720926303008075e-01, -8.3266726846886605e-17, -1.7720926303008128e-01 };
+  const RealT yB[3] = { -5.9069754343361050e-02, 1.1813950868672063e-01, -5.9069754343360363e-02 };
+
+  RealT polyX[6] = { 0.0 };
+  RealT polyY[6] = { 0.0 };
+  int num_poly_vert = 0;
+  RealT area = 0.0;
+  constexpr bool check_orientation = true;
+
+  const auto err = Intersection2DPolygon( xA, yA, 3, xB, yB, 3, length_tol, polyX, polyY, num_poly_vert, area,
+                                          check_orientation );
+
+  EXPECT_EQ( err, NO_FACE_GEOM_EXCEPTION );
+  EXPECT_EQ( num_poly_vert, 3 );
+  EXPECT_NEAR( area, 3.1403122903664482e-02, 1.0e-14 );
+  EXPECT_GT( SignedArea2DPolygon( polyX, polyY, num_poly_vert ), 0.0 );
 }
 
 }  // namespace tribol

--- a/src/tests/tribol_enzyme_poly_intersect.cpp
+++ b/src/tests/tribol_enzyme_poly_intersect.cpp
@@ -82,8 +82,8 @@ class EnzymePolyIntersectTest : public testing::Test {
 
     // compute the overlap polygon
     Intersection2DPolygon( x1, x1 + num_elem_coords, num_elem_coords, x2, x2 + num_elem_coords, num_elem_coords,
-                           length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type,
-                           edge1, edge2 );
+                           length_tol, xi, xi + max_overlap_vert, num_poly_verts, area, check_orientation, type, edge1,
+                           edge2 );
     // print some info about the overlap
     std::cout << std::setprecision( 15 ) << "Element 1 coords" << std::endl;
     for ( int i{ 0 }; i < num_elem_coords; ++i ) {
@@ -376,8 +376,8 @@ TEST( PolyIntersect, NearlyCoincidentTriangleOverlapUsesLengthTol )
   RealT area = 0.0;
   constexpr bool check_orientation = true;
 
-  const auto err = Intersection2DPolygon( xA, yA, 3, xB, yB, 3, length_tol, polyX, polyY, num_poly_vert, area,
-                                          check_orientation );
+  const auto err =
+      Intersection2DPolygon( xA, yA, 3, xB, yB, 3, length_tol, polyX, polyY, num_poly_vert, area, check_orientation );
 
   EXPECT_EQ( err, NO_FACE_GEOM_EXCEPTION );
   EXPECT_EQ( num_poly_vert, 3 );

--- a/src/tests/tribol_enzyme_poly_intersect.cpp
+++ b/src/tests/tribol_enzyme_poly_intersect.cpp
@@ -308,11 +308,13 @@ TEST_F( EnzymePolyIntersectTest, PerfectOverlap )
   CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, length_tol );
 }
 
-TEST_F( EnzymePolyIntersectTest, Mesh2VertexMovedInByPosTol )
+TEST_F( EnzymePolyIntersectTest, Mesh2VertexMovedPastLengthTol )
 {
   constexpr auto length_tol = 10.0 * delta_;
   RealT x1[8] = { 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
-  RealT x2[8] = { 0.0 + length_tol, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
+  // Move the vertex past the tolerance boundary.  Placing it exactly at length_tol makes the finite-difference stencil
+  // cross a topology branch, so the derivative is not well-defined.
+  RealT x2[8] = { 0.0 + 2.0 * length_tol, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
   int stencil_dir[4] = { 1, 1, 1, 1 };
   CheckIntersectionJacobian( x1, x2, stencil_dir, delta_, length_tol );
 }

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -1320,9 +1320,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
 
   // compute intersection polygon and area.
   RealT length_tol = this->m_params.len_collapse_ratio;
-  FaceGeomException inter_err = Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2,
-                                                       m2.numberOfNodesPerElement(), length_tol, this->m_polyLocX,
-                                                       this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
+  FaceGeomException inter_err =
+      Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2, m2.numberOfNodesPerElement(), length_tol,
+                             this->m_polyLocX, this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;
@@ -2504,8 +2504,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::projectPointsAndCom
 
   // call intersection routine to get intersecting polygon
   RealT length_tol = this->m_params.len_collapse_ratio;
-  FaceGeomException inter_err = Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2,
-                                                       length_tol, m_polyLocX, m_polyLocY, m_numPolyVert, m_area, false );
+  FaceGeomException inter_err =
+      Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2, length_tol, m_polyLocX,
+                             m_polyLocY, m_numPolyVert, m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -1320,10 +1320,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
 
   // compute intersection polygon and area.
   RealT length_tol_ratio = this->m_params.len_collapse_ratio;
-  FaceGeomException inter_err =
-      Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2, m2.numberOfNodesPerElement(),
-                             length_tol_ratio, this->m_polyLocX, this->m_polyLocY, this->m_numPolyVert, this->m_area,
-                             false );
+  FaceGeomException inter_err = Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2,
+                                                       m2.numberOfNodesPerElement(), length_tol_ratio, this->m_polyLocX,
+                                                       this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;
@@ -2505,9 +2504,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::projectPointsAndCom
 
   // call intersection routine to get intersecting polygon
   RealT length_tol_ratio = this->m_params.len_collapse_ratio;
-  FaceGeomException inter_err = Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2,
-                                                       length_tol_ratio, m_polyLocX, m_polyLocY, m_numPolyVert, m_area,
-                                                       false );
+  FaceGeomException inter_err =
+      Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2, length_tol_ratio,
+                             m_polyLocX, m_polyLocY, m_numPolyVert, m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -1319,10 +1319,11 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
   ElemReverse( X2, Y2, m2.numberOfNodesPerElement() );
 
   // compute intersection polygon and area.
-  RealT length_tol = this->m_params.len_collapse_ratio;
+  RealT length_tol_ratio = this->m_params.len_collapse_ratio;
   FaceGeomException inter_err =
-      Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2, m2.numberOfNodesPerElement(), length_tol,
-                             this->m_polyLocX, this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
+      Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2, m2.numberOfNodesPerElement(),
+                             length_tol_ratio, this->m_polyLocX, this->m_polyLocY, this->m_numPolyVert, this->m_area,
+                             false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;
@@ -2503,10 +2504,10 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::projectPointsAndCom
   }
 
   // call intersection routine to get intersecting polygon
-  RealT length_tol = this->m_params.len_collapse_ratio;
-  FaceGeomException inter_err =
-      Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2, length_tol, m_polyLocX,
-                             m_polyLocY, m_numPolyVert, m_area, false );
+  RealT length_tol_ratio = this->m_params.len_collapse_ratio;
+  FaceGeomException inter_err = Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2,
+                                                       length_tol_ratio, m_polyLocX, m_polyLocY, m_numPolyVert, m_area,
+                                                       false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -1288,9 +1288,6 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
                                                                                const MeshData::Viewer& m1,
                                                                                const MeshData::Viewer& m2 )
 {
-  IndexT element_id1 = this->getCpElementId1();
-  IndexT element_id2 = this->getCpElementId2();
-
   // project face vertex coordinates to contact plane
   ProjectPointsToPlane( x1, y1, z1, this->m_nX, this->m_nY, this->m_nZ, this->m_cX, this->m_cY, this->m_cZ,
                         &m_x1_bar[0], &m_y1_bar[0], &m_z1_bar[0], m1.numberOfNodesPerElement() );
@@ -1322,12 +1319,10 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
   ElemReverse( X2, Y2, m2.numberOfNodesPerElement() );
 
   // compute intersection polygon and area.
-  RealT pos_tol = this->m_params.len_collapse_ratio *
-                  axom::utilities::max( m1.getFaceRadius()[element_id1], m2.getFaceRadius()[element_id2] );
-  RealT len_tol = pos_tol;
-  FaceGeomException inter_err =
-      Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2, m2.numberOfNodesPerElement(), pos_tol,
-                             len_tol, this->m_polyLocX, this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
+  RealT length_tol = this->m_params.len_collapse_ratio;
+  FaceGeomException inter_err = Intersection2DPolygon( X1, Y1, m1.numberOfNodesPerElement(), X2, Y2,
+                                                       m2.numberOfNodesPerElement(), length_tol, this->m_polyLocX,
+                                                       this->m_polyLocY, this->m_numPolyVert, this->m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;
@@ -1340,8 +1335,8 @@ TRIBOL_HOST_DEVICE inline FaceGeomException MortarPlanePair::computeOverlap3D( c
 
   // handle the case where the actual polygon with connectivity
   // and computed vertex coordinates becomes degenerate due to
-  // either position tolerances (segment-segment intersections)
-  // or length tolerances (intersecting polygon segment lengths)
+  // the length tolerance used for segment-segment intersections
+  // or intersecting polygon segment lengths
   if ( this->m_numPolyVert < 3 ) {
 #ifdef TRIBOL_USE_HOST
     SLIC_DEBUG( "degenerate polygon intersection detected.\n" );
@@ -2356,8 +2351,8 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::computeOverlap3D( c
 
   // handle the case where the actual polygon with connectivity
   // and computed vertex coordinates becomes degenerate due to
-  // either position tolerances (segment-segment intersections)
-  // or length tolerances (intersecting polygon segment lengths)
+  // the length tolerance used for segment-segment intersections
+  // or intersecting polygon segment lengths
   if ( m_numPolyVert < 3 ) {
 #ifdef TRIBOL_USE_HOST
     SLIC_DEBUG( "degenerate polygon intersection detected.\n" );
@@ -2463,9 +2458,6 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::projectPointsAndCom
   }
 #endif
 
-  IndexT element_id1 = this->getCpElementId1();
-  IndexT element_id2 = this->getCpElementId2();
-
   constexpr int max_nodes_per_clipped_face = 5;
   RealT cfx1_proj[max_nodes_per_clipped_face];
   RealT cfy1_proj[max_nodes_per_clipped_face];
@@ -2511,12 +2503,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException CommonPlanePair::projectPointsAndCom
   }
 
   // call intersection routine to get intersecting polygon
-  RealT pos_tol = this->m_params.len_collapse_ratio *
-                  axom::utilities::max( m1.getFaceRadius()[element_id1], m2.getFaceRadius()[element_id2] );
-  RealT len_tol = pos_tol;
-  FaceGeomException inter_err =
-      Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2, pos_tol, len_tol,
-                             m_polyLocX, m_polyLocY, m_numPolyVert, m_area, false );
+  RealT length_tol = this->m_params.len_collapse_ratio;
+  FaceGeomException inter_err = Intersection2DPolygon( cfx1_loc, cfy1_loc, num_vert_1, cfx2_loc, cfy2_loc, num_vert_2,
+                                                       length_tol, m_polyLocX, m_polyLocY, m_numPolyVert, m_area, false );
 
   if ( inter_err != NO_FACE_GEOM_EXCEPTION ) {
     return inter_err;

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -647,6 +647,29 @@ TRIBOL_HOST_DEVICE inline RealT Area2DPolygon( const RealT* const x, const RealT
 
 /*!
  *
+ * \brief Computes a characteristic length scale for a 2D polygon.
+ *
+ * \param [in] x array of local x coordinates of polygon vertices
+ * \param [in] y array of local y coordinates of polygon vertices
+ * \param [in] numPolyVert number of polygon vertices
+ *
+ * \return maximum polygon edge length
+ */
+TRIBOL_HOST_DEVICE inline RealT Polygon2DLengthScale( const RealT* const x, const RealT* const y,
+                                                      const int numPolyVert )
+{
+  RealT lengthScale = 0.0;
+  for ( int i = 0; i < numPolyVert; ++i ) {
+    const int ia = i;
+    const int ib = ( i == ( numPolyVert - 1 ) ) ? 0 : ( i + 1 );
+    const RealT edgeLength = magnitude( x[ib] - x[ia], y[ib] - y[ia] );
+    lengthScale = ( edgeLength > lengthScale ) ? edgeLength : lengthScale;
+  }
+  return lengthScale;
+}
+
+/*!
+ *
  * \brief computes a segment-segment intersection in a way specific to the tribol
  *  polygon-polygon intersection calculation
  *
@@ -664,7 +687,7 @@ TRIBOL_HOST_DEVICE inline RealT Area2DPolygon( const RealT* const x, const RealT
  * \param [out] y local coordinate of the intersection point
  * \param [out] duplicate true if intersection point is computed as duplicate polygon
  *                 intersection point
- * \param [in] tol length tolerance for collapsing intersection points to interior points
+ * \param [in] lengthTol length tolerance for collapsing intersection points to interior points
  *
  * \return true if the segments intersect at a non-duplicate point, false otherwise
  *
@@ -675,15 +698,15 @@ TRIBOL_HOST_DEVICE inline RealT Area2DPolygon( const RealT* const x, const RealT
  *  to one of the polygons that is the solution to the intersection problem. The solution
  *  may arise due to the the segments intersecting at a vertex tagged as interior to one
  *  of the polygons, or due to collapsing the true intersection point to an interior
- *  vertex based on the position tolerance input argument. For intersection points that
- *  are within the position tolerance to a non-interior segment vertex, nothing is done
+ *  vertex based on the length tolerance input argument. For intersection points that
+ *  are within the length tolerance to a non-interior segment vertex, nothing is done
  *  because we want to retain this intersection point. Collapsing intersection points to
  *  vertices tagged as interior to one of the polygons may render a degenerate overlap
  *  polygon and must be checked.
  */
 TRIBOL_HOST_DEVICE inline bool SegmentIntersection2D( RealT xA1, RealT yA1, RealT xB1, RealT yB1, RealT xA2, RealT yA2,
                                                       RealT xB2, RealT yB2, const bool* interior, RealT& x, RealT& y,
-                                                      bool& duplicate, RealT tol )
+                                                      bool& duplicate, RealT lengthTol )
 {
   // note 1: this routine computes a unique segment-segment intersection, where two
   // segments are assumed to intersect at a single point. A segment-segment overlap
@@ -706,9 +729,6 @@ TRIBOL_HOST_DEVICE inline bool SegmentIntersection2D( RealT xA1, RealT yA1, Real
 
   RealT lambdaX2 = xB2 - xA2;
   RealT lambdaY2 = yB2 - yA2;
-
-  RealT seg1Mag = magnitude( lambdaX1, lambdaY1 );
-  RealT seg2Mag = magnitude( lambdaX2, lambdaY2 );
 
   // compute determinant of the lambda matrix, [ -lx1 -ly1, lx2 ly2 ]
   RealT det = -lambdaX1 * lambdaY2 + lambdaX2 * lambdaY1;
@@ -808,16 +828,11 @@ TRIBOL_HOST_DEVICE inline bool SegmentIntersection2D( RealT xA1, RealT yA1, Real
     }
   }
 
-  // check to see if the minimum distance is less than the position tolerance for
-  // the segments
-  RealT distRatio = ( idMin == 0 || idMin == 1 ) ? ( distMin / seg1Mag ) : ( distMin / seg2Mag );
-
-  // if the distRatio is less than the tolerance, or percentage cutoff of the original
-  // segment that we would like to keep, then check to see if the segment vertex closest
+  // if the minimum distance is less than the length tolerance, check to see if the segment vertex closest
   // to the computed intersection point is an interior point. If this is true, then collapse
   // the computed intersection point to the interior point and mark the duplicate boolean.
   // Also do this for the argument, interior, set to nullptr
-  if ( distRatio < tol ) {
+  if ( distMin < lengthTol ) {
     if ( interior == nullptr ) {
       x = xMinVert;
       y = yMinVert;
@@ -1139,8 +1154,9 @@ enum class OverlapVertexType
  * \param [in] xB array of local x coordinates of polygon B
  * \param [in] yB array of local y coordinates of polygon B
  * \param [in] numVertexB number of vertices in polygon B
- * \param [in] posTol position tolerance to collapse segment-segment intersection points
- * \param [in] lenTol length tolerance to collapse short intersection edges
+ * \param [in] lengthTol nondimensional length tolerance used directly for point-in-face barycentric checks and
+ * scaled by the face length scale for segment endpoint snapping, duplicate interior vertex removal, and short
+ * intersection-edge collapse
  * \param [out] polyX array of x coordinates of intersection polygon
  * \param [out] polyY array of y coordinates of intersection polygon
  * \param [out] numPolyVert number of vertices in intersection polygon
@@ -1163,8 +1179,8 @@ enum class OverlapVertexType
  *
  */
 TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
-    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB, RealT posTol,
-    RealT lenTol, RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
+    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB,
+    RealT lengthTol, RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
     OverlapVertexType* vertType = nullptr, int* edgeA = nullptr, int* edgeB = nullptr )
 {
   // for tribol, if you have called this routine it is because a positive area of
@@ -1219,6 +1235,11 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
   VertexAvgCentroid( xA, yA, nullptr, numVertexA, xCA, yCA, zC );
   VertexAvgCentroid( xB, yB, nullptr, numVertexB, xCB, yCB, zC );
 
+  const RealT lengthScaleA = Polygon2DLengthScale( xA, yA, numVertexA );
+  const RealT lengthScaleB = Polygon2DLengthScale( xB, yB, numVertexB );
+  const RealT faceLengthScale = ( lengthScaleA > lengthScaleB ) ? lengthScaleA : lengthScaleB;
+  const RealT physicalLengthTol = lengthTol * faceLengthScale;
+
   // check to see if any of polygon A's vertices are in polygon B, and vice-versa. Track
   // which vertices are interior to the other polygon. Keep in mind that vertex
   // coordinates are local 2D coordinates.
@@ -1227,7 +1248,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
 
   // check A in B
   for ( int i = 0; i < numVertexA; ++i ) {
-    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB ) ) {
+    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB, lengthTol ) ) {
       // interior A in B
       interiorVAId[i] = i;
       ++numVAI;
@@ -1258,7 +1279,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
 
   // check B in A
   for ( int i = 0; i < numVertexB; ++i ) {
-    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA ) ) {
+    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA, lengthTol ) ) {
       // interior B in A
       interiorVBId[i] = i;
       ++numVBI;
@@ -1299,7 +1320,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
           RealT distX = xA[i] - xB[j];
           RealT distY = yA[i] - yB[j];
           RealT distMag = magnitude( distX, distY );
-          if ( distMag < 1.E-15 ) {
+          if ( distMag < physicalLengthTol ) {
             // remove the interior designation for the vertex in polygon B
             //                 SLIC_DEBUG( "Removing duplicate interior vertex id: " << j << ".\n" );
             interiorVBId[j] = -1;
@@ -1371,7 +1392,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
 
         intersect[interId] =
             SegmentIntersection2D( xA[vAID1], yA[vAID1], xA[vAID2], yA[vAID2], xB[vBID1], yB[vBID1], xB[vBID2],
-                                   yB[vBID2], interior, interX[interId], interY[interId], dupl, posTol );
+                                   yB[vBID2], interior, interX[interId], interY[interId], dupl, physicalLengthTol );
         if ( intersect[interId] ) {
           edgeATemp[interId] = ia;
           edgeBTemp[interId] = jb;
@@ -1481,7 +1502,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
     int numFinalVert = 0;
 
     FaceGeomException segErr =
-        CheckPolySegs( polyXTemp, polyYTemp, numPolyVert, lenTol, polyX, polyY, vertIdx, numFinalVert );
+        CheckPolySegs( polyXTemp, polyYTemp, numPolyVert, physicalLengthTol, polyX, polyY, vertIdx, numFinalVert );
     for ( int i = 0; i < numFinalVert; ++i ) {
       if ( vertType ) {
         vertType[i] = vertTypeTemp2[vertIdx[i]];
@@ -1531,8 +1552,9 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
  * \param [in] xB array of local x coordinates of polygon B
  * \param [in] yB array of local y coordinates of polygon B
  * \param [in] numVertexB number of vertices in polygon B
- * \param [in] posTol position tolerance to collapse segment-segment intersection points
- * \param [in] lenTol length tolerance to collapse short intersection edges
+ * \param [in] lengthTol nondimensional length tolerance used directly for point-in-face barycentric checks and
+ * scaled by the face length scale for segment endpoint snapping, duplicate interior vertex removal, and short
+ * intersection-edge collapse
  * \param [out] polyX array of x coordinates of intersection polygon
  * \param [out] polyY array of y coordinates of intersection polygon
  * \param [out] numPolyVert number of vertices in intersection polygon
@@ -1547,13 +1569,13 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
  *
  */
 inline FaceGeomException Intersection2DPolygonEnzyme( const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB,
-                                                      const RealT* yB, int numVertexB, RealT posTol, RealT lenTol,
-                                                      RealT* polyX, RealT* polyY, int* numPolyVert )
+                                                      const RealT* yB, int numVertexB, RealT lengthTol, RealT* polyX,
+                                                      RealT* polyY, int* numPolyVert )
 {
   double area = 0.0;
   constexpr bool orientCheck = true;
-  return Intersection2DPolygon( xA, yA, numVertexA, xB, yB, numVertexB, posTol, lenTol, polyX, polyY, *numPolyVert,
-                                area, orientCheck );
+  return Intersection2DPolygon( xA, yA, numVertexA, xB, yB, numVertexB, lengthTol, polyX, polyY, *numPolyVert, area,
+                                orientCheck );
 }
 
 #endif

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -1179,8 +1179,8 @@ enum class OverlapVertexType
  *
  */
 TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
-    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB,
-    RealT lengthTol, RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
+    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB, RealT lengthTol,
+    RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
     OverlapVertexType* vertType = nullptr, int* edgeA = nullptr, int* edgeB = nullptr )
 {
   // for tribol, if you have called this routine it is because a positive area of
@@ -1476,6 +1476,30 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
       edgeATemp[k] = -1;
       edgeBTemp[k] = i;
       ++k;
+    }
+  }
+  numPolyVert = k;
+
+  // Collapse near-duplicate candidate vertices before reordering.  PolyReorderConvex() depends on the unordered point
+  // cloud being well-conditioned, so removing tolerance-scale duplicates before computing the ordering avoids ambiguous
+  // centroid/angle calculations.  Preserve the first occurrence and its metadata.
+  for ( int i = 0; i < numPolyVert; ++i ) {
+    int j = i + 1;
+    while ( j < numPolyVert ) {
+      const RealT distX = polyXTemp[i] - polyXTemp[j];
+      const RealT distY = polyYTemp[i] - polyYTemp[j];
+      if ( magnitude( distX, distY ) < physicalLengthTol ) {
+        for ( int l = j; l < numPolyVert - 1; ++l ) {
+          polyXTemp[l] = polyXTemp[l + 1];
+          polyYTemp[l] = polyYTemp[l + 1];
+          vertTypeTemp[l] = vertTypeTemp[l + 1];
+          edgeATemp[l] = edgeATemp[l + 1];
+          edgeBTemp[l] = edgeBTemp[l + 1];
+        }
+        --numPolyVert;
+      } else {
+        ++j;
+      }
     }
   }
 

--- a/src/tribol/geom/GeomUtilities.hpp
+++ b/src/tribol/geom/GeomUtilities.hpp
@@ -1154,9 +1154,8 @@ enum class OverlapVertexType
  * \param [in] xB array of local x coordinates of polygon B
  * \param [in] yB array of local y coordinates of polygon B
  * \param [in] numVertexB number of vertices in polygon B
- * \param [in] lengthTol nondimensional length tolerance used directly for point-in-face barycentric checks and
- * scaled by the face length scale for segment endpoint snapping, duplicate interior vertex removal, and short
- * intersection-edge collapse
+ * \param [in] lengthTolRatio nondimensional length tolerance ratio. Physical-distance checks scale it by an input
+ * polygon length scale.
  * \param [out] polyX array of x coordinates of intersection polygon
  * \param [out] polyY array of y coordinates of intersection polygon
  * \param [out] numPolyVert number of vertices in intersection polygon
@@ -1179,8 +1178,8 @@ enum class OverlapVertexType
  *
  */
 TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
-    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB, RealT lengthTol,
-    RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
+    const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB, const RealT* yB, int numVertexB,
+    RealT lengthTolRatio, RealT* polyX, RealT* polyY, int& numPolyVert, RealT& area, bool orientCheck = true,
     OverlapVertexType* vertType = nullptr, int* edgeA = nullptr, int* edgeB = nullptr )
 {
   // for tribol, if you have called this routine it is because a positive area of
@@ -1238,7 +1237,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
   const RealT lengthScaleA = Polygon2DLengthScale( xA, yA, numVertexA );
   const RealT lengthScaleB = Polygon2DLengthScale( xB, yB, numVertexB );
   const RealT faceLengthScale = ( lengthScaleA > lengthScaleB ) ? lengthScaleA : lengthScaleB;
-  const RealT physicalLengthTol = lengthTol * faceLengthScale;
+  const RealT physicalLengthTol = lengthTolRatio * faceLengthScale;
 
   // check to see if any of polygon A's vertices are in polygon B, and vice-versa. Track
   // which vertices are interior to the other polygon. Keep in mind that vertex
@@ -1248,7 +1247,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
 
   // check A in B
   for ( int i = 0; i < numVertexA; ++i ) {
-    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB, lengthTol ) ) {
+    if ( Point2DInFace( xA[i], yA[i], xB, yB, xCB, yCB, numVertexB, lengthTolRatio ) ) {
       // interior A in B
       interiorVAId[i] = i;
       ++numVAI;
@@ -1279,7 +1278,7 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
 
   // check B in A
   for ( int i = 0; i < numVertexB; ++i ) {
-    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA, lengthTol ) ) {
+    if ( Point2DInFace( xB[i], yB[i], xA, yA, xCA, yCA, numVertexA, lengthTolRatio ) ) {
       // interior B in A
       interiorVBId[i] = i;
       ++numVBI;
@@ -1576,9 +1575,8 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
  * \param [in] xB array of local x coordinates of polygon B
  * \param [in] yB array of local y coordinates of polygon B
  * \param [in] numVertexB number of vertices in polygon B
- * \param [in] lengthTol nondimensional length tolerance used directly for point-in-face barycentric checks and
- * scaled by the face length scale for segment endpoint snapping, duplicate interior vertex removal, and short
- * intersection-edge collapse
+ * \param [in] lengthTolRatio nondimensional length tolerance ratio. Physical-distance checks scale it by a polygon
+ * length scale.
  * \param [out] polyX array of x coordinates of intersection polygon
  * \param [out] polyY array of y coordinates of intersection polygon
  * \param [out] numPolyVert number of vertices in intersection polygon
@@ -1593,13 +1591,13 @@ TRIBOL_HOST_DEVICE inline FaceGeomException Intersection2DPolygon(
  *
  */
 inline FaceGeomException Intersection2DPolygonEnzyme( const RealT* xA, const RealT* yA, int numVertexA, const RealT* xB,
-                                                      const RealT* yB, int numVertexB, RealT lengthTol, RealT* polyX,
-                                                      RealT* polyY, int* numPolyVert )
+                                                      const RealT* yB, int numVertexB, RealT lengthTolRatio,
+                                                      RealT* polyX, RealT* polyY, int* numPolyVert )
 {
   double area = 0.0;
   constexpr bool orientCheck = true;
-  return Intersection2DPolygon( xA, yA, numVertexA, xB, yB, numVertexB, lengthTol, polyX, polyY, *numPolyVert, area,
-                                orientCheck );
+  return Intersection2DPolygon( xA, yA, numVertexA, xB, yB, numVertexB, lengthTolRatio, polyX, polyY, *numPolyVert,
+                                area, orientCheck );
 }
 
 #endif

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -841,7 +841,7 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
   RealT xti_2d[8];
   RealT yti_2d[8];
   int overlap_poly_size = 0;
-  Intersection2DPolygonEnzyme( x1t_2d, y1t_2d, size1, x2t_2d_rev, y2t_2d_rev, size2, 1.0e-8, 1.0e-8, xti_2d, yti_2d,
+  Intersection2DPolygonEnzyme( x1t_2d, y1t_2d, size1, x2t_2d_rev, y2t_2d_rev, size2, 1.0e-8, xti_2d, yti_2d,
                                &overlap_poly_size );
   RealT overlap_poly_area = Area2DPolygon( xti_2d, yti_2d, overlap_poly_size );
   if ( overlap_poly_area <= 0.0 ) {

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -705,8 +705,7 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
       }
     } else if ( lm_opts.eval_mode == ImplicitEvalMode::MORTAR_GAP ||
                 lm_opts.eval_mode == ImplicitEvalMode::MORTAR_RESIDUAL ) {
-      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2,
-                                cs->getParameters().len_collapse_ratio );
+      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2, cs->getParameters().len_collapse_ratio );
     }
     for ( int i{ 0 }; i < size1; ++i ) {
       int node_id = mesh1.getGlobalNodeId( elem1, i );

--- a/src/tribol/physics/Mortar.cpp
+++ b/src/tribol/physics/Mortar.cpp
@@ -693,7 +693,8 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
       ComputeMortarJacobianEnzyme( x1, n1, p1, f1, blockJ( 0, 0 ).data(), blockJ( 0, 1 ).data(),
                                    blockJ_n( 0, 0 ).data(), blockJ( 0, 2 ).data(), g1, blockJ( 2, 0 ).data(),
                                    blockJ( 2, 1 ).data(), blockJ_n( 2, 0 ).data(), size1, x2, f2, blockJ( 1, 0 ).data(),
-                                   blockJ( 1, 1 ).data(), blockJ_n( 1, 0 ).data(), blockJ( 1, 2 ).data(), size2 );
+                                   blockJ( 1, 1 ).data(), blockJ_n( 1, 0 ).data(), blockJ( 1, 2 ).data(), size2,
+                                   cs->getParameters().len_collapse_ratio );
 
       if ( lm_opts.sparse_mode == SparseMode::MFEM_ELEMENT_DENSE ) {
         cs->getMethodData()->storeElemBlockJ( { elem1, elem2, elem1 }, blockJ );
@@ -704,7 +705,8 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
       }
     } else if ( lm_opts.eval_mode == ImplicitEvalMode::MORTAR_GAP ||
                 lm_opts.eval_mode == ImplicitEvalMode::MORTAR_RESIDUAL ) {
-      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2 );
+      ComputeMortarForceEnzyme( x1, n1, p1, f1, g1, size1, x2, f2, size2,
+                                cs->getParameters().len_collapse_ratio );
     }
     for ( int i{ 0 }; i < size1; ++i ) {
       int node_id = mesh1.getGlobalNodeId( elem1, i );
@@ -726,7 +728,7 @@ int ApplyNormalEnzyme( CouplingScheme* cs )
 
 //------------------------------------------------------------------------------
 void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1, RealT* f1, RealT* g1, int size1,
-                               const RealT* x2, RealT* f2, int size2 )
+                               const RealT* x2, RealT* f2, int size2, RealT lenCollapseRatio )
 {
   // convention: elem1 = nonmortar element
   //             elem2 = mortar element
@@ -841,7 +843,7 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
   RealT xti_2d[8];
   RealT yti_2d[8];
   int overlap_poly_size = 0;
-  Intersection2DPolygonEnzyme( x1t_2d, y1t_2d, size1, x2t_2d_rev, y2t_2d_rev, size2, 1.0e-8, xti_2d, yti_2d,
+  Intersection2DPolygonEnzyme( x1t_2d, y1t_2d, size1, x2t_2d_rev, y2t_2d_rev, size2, lenCollapseRatio, xti_2d, yti_2d,
                                &overlap_poly_size );
   RealT overlap_poly_area = Area2DPolygon( xti_2d, yti_2d, overlap_poly_size );
   if ( overlap_poly_area <= 0.0 ) {
@@ -1004,7 +1006,7 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
 void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT* p1, RealT* f1, RealT* df1dx1,
                                   RealT* df1dx2, RealT* df1dn1, RealT* df1dp1, RealT* g1, RealT* dg1dx1, RealT* dg1dx2,
                                   RealT* dg1dn1, int size1, const RealT* x2, RealT* f2, RealT* df2dx1, RealT* df2dx2,
-                                  RealT* df2dn1, RealT* df2dp1, int size2 )
+                                  RealT* df2dn1, RealT* df2dp1, int size2, RealT lenCollapseRatio )
 {
   RealT x1_dot[12] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
   for ( int i{ 0 }; i < size1 * 3; ++i ) {
@@ -1019,7 +1021,8 @@ void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT*
          TRIBOL_ENZYME_CONST, size1,
          TRIBOL_ENZYME_CONST, x2,
          TRIBOL_ENZYME_DUP, f2, &df2dx1[size1*3*i],
-         TRIBOL_ENZYME_CONST, size2);
+         TRIBOL_ENZYME_CONST, size2,
+         TRIBOL_ENZYME_CONST, lenCollapseRatio);
     // clang-format on
     x1_dot[i] = 0.0;
   }
@@ -1036,7 +1039,8 @@ void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT*
          TRIBOL_ENZYME_CONST, size1,
          TRIBOL_ENZYME_CONST, x2,
          TRIBOL_ENZYME_DUP, f2, &df2dn1[size1*3*i],
-         TRIBOL_ENZYME_CONST, size2);
+         TRIBOL_ENZYME_CONST, size2,
+         TRIBOL_ENZYME_CONST, lenCollapseRatio);
     // clang-format on
     n1_dot[i] = 0.0;
   }
@@ -1053,7 +1057,8 @@ void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT*
          TRIBOL_ENZYME_CONST, size1,
          TRIBOL_ENZYME_CONST, x2,
          TRIBOL_ENZYME_DUP, f2, &df2dp1[size1*3*i],
-         TRIBOL_ENZYME_CONST, size2);
+         TRIBOL_ENZYME_CONST, size2,
+         TRIBOL_ENZYME_CONST, lenCollapseRatio);
     // clang-format on
     p1_dot[i] = 0.0;
   }
@@ -1070,7 +1075,8 @@ void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT*
          TRIBOL_ENZYME_CONST, size1,
          TRIBOL_ENZYME_DUP, x2, x2_dot,
          TRIBOL_ENZYME_DUP, f2, &df2dx2[size2*3*i],
-         TRIBOL_ENZYME_CONST, size2);
+         TRIBOL_ENZYME_CONST, size2,
+         TRIBOL_ENZYME_CONST, lenCollapseRatio);
     // clang-format on
     x2_dot[i] = 0.0;
   }

--- a/src/tribol/physics/Mortar.hpp
+++ b/src/tribol/physics/Mortar.hpp
@@ -185,9 +185,10 @@ int ApplyNormalEnzyme( CouplingScheme* cs );
  *                z3])
  * @param [out] f2 Nodal forces for element 2 (stored by node, e.g. [x0, x1, x2, x3, y0, y1, y2, y3, z0, z1, z2, z3])
  * @param [in] size2 Number of nodes on element 2
+ * @param [in] lenCollapseRatio Nondimensional topology collapse tolerance
  */
 void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1, RealT* f1, RealT* g1, int size1,
-                               const RealT* x2, RealT* f2, int size2 );
+                               const RealT* x2, RealT* f2, int size2, RealT lenCollapseRatio = 1.0e-8 );
 
 /**
  * @brief Computes the frictionless mortar forces and Jacobian for a 3D quad element (following Puso and Laursen (2004))
@@ -226,11 +227,12 @@ void ComputeMortarForceEnzyme( const RealT* x1, const RealT* n1, const RealT* p1
  * @param [out] df2dp1 Derivative of element 2 nodal forces with respect to element 1 nodal pressures (size =
  *                     num_nodes_per_elem^2 x spatial dim)
  * @param [in] size2 Number of nodes on element 2
+ * @param [in] lenCollapseRatio Nondimensional topology collapse tolerance
  */
 void ComputeMortarJacobianEnzyme( const RealT* x1, const RealT* n1, const RealT* p1, RealT* f1, RealT* df1dx1,
                                   RealT* df1dx2, RealT* df1dn1, RealT* df1dp1, RealT* g1, RealT* dg1dx1, RealT* dg1dx2,
                                   RealT* dg1dn1, int size1, const RealT* x2, RealT* f2, RealT* df2dx1, RealT* df2dx2,
-                                  RealT* df2dn1, RealT* df2dp1, int size2 );
+                                  RealT* df2dn1, RealT* df2dp1, int size2, RealT lenCollapseRatio = 1.0e-8 );
 #endif
 
 /*!


### PR DESCRIPTION
Fixes the cause of #229 for the geometry identified. Tolerances in `Intersection2DPolygon()` are used inconsistently. Specifically for the geometry identified, this causes a tolerance for determining if one polygon is not contained another to not be triggered, but a similar tolerance checking if the points should be collapsed to be triggered down the line.  Between the two checks, `PolyReorderConvex()` is called, but since the geometry contains non-collapsed points, it is not convex, causing the routine to fail.

This PR includes 2 fixes:
- makes the use of tolerances in `Intersection2DPolygon()` consistent
- merge near-identical points before calling `PolyReorderConvex()`