### PR TITLE
Fix build errors

### DIFF
--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -23,7 +23,7 @@ set(shared_sources
     )
 
 ## setup the dependency list for tribol shared library
-set(shared_depends mfem axom::core)
+set(shared_depends mfem axom::slic)
 blt_list_append(TO shared_depends ELEMENTS blt::mpi IF TRIBOL_USE_MPI )
 blt_list_append(TO shared_depends ELEMENTS caliper IF TRIBOL_USE_CALIPER )
 message(STATUS "Tribol shared library dependencies: ${shared_depends}")

--- a/src/tribol/geom/CompGeom.hpp
+++ b/src/tribol/geom/CompGeom.hpp
@@ -1521,7 +1521,6 @@ TRIBOL_HOST_DEVICE inline void CommonPlanePair::resetPlanePointAndCentroidGap( c
   if ( m_dim == 3 ) {
     // construct array of polygon overlap vertex coordinates
     constexpr int max_dim = 3;
-    constexpr int max_nodes_per_overlap = 10;
     RealT xVert[max_dim * max_nodes_per_overlap];
 
     for ( IndexT j{ 0 }; j < this->m_numPolyVert; ++j ) {


### PR DESCRIPTION
Fixes:

```
src/tribol/geom/CompGeom.hpp:1524:19: error: declaration of ‘max_nodes_per_overlap’ shadows a member of ‘tribol::CommonPlanePair’ [-Werror=shadow]
 1524 |     constexpr int max_nodes_per_overlap = 10;
      |                   ^~~~~~~~~~~~~~~~~~~~~
src/tribol/geom/CompGeom.hpp:89:24: note: shadowed declaration is here
   89 |   static constexpr int max_nodes_per_overlap{ 10 };
      |                        ^~~~~~~~~~~~~~~~~~~~~
```

Fixes:

```
CMakeFiles/shared_par_sparse_mat_test.dir/shared_par_sparse_mat.cpp.o: undefined reference to symbol '_ZN4axom4slic10initializeEb'
```
